### PR TITLE
feat(ui): add operator menu session sync and shell wrapper tdc-sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,494 +1,57 @@
+![License](https://img.shields.io/github/license/diegoabeltran16/tiddly-data-converter.svg)
+![Last Commit](https://img.shields.io/github/last-commit/diegoabeltran16/tiddly-data-converter.svg)
+![CI](https://github.com/diegoabeltran16/tiddly-data-converter/actions/workflows/ci.yml/badge.svg)
+
+
 # tiddly-data-converter
 
 Repositorio local-first para extraer, canonizar, derivar, auditar y revertir
 un corpus TiddlyWiki sin perder trazabilidad ni reversibilidad.
 
-## 1. Preparación
+## Operación
 
-Trabajar siempre desde la raíz del repositorio:
-
-```bash
-cd /repositorios/tiddly-data-converter
-```
-
-Requisitos mínimos:
-
-- Bash
-- Python 3
-- Go
-- Rust, solo para validar los módulos Rust
-
-Caches locales recomendadas:
+Desde la raíz del repositorio, usar un solo ejecutable:
 
 ```bash
-export GOCACHE=/tmp/tdc-go-build
-export CARGO_TARGET_DIR=/tmp/tdc-cargo-target
-mkdir -p "$GOCACHE" "$CARGO_TARGET_DIR"
+shell_scripts/tdc.sh
 ```
 
-Rutas principales:
+Ese comando abre el menú operador local. El menú no reemplaza al orquestador de
+admisión, al canonizador, al reverse ni a los scripts existentes: los invoca de
+forma guiada, muestra métricas y exige confirmaciones fuertes antes de cualquier
+acción que pueda escribir en el canon local.
+
+## Qué Permite Hacer
+
+El menú centraliza el flujo operativo actual:
+
+- preparación del entorno;
+- revisión del estado del canon;
+- construcción del canon desde HTML;
+- extracción HTML a JSONL temporal;
+- shardización hacia el canon local;
+- validación strict y reverse-preflight;
+- sincronización de entregables de sesiones por ID;
+- generación de derivados;
+- reverse hacia HTML derivado;
+- revisión de reportes y métricas;
+- rollback de admisiones cuando aplique.
+
+## Rutas De Autoridad
 
 | Ruta | Rol |
 |---|---|
 | `data/in/` | entradas locales, incluido el HTML vivo |
 | `data/out/local/tiddlers_*.jsonl` | canon oficial local |
-| `data/out/local/` | canon local, derivados, export y reverse |
-| `data/sessions/` | entregables de sesiones y candidatos canónicos |
-| `data/tmp/` | zona temporal de trabajo y reportes |
+| `data/sessions/` | staging operativo de entregables de sesión |
+| `data/tmp/` | temporales, reportes e inventarios |
+| `data/out/local/reverse_html/` | HTML derivado y reportes de reverse |
 
-Reglas de autoridad:
+## Reglas
 
 - `data/out/local/tiddlers_*.jsonl` es la fuente de verdad local.
-- `data/sessions/` es staging operativo, no canon paralelo.
-- `data/tmp/` es temporal y no define autoridad canónica.
+- `data/sessions/` no es canon paralelo.
 - Los derivados no son fuente de verdad.
-- Reverse no redefine el canon.
-
-HTML vivo esperado:
-
-```text
-data/in/tiddly-data-converter (Saved).html
-```
-
-## 2. Exportar del canon
-
-Exportar del canon significa producir artefactos derivados o puntuales a partir
-del canon local ya existente. No es lo mismo que construir el canon desde el
-HTML vivo.
-
-Atajo histórico para regenerar y verificar el export puntual S33:
-
-```bash
-bash shell_scripts/export_s33_regen.sh
-bash shell_scripts/export_s33_verify.sh
-```
-
-Primero ejecutar `export_s33_regen.sh`; después `export_s33_verify.sh`.
-
-Artefactos producidos en `data/out/local/export/`:
-
-- `s33-functional-tiddlers.jsonl`
-- `s33-export-log.jsonl`
-- `s33-manifest.json`
-
-Bootstrap mínimo de inspección o costura:
-
-```bash
-bash shell_scripts/run_pipeline.sh
-```
-
-Este flujo escribe en `data/out/local/pipeline/`. No reemplaza el canon local
-shardizado.
-
-## 3. Construir el canon desde HTML
-
-Construir el canon desde HTML parte del HTML vivo y vuelve a producir el canon
-local shardizado.
-
-Flujo operativo:
-
-```text
-HTML vivo
-  -> JSONL temporal
-  -> shards canónicos locales
-  -> validación
-```
-
-Este flujo sí puede escribir `data/out/local/tiddlers_*.jsonl` durante la
-shardización. Usarlo solo cuando se quiere reconstruir el canon local desde el
-HTML fuente.
-
-## 4. Extraer desde HTML a un JSONL temporal
-
-Este paso extrae tiddlers desde el HTML vivo hacia un JSONL temporal. El JSONL
-temporal no es todavía el canon definitivo.
-
-```bash
-cd /repositorios/tiddly-data-converter/go/bridge
-HTML="../../data/in/tiddly-data-converter (Saved).html"
-
-env GOCACHE=/tmp/tdc-go-build go run ./cmd/export_tiddlers \
-  --html "$HTML" \
-  --out /tmp/tiddlers.export.jsonl \
-  --log /tmp/tiddlers.export.log \
-  --manifest /tmp/tiddlers.export.manifest.json
-```
-
-Salidas esperadas:
-
-- `/tmp/tiddlers.export.jsonl`
-- `/tmp/tiddlers.export.log`
-- `/tmp/tiddlers.export.manifest.json`
-
-## 5. Shardizar el JSONL en el canon local
-
-Este paso convierte el JSONL temporal en shards del canon local. Escribe en
-`data/out/local/`.
-
-```bash
-cd /repositorios/tiddly-data-converter/go/canon
-
-env GOCACHE=/tmp/tdc-go-build go run ./cmd/shard_canon \
-  --input /tmp/tiddlers.export.jsonl \
-  --out-dir ../../data/out/local
-```
-
-Salida esperada:
-
-```text
-data/out/local/tiddlers_1.jsonl
-data/out/local/tiddlers_2.jsonl
-...
-data/out/local/tiddlers_7.jsonl
-```
-
-## 6. Validar el canon
-
-Validación estricta del canon:
-
-```bash
-cd /repositorios/tiddly-data-converter/go/canon
-
-env GOCACHE=/tmp/tdc-go-build go run ./cmd/canon_preflight \
-  --mode strict \
-  --input ../../data/out/local
-```
-
-Preflight requerido antes de reverse o admisión:
-
-```bash
-cd /repositorios/tiddly-data-converter/go/canon
-
-env GOCACHE=/tmp/tdc-go-build go run ./cmd/canon_preflight \
-  --mode reverse-preflight \
-  --input ../../data/out/local
-```
-
-Tests Go principales:
-
-```bash
-cd /repositorios/tiddly-data-converter/go/canon
-env GOCACHE=/tmp/tdc-go-build go test ./... -count=1
-
-cd /repositorios/tiddly-data-converter/go/bridge
-env GOCACHE=/tmp/tdc-go-build go test ./... -count=1
-
-cd /repositorios/tiddly-data-converter/go/ingesta
-env GOCACHE=/tmp/tdc-go-build go test ./... -count=1
-```
-
-Tests Rust principales:
-
-```bash
-cd /repositorios/tiddly-data-converter/rust/extractor
-env CARGO_TARGET_DIR=/tmp/tdc-cargo-target cargo test
-
-cd /repositorios/tiddly-data-converter/rust/doctor
-env CARGO_TARGET_DIR=/tmp/tdc-cargo-target cargo test
-```
-
-Checks Python y shell útiles:
-
-```bash
-cd /repositorios/tiddly-data-converter
-
-python3 python_scripts/validate_corpus_governance.py \
-  --canon-dir data/out/local \
-  --ai-dir data/out/local/ai
-
-bash tests/fixtures/s49/run_canon_proposal_test.sh
-bash tests/fixtures/s47/run_audit_test.sh
-env GOCACHE=/tmp/tdc-go-build-smoke CARGO_TARGET_DIR=/tmp/tdc-cargo-target-smoke bash tests/smoke/test_pipeline_smoke.sh
-```
-
-Condición crítica para reverse y admisión canónica: `Rejected: 0`.
-
-## 7. Pasar los entregables de sesiones al canon
-
-`data/sessions/` contiene entregables de sesión. Cada entregable que deba poder
-entrar al canon debe tener una línea equivalente dentro del archivo
-`*.canon-candidates.jsonl` de su sesión.
-
-Los archivos `.md.json` son artefactos de sesión importables o auditables, pero
-no se pasan uno por uno a `admit_session_candidates.py`. La unidad operativa
-simple es la sesión completa.
-
-El script de admisión no reemplaza al canonizador. Orquesta una admisión manual,
-validada y reversible:
-
-```text
-validate -> dry-run -> revisión humana -> apply --confirm-apply
-```
-
-Listar sesiones con candidatos:
-
-```bash
-cd /repositorios/tiddly-data-converter
-
-find data/sessions -type f -name "*.canon-candidates.jsonl" | sort
-```
-
-Construir la lista de sesiones desde los candidatos existentes. El valor usado
-por `--session-id` es el nombre del archivo sin `.canon-candidates.jsonl`:
-
-```bash
-mapfile -t SESSION_IDS < <(
-  find data/sessions -type f -name "*.canon-candidates.jsonl" \
-    -printf "%f\n" \
-    | sed 's/\.canon-candidates\.jsonl$//' \
-    | sort
-)
-
-printf '%s\n' "${SESSION_IDS[@]}"
-```
-
-Validar las sesiones sin tocar el canon:
-
-```bash
-for SESSION_ID in "${SESSION_IDS[@]}"; do
-  python3 python_scripts/admit_session_candidates.py validate \
-    --session-id "$SESSION_ID" \
-    --sessions-dir data/sessions \
-    --canon-dir data/out/local \
-    --allow-replacements \
-    --report-dir data/tmp/admissions
-done
-```
-
-Ejecutar dry-run sobre copia temporal del canon:
-
-```bash
-for SESSION_ID in "${SESSION_IDS[@]}"; do
-  python3 python_scripts/admit_session_candidates.py dry-run \
-    --session-id "$SESSION_ID" \
-    --sessions-dir data/sessions \
-    --canon-dir data/out/local \
-    --tmp-dir data/tmp/session_admission \
-    --report-dir data/tmp/admissions \
-    --allow-replacements
-done
-```
-
-Revisar los reportes generados:
-
-```bash
-test -n "$(ls data/tmp/admissions/admit-*.json 2>/dev/null)" || {
-  echo "No hay reportes admit-*.json en data/tmp/admissions" >&2
-  exit 1
-}
-
-ls -t data/tmp/admissions/admit-*.json | head
-```
-
-Abrir cada reporte que se quiera revisar:
-
-```bash
-ADMISSION_REPORT="$(ls -t data/tmp/admissions/admit-*.json | head -1)"
-python3 -m json.tool "$ADMISSION_REPORT" | less
-```
-
-Comprobar en cada reporte de `dry-run`:
-
-- `status` debe ser `ok`.
-- `rejected_candidates` debe estar vacío.
-- `reverse_result.rejected` debe ser `0`.
-- `canon_modified` debe ser `false` en `dry-run`.
-- Las pruebas relacionadas deben estar en `passed` o justificadamente en `skipped`.
-
-Aplicar al canon local solo como acción deliberada:
-
-```bash
-for SESSION_ID in "${SESSION_IDS[@]}"; do
-  python3 python_scripts/admit_session_candidates.py apply \
-    --session-id "$SESSION_ID" \
-    --sessions-dir data/sessions \
-    --canon-dir data/out/local \
-    --tmp-dir data/tmp/session_admission \
-    --report-dir data/tmp/admissions \
-    --allow-replacements \
-    --confirm-apply
-done
-```
-
-Para admitir o reparar todos los contratos históricos bajo
-`data/sessions/00_contratos/`, usar el lote automático de contratos. Este modo
-genera candidatos temporales, verifica qué contratos faltan o requieren
-reemplazo por `source_path`, y evita append ciego:
-
-```bash
-python3 python_scripts/admit_session_candidates.py dry-run \
-  --all-contracts \
-  --sessions-dir data/sessions \
-  --canon-dir data/out/local \
-  --tmp-dir data/tmp/session_admission \
-  --report-dir data/tmp/admissions
-```
-
-Si el reporte queda en `status: ok`, `rejected_count: 0` y
-`reverse_rejected: 0`, aplicar deliberadamente:
-
-```bash
-python3 python_scripts/admit_session_candidates.py apply \
-  --all-contracts \
-  --sessions-dir data/sessions \
-  --canon-dir data/out/local \
-  --tmp-dir data/tmp/session_admission \
-  --report-dir data/tmp/admissions \
-  --confirm-apply
-```
-
-Rollback desde un reporte de `apply`. Se revierte una sesión por reporte. Por
-defecto se revisa el reporte de admisión más reciente:
-
-```bash
-APPLY_REPORT="$(ls -t data/tmp/admissions/admit-*.json 2>/dev/null | head -1)"
-
-test -f "$APPLY_REPORT" || {
-  echo "No hay reportes admit-*.json en data/tmp/admissions" >&2
-  exit 1
-}
-
-python3 -m json.tool "$APPLY_REPORT" | less
-```
-
-Antes de continuar, confirmar en ese reporte:
-
-- `mode` debe ser `apply`;
-- `rollback_ready` debe ser `true`;
-- `admitted_ids` debe contener los ids admitidos por esa corrida.
-
-Ejecutar rollback solo después de esa revisión:
-
-```bash
-python3 python_scripts/admit_session_candidates.py rollback \
-  --admission-report "$APPLY_REPORT" \
-  --canon-dir data/out/local \
-  --tmp-dir data/tmp/session_admission_rollback \
-  --report-dir data/tmp/admissions
-```
-
-Advertencias:
-
-- `--session-id` admite el paquete de candidatos de la sesión completa.
-- `--all-contracts` procesa los contratos existentes en `data/sessions/00_contratos/`.
-- `--allow-replacements` permite reemplazar una línea ya admitida solo cuando el `source_path` coincide; se usa para reparar nomenclatura sin duplicar.
-- `--candidate-file` queda como opción avanzada cuando se necesita apuntar a un JSONL concreto.
-- No usar `--candidate-file data/sessions`.
-- `--candidate-file` debe apuntar a un archivo `.canon-candidates.jsonl`, no a una carpeta.
-- No copiar placeholders con signos de menor/mayor en Bash: Bash los interpreta como redirección.
-- No ejecutar comandos con `SESSION_IDS`, `SESSION_ID` o `APPLY_REPORT` vacíos.
-- No ejecutar rollback si no hubo un `apply` real previo.
-- Para la primera operación real, revisar los reportes de `dry-run` antes de lanzar el loop de `apply`.
-- No ejecutar `apply --confirm-apply` sin revisar antes el reporte de `dry-run`.
-
-## 8. Derivados
-
-Los derivados se generan desde el canon local. No son fuente de verdad y no hacen
-writeback al canon.
-
-Entry point principal:
-
-```bash
-cd /repositorios/tiddly-data-converter
-
-python3 python_scripts/derive_layers.py \
-  --input-dir data/out/local \
-  --enriched-dir data/out/local/enriched \
-  --ai-dir data/out/local/ai \
-  --microsoft-copilot-dir data/out/local/microsoft_copilot \
-  --reports-dir data/out/local/ai/reports \
-  --audit-dir data/out/local/audit \
-  --export-dir data/out/local/export \
-  --chunk-target-tokens 1800 \
-  --chunk-max-tokens 4000
-```
-
-Capas actuales:
-
-| Capa | Ubicación | Rol |
-|---|---|---|
-| `enriched` | `data/out/local/enriched/` | enriquecimiento estructural |
-| `ai` | `data/out/local/ai/` | preparación RAG y chunking |
-| `microsoft_copilot` | `data/out/local/microsoft_copilot/` | proyección JSON/CSV/TXT para lectura por agentes |
-| `chunks` | `data/out/local/ai/chunks_ai_*.jsonl` | fragmentos trazables al nodo fuente |
-| `audit` | `data/out/local/audit/` | reportes de auditoría normativa |
-| `export` | `data/out/local/export/` | exportaciones puntuales |
-
-Gobernanza de derivados:
-
-```bash
-python3 python_scripts/validate_corpus_governance.py \
-  --canon-dir data/out/local \
-  --ai-dir data/out/local/ai
-```
-
-Auditoría normativa:
-
-```bash
-python3 python_scripts/audit_normative_projection.py \
-  --mode audit \
-  --input-root data/out/local \
-  --docs-root docs
-```
-
-Auditoría con safe fixes y regeneración:
-
-```bash
-python3 python_scripts/audit_normative_projection.py \
-  --mode apply \
-  --input-root data/out/local \
-  --docs-root docs
-```
-
-Salidas de auditoría en `data/out/local/audit/`:
-
-- `manifest.json`
-- `compliance_report.json`
-- `compliance_summary.md`
-- `proposed_fixes.json`
-- `applied_safe_fixes.json`
-- `pre_post_diff.json`
-
-## 9. Reverse
-
-Reverse reconstruye una salida HTML interpretable desde el canon local. El HTML
-resultante es derivado: no cambia la autoridad del canon y no debe usarse para
-corregir el canon manualmente.
-
-Preflight antes de reverse:
-
-```bash
-cd /repositorios/tiddly-data-converter/go/canon
-
-env GOCACHE=/tmp/tdc-go-build go run ./cmd/canon_preflight \
-  --mode reverse-preflight \
-  --input ../../data/out/local
-```
-
-Reverse autoritativo recomendado:
-
-```bash
-cd /repositorios/tiddly-data-converter/go/bridge
-HTML="../../data/in/tiddly-data-converter (Saved).html"
-
-env GOCACHE=/tmp/tdc-go-build go run ./cmd/reverse_tiddlers \
-  --html "$HTML" \
-  --canon ../../data/out/local \
-  --out-html ../../data/out/local/reverse_html/tiddly-data-converter.derived.html \
-  --report ../../data/out/local/reverse_html/reverse-report.json \
-  --mode authoritative-upsert
-```
-
-Salidas:
-
-- `data/out/local/reverse_html/tiddly-data-converter.derived.html`
-- `data/out/local/reverse_html/reverse-report.json`
-
-Condición crítica:
-
-```text
-Rejected: 0
-```
-
-Si reverse rechaza líneas, corregir antes el canon o los candidatos. No corregir
-a mano el HTML resultante como sustituto de una reparación canónica.
+- Reverse no corrige ni redefine el canon.
+- La admisión de sesiones es manual, validada y reversible.
+- La condición crítica para admisión y reverse es `Rejected: 0`.

--- a/python_scripts/operator_menu.py
+++ b/python_scripts/operator_menu.py
@@ -1,0 +1,841 @@
+#!/usr/bin/env python3
+"""Interactive operator menu for the local tiddly-data-converter workflow."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from path_governance import (  # noqa: E402
+    DEFAULT_AI_DIR,
+    DEFAULT_AUDIT_DIR,
+    DEFAULT_CANON_DIR,
+    DEFAULT_ENRICHED_DIR,
+    DEFAULT_EXPORT_DIR,
+    DEFAULT_INPUT_HTML,
+    DEFAULT_MICROSOFT_COPILOT_DIR,
+    DEFAULT_REVERSE_HTML,
+    DEFAULT_REVERSE_REPORT,
+    REPO_ROOT,
+    as_display_path,
+)
+from session_sync import DEFAULT_SESSION_SYNC_DIR, scan_session_sync  # noqa: E402
+
+
+DEFAULT_SESSIONS_DIR = REPO_ROOT / "data" / "sessions"
+DEFAULT_TMP_DIR = REPO_ROOT / "data" / "tmp"
+DEFAULT_ADMISSION_TMP_DIR = DEFAULT_TMP_DIR / "session_admission"
+DEFAULT_ADMISSION_REPORT_DIR = DEFAULT_TMP_DIR / "admissions"
+HTML_EXPORT_DIR = DEFAULT_TMP_DIR / "html_export"
+
+
+@dataclass
+class CommandResult:
+    args: list[str]
+    cwd: Path
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@dataclass
+class MenuState:
+    selected_html: Path | None = None
+    last_export_jsonl: Path | None = None
+    last_sync_inventory: dict[str, Any] | None = None
+    last_sync_candidate_file: Path | None = None
+    last_validate_report: Path | None = None
+    last_dry_run_report: Path | None = None
+
+
+def stamp_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+
+def display(path: Path | str | None) -> str:
+    if path is None:
+        return "-"
+    path_obj = Path(path)
+    try:
+        return as_display_path(path_obj.resolve())
+    except OSError:
+        return str(path)
+
+
+def prompt(message: str) -> str:
+    try:
+        return input(message)
+    except EOFError:
+        return ""
+
+
+def pause() -> None:
+    if sys.stdin.isatty():
+        prompt("\nEnter para volver al menu...")
+
+
+def command_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.setdefault("GOCACHE", "/tmp/tdc-go-build")
+    env.setdefault("CARGO_TARGET_DIR", "/tmp/tdc-cargo-target")
+    return env
+
+
+def run_command(args: list[str], cwd: Path = REPO_ROOT) -> CommandResult:
+    completed = subprocess.run(
+        args,
+        cwd=cwd,
+        env=command_env(),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return CommandResult(
+        args=args,
+        cwd=cwd,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def print_command_result(result: CommandResult, max_chars: int = 2400) -> None:
+    print(f"$ {' '.join(result.args)}")
+    print(f"cwd: {display(result.cwd)}")
+    print(f"exit: {result.returncode}")
+    stdout = result.stdout.strip()
+    stderr = result.stderr.strip()
+    if stdout:
+        print("\nstdout:")
+        print(stdout[-max_chars:])
+    if stderr:
+        print("\nstderr:")
+        print(stderr[-max_chars:])
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+
+def parse_stdout_json(stdout: str) -> dict[str, Any] | None:
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+def count_jsonl_lines(path: Path) -> int:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return sum(1 for line in handle if line.strip())
+    except OSError:
+        return 0
+
+
+def canon_shards(canon_dir: Path = DEFAULT_CANON_DIR) -> list[Path]:
+    return sorted(canon_dir.glob("tiddlers_*.jsonl"))
+
+
+def canon_summary(canon_dir: Path = DEFAULT_CANON_DIR) -> dict[str, Any]:
+    shards = canon_shards(canon_dir)
+    return {
+        "shards": shards,
+        "line_count": sum(count_jsonl_lines(path) for path in shards),
+    }
+
+
+def select_path(paths: list[Path], label: str, label_func: Any | None = None) -> Path | None:
+    if not paths:
+        print(f"No se encontraron opciones para {label}.")
+        return None
+    if len(paths) == 1:
+        print(f"{label}: {display(paths[0])}")
+        return paths[0]
+
+    print(f"\nSeleccionar {label}:")
+    for index, path in enumerate(paths, start=1):
+        prefix = f"{label_func(path)} - " if label_func else ""
+        print(f"{index}) {prefix}{display(path)}")
+    print("0) Volver")
+    raw = prompt("> ").strip()
+    if not raw or raw == "0":
+        return None
+    if not raw.isdigit() or not (1 <= int(raw) <= len(paths)):
+        print("Seleccion invalida.")
+        return None
+    return paths[int(raw) - 1]
+
+
+def detect_html_files() -> list[Path]:
+    data_in = REPO_ROOT / "data" / "in"
+    return sorted([*data_in.rglob("*.html"), *data_in.rglob("*.htm")])
+
+
+def html_option_label(path: Path) -> str:
+    if path.resolve() == DEFAULT_INPUT_HTML.resolve():
+        return "HTML saved actual"
+    if "empty" in path.name.lower():
+        return "HTML empty / plantilla base"
+    return "HTML detectado"
+
+
+def choose_html(state: MenuState) -> Path | None:
+    html_files = detect_html_files()
+    if state.selected_html and state.selected_html.exists():
+        print(f"HTML actual: {display(state.selected_html)}")
+        answer = prompt("Usar este HTML? [Enter = si, c = cambiar] ").strip().lower()
+        if answer != "c":
+            return state.selected_html
+
+    selected = select_path(html_files, "HTML fuente", html_option_label)
+    if selected:
+        state.selected_html = selected
+    return selected
+
+
+def recent_files(roots: list[Path], pattern: str, limit: int = 12) -> list[Path]:
+    files_by_path: dict[Path, Path] = {}
+    for root in roots:
+        if root.exists():
+            for path in root.rglob(pattern):
+                if path.is_file():
+                    files_by_path[path.resolve()] = path
+    files = list(files_by_path.values())
+    return sorted(files, key=lambda path: path.stat().st_mtime, reverse=True)[:limit]
+
+
+def latest_admission_reports(apply_only: bool = False) -> list[Path]:
+    reports = recent_files([DEFAULT_ADMISSION_REPORT_DIR], "*.json", limit=80)
+    selected: list[Path] = []
+    for path in reports:
+        try:
+            payload = load_json(path)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if apply_only and payload.get("mode") != "apply":
+            continue
+        if apply_only and not payload.get("rollback_ready"):
+            continue
+        selected.append(path)
+    return selected[:12]
+
+
+def summarize_report(path: Path) -> str:
+    try:
+        payload = load_json(path)
+    except (OSError, json.JSONDecodeError):
+        return "no se pudo leer JSON"
+    if not isinstance(payload, dict):
+        return "JSON no objeto"
+
+    if "missing_by_id" in payload and "existing_by_id" in payload:
+        return (
+            f"run_id={payload.get('run_id')}, "
+            f"records={payload.get('total_session_records')}, "
+            f"existing={len(payload.get('existing_by_id') or [])}, "
+            f"missing={len(payload.get('missing_by_id') or [])}, "
+            f"conflicts={len(payload.get('same_id_different_content') or [])}, "
+            f"invalid={len(payload.get('invalid') or [])}"
+        )
+
+    parts = []
+    for key in ("mode", "status", "session_id", "candidate_count", "eligible_count", "admitted_count"):
+        if key in payload:
+            parts.append(f"{key}={payload[key]}")
+    for key in ("canon_lines", "eligible_count", "out_of_scope_count", "already_present_count", "inserted_count", "updated_count", "rejected_count"):
+        if key in payload and f"{key}={payload[key]}" not in parts:
+            parts.append(f"{key}={payload[key]}")
+    if "rejected_candidates" in payload:
+        parts.append(f"rejected={len(payload.get('rejected_candidates') or [])}")
+    reverse = payload.get("reverse_result")
+    if isinstance(reverse, dict) and "rejected" in reverse:
+        parts.append(f"reverse_rejected={reverse.get('rejected')}")
+    if "not_ready" in payload:
+        parts.append(f"not_ready={payload.get('not_ready')}")
+    return ", ".join(parts) if parts else "sin resumen conocido"
+
+
+def option_preparation() -> None:
+    print("\nEstado del entorno:")
+    checks = [
+        ("repo root", Path.cwd().resolve() == REPO_ROOT.resolve(), display(REPO_ROOT)),
+        ("data/sessions", DEFAULT_SESSIONS_DIR.exists(), display(DEFAULT_SESSIONS_DIR)),
+        ("data/out/local", DEFAULT_CANON_DIR.exists(), display(DEFAULT_CANON_DIR)),
+        ("python_scripts", (REPO_ROOT / "python_scripts").exists(), "python_scripts"),
+        ("admit_session_candidates.py", (REPO_ROOT / "python_scripts" / "admit_session_candidates.py").exists(), ""),
+        ("go/canon", (REPO_ROOT / "go" / "canon").exists(), "go/canon"),
+        ("go/bridge", (REPO_ROOT / "go" / "bridge").exists(), "go/bridge"),
+        ("go/ingesta", (REPO_ROOT / "go" / "ingesta").exists(), "go/ingesta"),
+        ("data/tmp", DEFAULT_TMP_DIR.exists(), display(DEFAULT_TMP_DIR)),
+        ("python3", shutil.which("python3") is not None, shutil.which("python3") or ""),
+        ("go", shutil.which("go") is not None, shutil.which("go") or ""),
+    ]
+    for name, ok, detail in checks:
+        state = "OK" if ok else "FALTA"
+        suffix = f" - {detail}" if detail else ""
+        print(f"- {name}: {state}{suffix}")
+    DEFAULT_TMP_DIR.mkdir(parents=True, exist_ok=True)
+    print("\nSiguiente paso recomendado: validar canon o revisar estado del canon.")
+
+
+def option_canon_status() -> None:
+    summary = canon_summary()
+    print("\nCanon local:")
+    print(f"- shards detectados: {len(summary['shards'])}")
+    print(f"- lineas canonicas: {summary['line_count']}")
+    for shard in summary["shards"]:
+        print(f"  - {display(shard)}: {count_jsonl_lines(shard)} lineas")
+
+    expected = {path.name for path in summary["shards"]}
+    allowed_dirs = {"enriched", "ai", "audit", "export", "microsoft_copilot", "reverse_html"}
+    unexpected: list[str] = []
+    for child in DEFAULT_CANON_DIR.iterdir() if DEFAULT_CANON_DIR.exists() else []:
+        if child.name in expected or child.name in allowed_dirs:
+            continue
+        unexpected.append(child.name)
+    print(f"- archivos inesperados en data/out/local: {len(unexpected)}")
+    for name in unexpected[:12]:
+        print(f"  - {name}")
+    print(f"- reverse_html: {'OK' if (DEFAULT_CANON_DIR / 'reverse_html').exists() else 'no existe'}")
+    print(f"- reportes de admision recientes: {len(latest_admission_reports())}")
+    print("\nSiguiente paso recomendado: validar canon antes de reverse o admision.")
+
+
+def option_build_from_html(state: MenuState) -> None:
+    print("\nConstruir canon desde HTML")
+    print("Flujo: HTML vivo -> JSONL temporal -> shards canonicos locales -> validacion")
+    selected = choose_html(state)
+    if selected:
+        print(f"HTML seleccionado: {display(selected)}")
+        print("Siguiente paso recomendado: opcion 4 para extraer a JSONL temporal.")
+
+
+def option_extract_html(state: MenuState) -> None:
+    html = choose_html(state)
+    if not html:
+        return
+    run_id = f"export-{stamp_now()}"
+    out_dir = HTML_EXPORT_DIR / run_id
+    out_jsonl = out_dir / "tiddlers.export.jsonl"
+    out_log = out_dir / "tiddlers.export.log"
+    manifest = out_dir / "tiddlers.export.manifest.json"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    result = run_command(
+        [
+            "go",
+            "run",
+            "./cmd/export_tiddlers",
+            "--html",
+            str(html),
+            "--out",
+            str(out_jsonl),
+            "--log",
+            str(out_log),
+            "--manifest",
+            str(manifest),
+            "--run-id",
+            run_id,
+        ],
+        cwd=REPO_ROOT / "go" / "bridge",
+    )
+    print_command_result(result)
+    if result.returncode == 0:
+        state.last_export_jsonl = out_jsonl
+        print("\nSalidas temporales:")
+        print(f"- JSONL: {display(out_jsonl)} ({count_jsonl_lines(out_jsonl)} lineas)")
+        print(f"- log: {display(out_log)}")
+        print(f"- manifest: {display(manifest)}")
+        print("Siguiente paso recomendado: opcion 5 para shardizar si quieres reconstruir el canon local.")
+    else:
+        print("Extraccion fallida. No se escribio el canon.")
+
+
+def option_shard_jsonl(state: MenuState) -> None:
+    candidates = recent_files([HTML_EXPORT_DIR], "tiddlers.export.jsonl", limit=8)
+    legacy_tmp = Path("/tmp/tiddlers.export.jsonl")
+    if legacy_tmp.exists():
+        candidates.append(legacy_tmp)
+    if state.last_export_jsonl and state.last_export_jsonl.exists() and state.last_export_jsonl not in candidates:
+        candidates.insert(0, state.last_export_jsonl)
+
+    selected = select_path(candidates, "JSONL temporal")
+    if not selected:
+        return
+
+    print("\nAdvertencia: esta opcion escribe shards en data/out/local.")
+    print("JSONL temporal != canon; los shards en data/out/local son el canon local oficial.")
+    confirmation = prompt("Escribe WRITE CANON para continuar: ").strip()
+    if confirmation != "WRITE CANON":
+        print("Shardizacion cancelada. No se modifico el canon.")
+        return
+
+    result = run_command(
+        [
+            "go",
+            "run",
+            "./cmd/shard_canon",
+            "--input",
+            str(selected),
+            "--out-dir",
+            str(DEFAULT_CANON_DIR),
+        ],
+        cwd=REPO_ROOT / "go" / "canon",
+    )
+    print_command_result(result)
+    if result.returncode == 0:
+        option_canon_status()
+        print("Siguiente paso recomendado: opcion 6 para validar el canon.")
+
+
+def run_preflight(mode: str) -> CommandResult:
+    return run_command(
+        ["go", "run", "./cmd/canon_preflight", "--mode", mode, "--input", str(DEFAULT_CANON_DIR)],
+        cwd=REPO_ROOT / "go" / "canon",
+    )
+
+
+def option_validate_canon() -> bool:
+    print("\nValidacion strict")
+    strict = run_preflight("strict")
+    print_command_result(strict)
+    if strict.returncode != 0:
+        print("Fallo strict. No se recomienda reverse ni admision hasta corregir.")
+        return False
+
+    print("\nReverse preflight")
+    reverse = run_preflight("reverse-preflight")
+    print_command_result(reverse)
+    if reverse.returncode != 0:
+        print("Fallo reverse-preflight. No se recomienda reverse ni admision hasta corregir.")
+        return False
+
+    print("\nEstado final: OK. Condicion critica esperada: not_ready=0 y Rejected=0 en reverse.")
+    return True
+
+
+def print_inventory_summary(inventory: dict[str, Any]) -> None:
+    summary = canon_summary()
+    print("\nSincronizacion de sesiones")
+    print("Canon actual:")
+    print(f"- shards: {len(summary['shards'])}")
+    print(f"- lineas: {summary['line_count']}")
+    print("Sessions:")
+    print(f"- archivos detectados: {inventory['total_files_scanned']}")
+    print(f"- entregables validos: {inventory['total_session_records']}")
+    print(f"- ya existen en canon por ID: {len(inventory['existing_by_id'])}")
+    print(f"- faltantes por ID: {len(inventory['missing_by_id'])}")
+    print(f"- conflictos: {len(inventory['same_id_different_content'])}")
+    print(f"- invalidos: {len(inventory['invalid'])}")
+    print(f"- unsupported: {len(inventory['unsupported'])}")
+    print(f"- inventario: {inventory['inventory_path']}")
+    if inventory.get("generated_candidate_file"):
+        print(f"- candidatos faltantes: {inventory['generated_candidate_file']}")
+
+
+def print_items(title: str, items: list[dict[str, Any]], limit: int = 40) -> None:
+    print(f"\n{title}: {len(items)}")
+    for item in items[:limit]:
+        print(f"- {item.get('id', '-')}: {item.get('title', '-')}")
+        print(f"  {item.get('source_path', item.get('path', '-'))}")
+        if item.get("message"):
+            print(f"  {item['message']}")
+    if len(items) > limit:
+        print(f"... {len(items) - limit} mas")
+
+
+def run_admission_command(mode: str, candidate_file: Path, extra: list[str] | None = None) -> tuple[CommandResult, dict[str, Any] | None]:
+    args = [
+        sys.executable,
+        "python_scripts/admit_session_candidates.py",
+        mode,
+        "--candidate-file",
+        str(candidate_file),
+        "--sessions-dir",
+        str(DEFAULT_SESSIONS_DIR),
+        "--canon-dir",
+        str(DEFAULT_CANON_DIR),
+        "--tmp-dir",
+        str(DEFAULT_ADMISSION_TMP_DIR),
+        "--report-dir",
+        str(DEFAULT_ADMISSION_REPORT_DIR),
+    ]
+    if extra:
+        args.extend(extra)
+    result = run_command(args, cwd=REPO_ROOT)
+    print_command_result(result)
+    return result, parse_stdout_json(result.stdout)
+
+
+def dry_run_report_is_usable(report_path: Path, candidate_file: Path) -> tuple[bool, str]:
+    try:
+        payload = load_json(report_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        return False, f"no se pudo leer dry-run: {exc}"
+    if payload.get("mode") != "dry-run":
+        return False, "el reporte no es de dry-run"
+    if payload.get("status") != "ok":
+        return False, "el dry-run no termino ok"
+    if payload.get("candidate_file") != as_display_path(candidate_file):
+        return False, "el reporte dry-run no corresponde al candidato actual"
+    if payload.get("rejected_candidates"):
+        return False, "el dry-run tiene candidatos rechazados"
+    reverse = payload.get("reverse_result") or {}
+    if int(reverse.get("rejected") or 0) != 0:
+        return False, "reverse_authoritative tuvo rejected > 0"
+    return True, "ok"
+
+
+def option_session_sync(state: MenuState) -> None:
+    print("\nEscaneando data/sessions por ID canonico...")
+    try:
+        inventory = scan_session_sync(
+            sessions_dir=DEFAULT_SESSIONS_DIR,
+            canon_dir=DEFAULT_CANON_DIR,
+            out_dir=DEFAULT_SESSION_SYNC_DIR,
+        )
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"No se pudo generar inventario: {exc}")
+        return
+
+    state.last_sync_inventory = inventory
+    candidate_value = inventory.get("generated_candidate_file")
+    state.last_sync_candidate_file = (REPO_ROOT / candidate_value).resolve() if candidate_value else None
+    print_inventory_summary(inventory)
+
+    while True:
+        print(
+            "\nSincronizacion de sesiones\n"
+            "1) Ver faltantes\n"
+            "2) Ver conflictos\n"
+            "3) Ver candidatos generados\n"
+            "4) Validar candidatos\n"
+            "5) Dry-run de admision\n"
+            "6) Apply confirmado\n"
+            "7) Rollback ultimo apply\n"
+            "0) Volver"
+        )
+        choice = prompt("> ").strip()
+        if choice == "0" or choice == "":
+            return
+        if choice == "1":
+            print_items("Faltantes por ID", inventory["missing_by_id"])
+        elif choice == "2":
+            print_items("Conflictos same_id_different_content", inventory["same_id_different_content"])
+            print_items("Invalidos", inventory["invalid"], limit=20)
+        elif choice == "3":
+            if state.last_sync_candidate_file:
+                print(f"Candidato temporal: {display(state.last_sync_candidate_file)}")
+                print(f"Lineas: {count_jsonl_lines(state.last_sync_candidate_file)}")
+            else:
+                print("No hay faltantes; no se genero archivo de candidatos.")
+        elif choice == "4":
+            if not state.last_sync_candidate_file:
+                print("No hay candidatos faltantes para validar.")
+                continue
+            if inventory["same_id_different_content"]:
+                print("Hay conflictos por ID. Resolver antes de validar admision.")
+                continue
+            result, payload = run_admission_command("validate", state.last_sync_candidate_file)
+            if payload and payload.get("report"):
+                state.last_validate_report = (REPO_ROOT / payload["report"]).resolve()
+            if result.returncode == 0:
+                print("Validacion OK. Siguiente paso recomendado: dry-run.")
+        elif choice == "5":
+            if not state.last_sync_candidate_file:
+                print("No hay candidatos faltantes para dry-run.")
+                continue
+            if inventory["same_id_different_content"]:
+                print("Hay conflictos por ID. Resolver antes de dry-run.")
+                continue
+            result, payload = run_admission_command("dry-run", state.last_sync_candidate_file)
+            if payload and payload.get("report"):
+                state.last_dry_run_report = (REPO_ROOT / payload["report"]).resolve()
+            if result.returncode == 0:
+                print("Dry-run OK. Revisar el reporte antes de apply.")
+        elif choice == "6":
+            if not state.last_sync_candidate_file:
+                print("No hay candidatos faltantes para apply.")
+                continue
+            if inventory["same_id_different_content"]:
+                print("Hay conflictos por ID. Apply bloqueado.")
+                continue
+            if not state.last_dry_run_report:
+                print("Apply bloqueado: no hay dry-run previo en esta ejecucion del menu.")
+                continue
+            usable, reason = dry_run_report_is_usable(state.last_dry_run_report, state.last_sync_candidate_file)
+            if not usable:
+                print(f"Apply bloqueado: {reason}")
+                continue
+            print("\nApply confirmado modificara data/out/local.")
+            print(f"- candidatos: {display(state.last_sync_candidate_file)}")
+            print(f"- lineas a insertar: {count_jsonl_lines(state.last_sync_candidate_file)}")
+            print(f"- dry-run revisable: {display(state.last_dry_run_report)}")
+            confirmation = prompt("Escribe APPLY para modificar el canon local: ").strip()
+            if confirmation != "APPLY":
+                print("Apply cancelado.")
+                continue
+            run_admission_command("apply", state.last_sync_candidate_file, ["--confirm-apply"])
+        elif choice == "7":
+            option_rollback()
+        else:
+            print("Opcion invalida.")
+
+
+def option_derivatives() -> None:
+    print("\nDerivados: canon local -> derivados")
+    print("Los derivados no son fuente de verdad y no escriben al canon.")
+    for path in (DEFAULT_ENRICHED_DIR, DEFAULT_AI_DIR, DEFAULT_MICROSOFT_COPILOT_DIR, DEFAULT_AUDIT_DIR, DEFAULT_EXPORT_DIR):
+        print(f"- {display(path)}: {'OK' if path.exists() else 'no existe'}")
+
+    print("\n1) Generar derivados principales")
+    print("2) Validar gobernanza de derivados")
+    print("3) Auditoria normativa")
+    print("0) Volver")
+    choice = prompt("> ").strip()
+    if choice == "1":
+        confirmation = prompt("Escribe DERIVE para generar derivados locales: ").strip()
+        if confirmation != "DERIVE":
+            print("Generacion cancelada.")
+            return
+        result = run_command(
+            [
+                sys.executable,
+                "python_scripts/derive_layers.py",
+                "--input-dir",
+                str(DEFAULT_CANON_DIR),
+                "--enriched-dir",
+                str(DEFAULT_ENRICHED_DIR),
+                "--ai-dir",
+                str(DEFAULT_AI_DIR),
+                "--microsoft-copilot-dir",
+                str(DEFAULT_MICROSOFT_COPILOT_DIR),
+                "--reports-dir",
+                str(DEFAULT_AI_DIR / "reports"),
+                "--audit-dir",
+                str(DEFAULT_AUDIT_DIR),
+                "--export-dir",
+                str(DEFAULT_EXPORT_DIR),
+                "--chunk-target-tokens",
+                "1800",
+                "--chunk-max-tokens",
+                "4000",
+            ],
+            cwd=REPO_ROOT,
+        )
+        print_command_result(result)
+    elif choice == "2":
+        result = run_command(
+            [
+                sys.executable,
+                "python_scripts/validate_corpus_governance.py",
+                "--canon-dir",
+                str(DEFAULT_CANON_DIR),
+                "--ai-dir",
+                str(DEFAULT_AI_DIR),
+            ],
+            cwd=REPO_ROOT,
+        )
+        print_command_result(result)
+    elif choice == "3":
+        result = run_command(
+            [
+                sys.executable,
+                "python_scripts/audit_normative_projection.py",
+                "--mode",
+                "audit",
+                "--input-root",
+                str(DEFAULT_CANON_DIR),
+                "--docs-root",
+                "docs",
+            ],
+            cwd=REPO_ROOT,
+        )
+        print_command_result(result)
+
+
+def option_reverse(state: MenuState) -> None:
+    html = choose_html(state)
+    if not html:
+        return
+    print("\nEjecutando reverse-preflight antes de reverse...")
+    preflight = run_preflight("reverse-preflight")
+    print_command_result(preflight)
+    if preflight.returncode != 0:
+        print("Reverse bloqueado: reverse-preflight fallo.")
+        return
+
+    print("\nReverse genera HTML derivado. No cambia la autoridad del canon.")
+    confirmation = prompt("Escribe REVERSE para generar HTML derivado: ").strip()
+    if confirmation != "REVERSE":
+        print("Reverse cancelado.")
+        return
+
+    result = run_command(
+        [
+            "go",
+            "run",
+            "./cmd/reverse_tiddlers",
+            "--html",
+            str(html),
+            "--canon",
+            str(DEFAULT_CANON_DIR),
+            "--out-html",
+            str(DEFAULT_REVERSE_HTML),
+            "--report",
+            str(DEFAULT_REVERSE_REPORT),
+            "--mode",
+            "authoritative-upsert",
+        ],
+        cwd=REPO_ROOT / "go" / "bridge",
+    )
+    print_command_result(result)
+    if DEFAULT_REVERSE_REPORT.exists():
+        print(f"\nReporte: {display(DEFAULT_REVERSE_REPORT)}")
+        print(summarize_report(DEFAULT_REVERSE_REPORT))
+        try:
+            payload = load_json(DEFAULT_REVERSE_REPORT)
+            print(f"Rejected: {payload.get('rejected_count', payload.get('rejected', '-'))}")
+        except (OSError, json.JSONDecodeError):
+            pass
+
+
+def option_reports() -> None:
+    roots = [
+        DEFAULT_TMP_DIR,
+        DEFAULT_ADMISSION_REPORT_DIR,
+        DEFAULT_SESSION_SYNC_DIR,
+        DEFAULT_CANON_DIR / "reverse_html",
+    ]
+    reports = recent_files(roots, "*.json", limit=16)
+    print("\nReportes recientes:")
+    for index, path in enumerate(reports, start=1):
+        print(f"{index}) {display(path)}")
+        print(f"   {summarize_report(path)}")
+    summary = canon_summary()
+    print("\nMetricas canon:")
+    print(f"- shards: {len(summary['shards'])}")
+    print(f"- lineas: {summary['line_count']}")
+
+
+def option_rollback() -> None:
+    reports = latest_admission_reports(apply_only=True)
+    selected = select_path(reports, "reporte apply con rollback disponible")
+    if not selected:
+        return
+    print(f"Reporte seleccionado: {display(selected)}")
+    print(summarize_report(selected))
+    confirmation = prompt("Escribe ROLLBACK para modificar el canon local: ").strip()
+    if confirmation != "ROLLBACK":
+        print("Rollback cancelado.")
+        return
+
+    result = run_command(
+        [
+            sys.executable,
+            "python_scripts/admit_session_candidates.py",
+            "rollback",
+            "--admission-report",
+            str(selected),
+            "--canon-dir",
+            str(DEFAULT_CANON_DIR),
+            "--tmp-dir",
+            str(DEFAULT_TMP_DIR / "session_admission_rollback"),
+            "--report-dir",
+            str(DEFAULT_ADMISSION_REPORT_DIR),
+        ],
+        cwd=REPO_ROOT,
+    )
+    print_command_result(result)
+
+
+def main_menu() -> None:
+    state = MenuState(selected_html=DEFAULT_INPUT_HTML if DEFAULT_INPUT_HTML.exists() else None)
+    while True:
+        print(
+            "\nTiddly Data Converter - Operador local\n\n"
+            "1) Preparacion\n"
+            "2) Exportar del canon\n"
+            "3) Construir canon desde HTML\n"
+            "4) Extraer HTML a JSONL temporal\n"
+            "5) Shardizar JSONL en canon local\n"
+            "6) Validar canon\n"
+            "7) Sincronizar entregables de sesiones al canon\n"
+            "8) Generar derivados\n"
+            "9) Ejecutar reverse\n"
+            "10) Ver reportes / metricas\n"
+            "11) Rollback de admision\n"
+            "0) Salir"
+        )
+        choice = prompt("> ").strip()
+        if choice == "0" or (choice == "" and not sys.stdin.isatty()):
+            print("Salida.")
+            return
+        if choice == "":
+            continue
+        if choice == "1":
+            option_preparation()
+        elif choice == "2":
+            option_canon_status()
+        elif choice == "3":
+            option_build_from_html(state)
+        elif choice == "4":
+            option_extract_html(state)
+        elif choice == "5":
+            option_shard_jsonl(state)
+        elif choice == "6":
+            option_validate_canon()
+        elif choice == "7":
+            option_session_sync(state)
+        elif choice == "8":
+            option_derivatives()
+        elif choice == "9":
+            option_reverse(state)
+        elif choice == "10":
+            option_reports()
+        elif choice == "11":
+            option_rollback()
+        else:
+            print("Opcion invalida.")
+        pause()
+
+
+def main() -> int:
+    try:
+        main_menu()
+    except KeyboardInterrupt:
+        print("\nInterrumpido.")
+        return 130
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python_scripts/session_sync.py
+++ b/python_scripts/session_sync.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Inventory data/sessions artifacts and prepare safe canon candidates.
+
+This helper does not modify the canon. It reads session artifacts, derives
+canonical identity through the existing canon_preflight normalize command, and
+writes an inventory plus a temporary candidate file for records missing by id.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from admit_session_candidates import (  # noqa: E402
+    CANON_STATUS_CANDIDATE,
+    DEFAULT_SESSIONS_DIR,
+    _canonical_json,
+    _load_canon_index,
+    _project_candidate_record_as_admitted,
+    _run_normalize,
+    _safe_str,
+    _write_jsonl,
+)
+from path_governance import (  # noqa: E402
+    DEFAULT_CANON_DIR,
+    REPO_ROOT,
+    as_display_path,
+    resolve_repo_path,
+)
+
+
+DEFAULT_SESSION_SYNC_DIR = REPO_ROOT / "data" / "tmp" / "session_sync"
+SESSION_RE = re.compile(r"^(m\d+)-s([0-9]+[a-z]?)-(.+)$")
+
+FAMILY_BY_RELATIVE_ROOT: dict[tuple[str, ...], dict[str, Any]] = {
+    ("00_contratos",): {
+        "family": "contrato_de_sesion",
+        "role_primary": "policy",
+        "source_role": "policy",
+        "order": 1,
+    },
+    ("01_procedencia",): {
+        "family": "procedencia_de_sesion",
+        "role_primary": "evidence",
+        "source_role": "procedencia",
+        "order": 2,
+    },
+    ("02_detalles_de_sesion",): {
+        "family": "detalles_de_sesion",
+        "role_primary": "log",
+        "source_role": "reporte",
+        "order": 3,
+    },
+    ("03_hipotesis",): {
+        "family": "hipotesis_de_sesion",
+        "role_primary": "procedure",
+        "source_role": "hipotesis",
+        "order": 4,
+    },
+    ("04_balance_de_sesion",): {
+        "family": "balance_de_sesion",
+        "role_primary": "log",
+        "source_role": "reporte",
+        "order": 5,
+    },
+    ("05_propuesta_de_sesion",): {
+        "family": "propuesta_de_sesion",
+        "role_primary": "procedure",
+        "source_role": "procedure",
+        "order": 6,
+    },
+    ("06_diagnoses", "sesion"): {
+        "family": "diagnostico_de_sesion",
+        "role_primary": "log",
+        "source_role": "reporte",
+        "order": 7,
+    },
+}
+
+
+@dataclass
+class SessionArtifactCandidate:
+    source_path: Path
+    session_id: str
+    artifact_family: str
+    record: dict[str, Any]
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _stamp_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+
+def _load_session_tiddler(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if isinstance(payload, list):
+        if payload and isinstance(payload[0], dict):
+            return payload[0]
+        raise ValueError("JSON array does not contain a tiddler object")
+    if isinstance(payload, dict):
+        return payload
+    raise ValueError("JSON payload is not an object or tiddler array")
+
+
+def _session_id_from_path(path: Path) -> str:
+    name = path.name
+    if name.endswith(".md.json"):
+        return name[: -len(".md.json")]
+    return path.stem
+
+
+def _session_parts(session_id: str) -> tuple[str, str, str]:
+    match = SESSION_RE.match(session_id)
+    if not match:
+        return "", "", session_id
+    milestone, number, slug = match.groups()
+    if slug.startswith("session-"):
+        slug = slug[len("session-") :]
+    return milestone, number, slug
+
+
+def _family_spec(path: Path, sessions_dir: Path) -> dict[str, Any] | None:
+    rel = path.relative_to(sessions_dir)
+    parts = rel.parts
+    for prefix, spec in FAMILY_BY_RELATIVE_ROOT.items():
+        if parts[: len(prefix)] == prefix:
+            return spec
+    return None
+
+
+def _artifact_text(payload: dict[str, Any]) -> str:
+    text = payload.get("text")
+    if isinstance(text, str) and text.strip():
+        return text
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def _session_tags(session_id: str, artifact_family: str) -> list[str]:
+    milestone, number, _slug = _session_parts(session_id)
+    tags = []
+    if milestone and number:
+        tags.append(f"session:{milestone}-s{number}")
+        tags.append(f"milestone:{milestone}")
+    else:
+        tags.append(f"session:{session_id}")
+    tags.extend([f"artifact:{artifact_family}", "status:candidate", "layer:session"])
+
+    deduped: list[str] = []
+    seen = set()
+    for tag in tags:
+        if tag not in seen:
+            seen.add(tag)
+            deduped.append(tag)
+    return deduped
+
+
+def _provenance_ref(session_id: str, source_path: Path, sessions_dir: Path) -> str:
+    provenance_path = sessions_dir / "01_procedencia" / f"{session_id}.md.json"
+    if provenance_path.exists():
+        return as_display_path(provenance_path)
+    return as_display_path(source_path)
+
+
+def build_candidate_from_artifact(path: Path, sessions_dir: Path) -> SessionArtifactCandidate:
+    spec = _family_spec(path, sessions_dir)
+    if spec is None:
+        raise ValueError("unsupported session artifact family")
+
+    payload = _load_session_tiddler(path)
+    title = _safe_str(payload.get("title"))
+    if not title:
+        raise ValueError("session artifact has no title")
+
+    session_id = _session_id_from_path(path)
+    artifact_family = _safe_str(spec["family"])
+    source_type = _safe_str(payload.get("type")) or "text/markdown"
+    text = _artifact_text(payload)
+    created = _safe_str(payload.get("created")) or "19700101000000000"
+    modified = _safe_str(payload.get("modified")) or created
+    source_path = as_display_path(path)
+    tags = _session_tags(session_id, artifact_family)
+
+    content_type = "application/json" if source_type == "application/json" else "text/markdown"
+    modality = "metadata" if content_type == "application/json" else "text"
+
+    record = {
+        "schema_version": "v0",
+        "id": "",
+        "key": title,
+        "title": title,
+        "canonical_slug": "",
+        "version_id": "",
+        "content_type": content_type,
+        "modality": modality,
+        "encoding": "utf-8",
+        "is_binary": False,
+        "is_reference_only": False,
+        "role_primary": spec["role_primary"],
+        "tags": tags,
+        "taxonomy_path": ["sessions", artifact_family],
+        "semantic_text": None,
+        "content": {"plain": text},
+        "raw_payload_ref": "",
+        "mime_type": source_type,
+        "document_id": f"sessions-{session_id}",
+        "section_path": ["sessions", artifact_family, session_id],
+        "order_in_document": spec["order"],
+        "relations": [],
+        "source_tags": list(tags),
+        "normalized_tags": list(tags),
+        "source_fields": {
+            "artifact_family": artifact_family,
+            "canonical_status": CANON_STATUS_CANDIDATE,
+            "document_key": f"data/sessions/{session_id}",
+            "provenance_ref": _provenance_ref(session_id, path, sessions_dir),
+            "session_origin": session_id,
+            "source_path": source_path,
+        },
+        "source_role": spec["source_role"],
+        "text": text,
+        "source_type": source_type,
+        "source_position": source_path,
+        "created": created,
+        "modified": modified,
+    }
+    return SessionArtifactCandidate(
+        source_path=path,
+        session_id=session_id,
+        artifact_family=artifact_family,
+        record=record,
+    )
+
+
+def _normalize_candidates(
+    candidates: list[SessionArtifactCandidate],
+    run_dir: Path,
+) -> tuple[list[SessionArtifactCandidate], list[dict[str, Any]]]:
+    if not candidates:
+        return [], []
+
+    raw_records = [candidate.record for candidate in candidates]
+    try:
+        normalized_records, _result = _run_normalize(raw_records, run_dir / "normalize")
+    except RuntimeError as exc:
+        invalid = [
+            {
+                "path": as_display_path(candidate.source_path),
+                "classification": "invalid",
+                "message": f"normalize failed in batch: {exc}",
+            }
+            for candidate in candidates
+        ]
+        return [], invalid
+
+    normalized_candidates: list[SessionArtifactCandidate] = []
+    invalid: list[dict[str, Any]] = []
+    for candidate, record in zip(candidates, normalized_records):
+        rec_id = _safe_str(record.get("id"))
+        if not rec_id:
+            invalid.append(
+                {
+                    "path": as_display_path(candidate.source_path),
+                    "classification": "invalid",
+                    "message": "canon_preflight normalize did not derive id",
+                }
+            )
+            continue
+        record["raw_payload_ref"] = f"node:{rec_id}"
+        normalized_candidates.append(
+            SessionArtifactCandidate(
+                source_path=candidate.source_path,
+                session_id=candidate.session_id,
+                artifact_family=candidate.artifact_family,
+                record=record,
+            )
+        )
+    return normalized_candidates, invalid
+
+
+def _summary_record(candidate: SessionArtifactCandidate) -> dict[str, Any]:
+    record = candidate.record
+    source_fields = record.get("source_fields") or {}
+    return {
+        "id": _safe_str(record.get("id")),
+        "title": _safe_str(record.get("title")),
+        "session_origin": candidate.session_id,
+        "artifact_family": candidate.artifact_family,
+        "source_path": _safe_str(source_fields.get("source_path")) or as_display_path(candidate.source_path),
+    }
+
+
+def scan_session_sync(
+    sessions_dir: Path = DEFAULT_SESSIONS_DIR,
+    canon_dir: Path = DEFAULT_CANON_DIR,
+    out_dir: Path = DEFAULT_SESSION_SYNC_DIR,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    sessions_dir = sessions_dir.resolve()
+    canon_dir = canon_dir.resolve()
+    run_id = run_id or f"sync-{_stamp_now()}"
+    run_dir = out_dir.resolve() / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    md_paths = sorted(sessions_dir.rglob("*.md.json"))
+    candidate_paths = sorted(sessions_dir.rglob("*.canon-candidates.jsonl"))
+    unsupported_paths = [
+        path
+        for path in sorted(sessions_dir.rglob("*"))
+        if path.is_file() and not path.name.endswith(".md.json") and not path.name.endswith(".canon-candidates.jsonl")
+    ]
+
+    prepared: list[SessionArtifactCandidate] = []
+    invalid: list[dict[str, Any]] = []
+    unsupported: list[dict[str, Any]] = []
+
+    for path in md_paths:
+        try:
+            prepared.append(build_candidate_from_artifact(path, sessions_dir))
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            invalid.append(
+                {
+                    "path": as_display_path(path),
+                    "classification": "invalid",
+                    "message": str(exc),
+                }
+            )
+
+    for path in unsupported_paths:
+        unsupported.append(
+            {
+                "path": as_display_path(path),
+                "classification": "unsupported",
+                "message": "not a .md.json session artifact or .canon-candidates.jsonl support file",
+            }
+        )
+
+    normalized, normalize_invalid = _normalize_candidates(prepared, run_dir)
+    invalid.extend(normalize_invalid)
+
+    canon_index = _load_canon_index(canon_dir)
+    existing_by_id: list[dict[str, Any]] = []
+    missing_by_id: list[dict[str, Any]] = []
+    same_id_different_content: list[dict[str, Any]] = []
+
+    seen_ids: dict[str, str] = {}
+    missing_records: list[dict[str, Any]] = []
+
+    for candidate in normalized:
+        rec_id = _safe_str(candidate.record.get("id"))
+        summary = _summary_record(candidate)
+        previous_source = seen_ids.get(rec_id)
+        if previous_source and previous_source != summary["source_path"]:
+            same_id_different_content.append(
+                {
+                    **summary,
+                    "classification": "same_id_different_content",
+                    "message": f"id also derived from {previous_source}",
+                }
+            )
+            continue
+        seen_ids[rec_id] = summary["source_path"]
+
+        existing = canon_index.by_id.get(rec_id)
+        if existing is None:
+            missing_by_id.append({**summary, "classification": "missing_by_id"})
+            missing_records.append(candidate.record)
+            continue
+
+        projected = _project_candidate_record_as_admitted(candidate.record)
+        if existing.serialized == _canonical_json(candidate.record) or existing.serialized == _canonical_json(projected):
+            existing_by_id.append(
+                {
+                    **summary,
+                    "classification": "existing_by_id",
+                    "shard": existing.shard,
+                    "line_no": existing.line_no,
+                }
+            )
+        else:
+            same_id_different_content.append(
+                {
+                    **summary,
+                    "classification": "same_id_different_content",
+                    "shard": existing.shard,
+                    "line_no": existing.line_no,
+                    "message": "id exists in canon but normalized session artifact differs",
+                }
+            )
+
+    generated_candidate_file = None
+    if missing_records:
+        generated_candidate_file = run_dir / "missing-candidates.canon-candidates.jsonl"
+        _write_jsonl(generated_candidate_file, missing_records)
+
+    inventory_path = run_dir / "inventory.json"
+    inventory = {
+        "run_id": run_id,
+        "timestamp": _iso_now(),
+        "canon_dir": as_display_path(canon_dir),
+        "sessions_dir": as_display_path(sessions_dir),
+        "total_files_scanned": len(md_paths) + len(candidate_paths),
+        "total_session_records": len(normalized),
+        "candidate_support_files": [as_display_path(path) for path in candidate_paths],
+        "existing_by_id": existing_by_id,
+        "missing_by_id": missing_by_id,
+        "same_id_different_content": same_id_different_content,
+        "invalid": invalid,
+        "unsupported": unsupported,
+        "generated_candidate_file": as_display_path(generated_candidate_file) if generated_candidate_file else None,
+        "inventory_path": as_display_path(inventory_path),
+    }
+    _write_json(inventory_path, inventory)
+    return inventory
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Scan data/sessions by canonical id and generate missing session candidates."
+    )
+    parser.add_argument("command", choices=["scan"], help="Operation to run")
+    parser.add_argument("--sessions-dir", default=as_display_path(DEFAULT_SESSIONS_DIR))
+    parser.add_argument("--canon-dir", default=as_display_path(DEFAULT_CANON_DIR))
+    parser.add_argument("--out-dir", default=as_display_path(DEFAULT_SESSION_SYNC_DIR))
+    parser.add_argument("--run-id", default=None)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        inventory = scan_session_sync(
+            sessions_dir=resolve_repo_path(args.sessions_dir, DEFAULT_SESSIONS_DIR),
+            canon_dir=resolve_repo_path(args.canon_dir, DEFAULT_CANON_DIR),
+            out_dir=resolve_repo_path(args.out_dir, DEFAULT_SESSION_SYNC_DIR),
+            run_id=args.run_id,
+        )
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
+        print(json.dumps({"status": "fail", "error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "run_id": inventory["run_id"],
+                "inventory": inventory["inventory_path"],
+                "generated_candidate_file": inventory["generated_candidate_file"],
+                "total_session_records": inventory["total_session_records"],
+                "existing_by_id": len(inventory["existing_by_id"]),
+                "missing_by_id": len(inventory["missing_by_id"]),
+                "same_id_different_content": len(inventory["same_id_different_content"]),
+                "invalid": len(inventory["invalid"]),
+                "unsupported": len(inventory["unsupported"]),
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shell_scripts/tdc.sh
+++ b/shell_scripts/tdc.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+python3 python_scripts/operator_menu.py


### PR DESCRIPTION
# PR: ui(pipeline): operator menu session sync and tdc-sh entry point staged validated s70

```text
Commit: feat(ui): add operator menu session sync and shell wrapper tdc-sh s70
Meta: Es:listo|V:1|R:3|Md:estable|B:ui|Ctx:runtime|Pr:P1|Sz:M|Est:5|Dr:+1|Dc:+2
Arch: Sb:Ejecución|Ea:Implementación|Cx:Interfaz local|Lg:PYTHON|Mdls:operator_menu,session_sync,tdc.sh,data/sessions/s70,README
```

---

## Metadatos

| Campo | Valor |
|-------|-------|
| Estado | listo |
| Vuelta | 1 |
| Radio | 3 |
| Madurez | estable |
| Bloque | ui |
| ContextoCambio | runtime |
| Priority | P1 |
| Size | M |
| Estimate | 5 |
| Delta-r | +1 |
| Delta-c | +2 |

---

## Tablero y Arquitectura

| Campo | Valor |
|-------|-------|
| StatusTablero | Ejecución |
| EstadoArquitectonico | Implementación |
| Caja | Interfaz local |
| Lenguajes | PYTHON |
| Modulos | operator_menu, session_sync, tdc.sh, data/sessions/s70, README |

---

## Objetivo

Crear una capa operativa humana (`operator_menu.py`, `session_sync.py`, `shell_scripts/tdc.sh`) que envuelva el flujo existente del proyecto sin reemplazar el canonizador, el orquestador de admisión ni el reverse, exponiendo un único entry point (`tdc.sh`) con menú guiado, confirmaciones fuertes antes de cualquier escritura en el canon, e inventario de entregables de sesión por ID canónico con detección de conflictos.

---

## Resultado integrado

Se entrega la capa de interfaz local v0: menú operativo Python con 10+ opciones funcionales que invocan los flujos existentes de forma guiada; helper de sincronización `session_sync.py` que escanea `data/sessions/**/*.md.json`, compara por ID canónico contra el canon real y clasifica entregables en existentes, faltantes o conflictivos (`same_id_different_content`); wrapper `shell_scripts/tdc.sh` como único entry point público; README reducido a guía operativa mínima con un solo bloque ejecutable. El canon real (`data/out/local`) no fue modificado. Los 9 conflictos heredados detectados por `session_sync` quedan bloqueados y pendientes de S71. Los 7 candidatos S70 pasaron `validate`, `dry-run` y reverse autoritativo con `Rejected: 0`.

---

## Acciones realizadas

- Creado `python_scripts/operator_menu.py`: menú interactivo local con opciones de preparación de entorno, revisión de estado del canon, construcción desde HTML, extracción, shardización, validación, sincronización de sesiones, derivados, reverse, reportes y rollback.
- Creado `python_scripts/session_sync.py`: escaneo de `data/sessions/**/*.md.json`, comparación por ID canónico contra `data/out/local`, clasificación en `existing`, `missing` e `conflict_same_id_different_content`; inventario en `data/tmp/session_sync/`.
- Creado `shell_scripts/tdc.sh`: wrapper Bash que invoca `operator_menu.py`; ubicado en carpeta shell existente evitando carpeta `scripts/` redundante.
- Modificado `README.md`: reducido a guía operativa corta con un único bloque ejecutable (`shell_scripts/tdc.sh`); comandos técnicos removidos del README principal.
- Generada familia mínima S70 (7 artefactos) bajo `data/sessions/`.
- Generados 7 candidatos canónicos en `data/sessions/06_diagnoses/sesion/m03-s70-operator-menu-and-session-sync-v0.canon-candidates.jsonl`.

---

## Archivos modificados / añadidos

| Archivo | Acción | Sesión |
|---------|--------|--------|
| `python_scripts/operator_menu.py` | creado | S70 |
| `python_scripts/session_sync.py` | creado | S70 |
| `shell_scripts/tdc.sh` | creado | S70 |
| `README.md` | reducido a guía operativa mínima | S70 |
| `data/sessions/00_contratos/m03-s70-operator-menu-and-session-sync-v0.md.json` | familia mínima | S70 |
| `data/sessions/{01_procedencia…05_propuesta_de_sesion}/m03-s70-operator-menu-and-session-sync-v0.md.json` | familia mínima (5 artefactos) | S70 |
| `data/sessions/06_diagnoses/sesion/m03-s70-operator-menu-and-session-sync-v0.md.json` | diagnóstico de sesión | S70 |
| `data/sessions/06_diagnoses/sesion/m03-s70-operator-menu-and-session-sync-v0.canon-candidates.jsonl` | 7 candidatos canónicos | S70 |

---

## Comprobaciones sugeridas

```bash
# Compilación
python3 -m py_compile python_scripts/operator_menu.py python_scripts/session_sync.py
bash -n shell_scripts/tdc.sh

# Apertura del menú (verificar arranque y salida limpia)
python3 python_scripts/operator_menu.py
# Seleccionar opción de salida; no debe modificar data/out/local

# Sincronización de sesiones
python3 python_scripts/session_sync.py scan \
  --sessions-dir data/sessions \
  --canon-dir data/out/local \
  --out-dir data/tmp/session_sync
# Esperado: 102 entregables válidos, 86 existentes por ID,
#           7 faltantes S70, 9 conflictos heredados, 0 inválidos

# Validate + dry-run S70
python3 python_scripts/admit_session_candidates.py validate \
  --session-id m03-s70-operator-menu-and-session-sync-v0 \
  --sessions-dir data/sessions \
  --canon-dir data/out/local \
  --report-dir data/tmp/admissions/s70
# Esperado: status: ok, candidate_count: 7, rejected_count: 0

python3 python_scripts/admit_session_candidates.py dry-run \
  --session-id m03-s70-operator-menu-and-session-sync-v0 \
  --sessions-dir data/sessions \
  --canon-dir data/out/local \
  --tmp-dir data/tmp/session_admission \
  --report-dir data/tmp/admissions/s70
# Esperado: status: ok, admitted_count: 7, reverse_rejected: 0, canon_modified: false

# Canon strict y reverse-preflight
cd go/canon
env GOCACHE=/tmp/tdc-go-build go run ./cmd/canon_preflight \
  --mode strict --input ../../data/out/local
# Esperado: 693 line(s) valid

env GOCACHE=/tmp/tdc-go-build go run ./cmd/canon_preflight \
  --mode reverse-preflight --input ../../data/out/local
# Esperado: 693 ready, not_ready: 0

# Tests Go
env GOCACHE=/tmp/tdc-go-build go test ./... -count=1          # go/canon
cd ../bridge && env GOCACHE=/tmp/tdc-go-build go test ./... -count=1

# Fixture reproducible S69
bash tests/fixtures/s69/run_session_admission_test.sh
# Esperado: Ran 4 tests — OK

# Hash del canon real — debe permanecer sin cambio
sha256sum data/out/local/tiddlers_*.jsonl
```

---

## Notas para el revisor

- **Canon real no modificado**: `data/out/local/tiddlers_*.jsonl` no fue alterado en S70. Canon actual: 693 líneas, 7 shards.
- Los 7 candidatos S70 quedan en staging como `canonical_status: candidate_not_admitted`. Para admitir: ejecutar `dry-run` → revisar reporte → confirmar `Rejected: 0` → `apply --confirm-apply`. Ver README sección 7 (docs del PR s66–s69).
- **9 conflictos heredados detectados**: registros existentes por ID cuyo contenido derivado desde sessions difiere del canon. El menú y `session_sync` los bloquean como `same_id_different_content`. Requieren resolución en S71 antes de poder admitir en lote.
- **Delta-r: +1** — se añade una nueva superficie de escritura al canon vía menú (opción `apply --confirm-apply`), pero protegida por las mismas compuertas del orquestador S67–S68: `dry-run` previo obligatorio, confirmación explícita y reverse con `Rejected: 0`.
- **Delta-c: +2** — dos nuevos módulos Python: `operator_menu` (10+ opciones, invocación de flujos existentes, menú interactivo) y `session_sync` (escaneo recursivo de sessions, clasificación por ID canónico, generación de inventarios JSON).
- El wrapper tdc.sh fue colocado en la carpeta shell existente para evitar duplicar superficie. No se creó carpeta `scripts/` separada.
- Sesión: `m03-s70`. Contrato de sesión `.md.json` existe bajo 00_contratos.
