### PR TITLE
feat(inspect): agrega audit_perimeter y compuerta reconstruction-plan en rust/doctor con roles de fuente explicitos, backup y reporte hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ data/extraction_output/
 # Solo se versionan fixtures controlados bajo tests/fixtures/
 *.tiddlywiki.html
 user_input*.html
-data/in/*.html
 data/in/*:Zone.Identifier
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -40,7 +39,9 @@ go/canon/emit
 go/canon/canon_preflight
 /.codex
 
-/data/in
+/data/in/empty-store.html
+/data/in/tiddly-data-converter (Saved).html
+/data/in/tiddly-data-converter (Saved).html:Zone.Identifier
 /data/out
 /data/tmp
 /data/sessions

--- a/README.md
+++ b/README.md
@@ -25,17 +25,19 @@ acción que pueda escribir en el canon local.
 
 El menú centraliza el flujo operativo actual:
 
-- preparación del entorno;
-- revisión del estado del canon;
-- construcción del canon desde HTML;
-- extracción HTML a JSONL temporal;
-- shardización hacia el canon local;
-- validación strict y reverse-preflight;
-- sincronización de entregables de sesiones por ID;
-- generación de derivados;
-- reverse hacia HTML derivado;
-- revisión de reportes y métricas;
-- rollback de admisiones cuando aplique.
+- Preparación del entorno
+- Chequeo del perímetro Rust de entradas, canon, reverse y capas no autoritativas
+- Compuerta Rust del plan de reconstrucción antes de tocar canon o reverse
+- Revisión del estado del canon
+- Construcción del canon desde HTML
+- Extracción HTML a JSONL temporal
+- Shardización hacia el canon local
+- Validación strict y reverse-preflight
+- Sincronización de entregables de sesiones por ID
+- Generación de derivados
+- Reverse hacia HTML derivado
+- Revisión de reportes y métricas
+- Rollback de admisiones cuando aplique
 
 ## Rutas De Autoridad
 
@@ -50,8 +52,10 @@ El menú centraliza el flujo operativo actual:
 ## Reglas
 
 - `data/out/local/tiddlers_*.jsonl` es la fuente de verdad local.
+- `data/in/objeto_de_estudio_trazabilidad_y_desarrollo.html` es la semilla reusable principal; `empty-store.html` es auxiliar.
 - `data/sessions/` no es canon paralelo.
 - Los derivados no son fuente de verdad.
 - Reverse no corrige ni redefine el canon.
+- La reconstrucción desde HTML exige fuente explícita, destino explícito, backup y reporte de hash cuando puede escribir `data/out/local`.
 - La admisión de sesiones es manual, validada y reversible.
 - La condición crítica para admisión y reverse es `Rejected: 0`.

--- a/estructura.txt
+++ b/estructura.txt
@@ -20,15 +20,113 @@
 ├── .gitignore
 ├── data
 │   ├── in
+│   │   └── objeto_de_estudio_trazabilidad_y_desarrollo.html
 │   ├── out
 │   │   ├── local
 │   │   │   ├── ai
-│   │   │   │   └── reports
+│   │   │   │   ├── chunks_ai_1.jsonl
+│   │   │   │   ├── chunks_ai_2.jsonl
+│   │   │   │   ├── chunks_ai_3.jsonl
+│   │   │   │   ├── chunks_ai_4.jsonl
+│   │   │   │   ├── chunks_ai_5.jsonl
+│   │   │   │   ├── chunks_ai_6.jsonl
+│   │   │   │   ├── chunks_ai_7.jsonl
+│   │   │   │   ├── chunks_ai_8.jsonl
+│   │   │   │   ├── manifest.json
+│   │   │   │   ├── reports
+│   │   │   │   │   ├── chunk_qc_report.json
+│   │   │   │   │   ├── classification_report.json
+│   │   │   │   │   ├── derivation_report.json
+│   │   │   │   │   ├── relations_qc_report.json
+│   │   │   │   │   └── retrieval_qc_report.json
+│   │   │   │   ├── tiddlers_ai_1.jsonl
+│   │   │   │   ├── tiddlers_ai_2.jsonl
+│   │   │   │   ├── tiddlers_ai_3.jsonl
+│   │   │   │   ├── tiddlers_ai_4.jsonl
+│   │   │   │   ├── tiddlers_ai_5.jsonl
+│   │   │   │   ├── tiddlers_ai_6.jsonl
+│   │   │   │   ├── tiddlers_ai_7.jsonl
+│   │   │   │   └── tiddlers_ai_8.jsonl
 │   │   │   ├── audit
+│   │   │   │   ├── applied_safe_fixes.json
+│   │   │   │   ├── audit_log.jsonl
+│   │   │   │   ├── compliance_report.json
+│   │   │   │   ├── compliance_summary.md
+│   │   │   │   ├── manifest.json
+│   │   │   │   ├── manual_review_queue.jsonl
+│   │   │   │   ├── pre_post_diff.json
+│   │   │   │   ├── proposed_fixes.json
+│   │   │   │   └── warnings.jsonl
 │   │   │   ├── enriched
+│   │   │   │   ├── manifest.json
+│   │   │   │   ├── tiddlers_enriched_1.jsonl
+│   │   │   │   ├── tiddlers_enriched_2.jsonl
+│   │   │   │   ├── tiddlers_enriched_3.jsonl
+│   │   │   │   ├── tiddlers_enriched_4.jsonl
+│   │   │   │   ├── tiddlers_enriched_5.jsonl
+│   │   │   │   ├── tiddlers_enriched_6.jsonl
+│   │   │   │   ├── tiddlers_enriched_7.jsonl
+│   │   │   │   └── tiddlers_enriched_8.jsonl
 │   │   │   ├── export
 │   │   │   ├── microsoft_copilot
-│   │   │   │   └── copilot_agent
+│   │   │   │   ├── artifacts.csv
+│   │   │   │   ├── bundles
+│   │   │   │   │   ├── governance_core.txt
+│   │   │   │   │   ├── pipeline_and_layers.txt
+│   │   │   │   │   └── recent_sessions.txt
+│   │   │   │   ├── copilot_agent
+│   │   │   │   │   ├── corpus.txt
+│   │   │   │   │   ├── entities.json
+│   │   │   │   │   └── relations.csv
+│   │   │   │   ├── coverage.csv
+│   │   │   │   ├── edges.csv
+│   │   │   │   ├── entities.json
+│   │   │   │   ├── manifest.json
+│   │   │   │   ├── navigation_index.json
+│   │   │   │   ├── nodes.csv
+│   │   │   │   ├── overview.txt
+│   │   │   │   ├── reading_guide.txt
+│   │   │   │   ├── source_arbitration_report.json
+│   │   │   │   ├── spec
+│   │   │   │   │   ├── checklist_global_s61.md
+│   │   │   │   │   ├── memoria_decisiones_s61.md
+│   │   │   │   │   ├── plan_de_implementacion_s61.md
+│   │   │   │   │   └── summaries
+│   │   │   │   │       ├── contratos-instructions.json
+│   │   │   │   │       ├── contratos-instructions.md
+│   │   │   │   │       ├── contratos-s58-s59-s60.json
+│   │   │   │   │       ├── contratos-s58-s59-s60.md
+│   │   │   │   │       ├── dependencia-y-superficie-externa.json
+│   │   │   │   │       ├── dependencia-y-superficie-externa.md
+│   │   │   │   │       ├── desarrollo-y-evolucion.json
+│   │   │   │   │       ├── desarrollo-y-evolucion.md
+│   │   │   │   │       ├── detalles-del-tema.json
+│   │   │   │   │       ├── detalles-del-tema.md
+│   │   │   │   │       ├── elementos-especificos.json
+│   │   │   │   │       ├── elementos-especificos.md
+│   │   │   │   │       ├── glosario-y-convenciones.json
+│   │   │   │   │       ├── glosario-y-convenciones.md
+│   │   │   │   │       ├── hipotesis.json
+│   │   │   │   │       ├── hipotesis.md
+│   │   │   │   │       ├── microsoft-support-formats.json
+│   │   │   │   │       ├── microsoft-support-formats.md
+│   │   │   │   │       ├── politica-de-memoria-activa.json
+│   │   │   │   │       ├── politica-de-memoria-activa.md
+│   │   │   │   │       ├── prcommits.json
+│   │   │   │   │       ├── prcommits.md
+│   │   │   │   │       ├── principios-de-gestion.json
+│   │   │   │   │       ├── principios-de-gestion.md
+│   │   │   │   │       ├── procedencia-epistemologica.json
+│   │   │   │   │       ├── procedencia-epistemologica.md
+│   │   │   │   │       ├── protocolo-de-sesion.json
+│   │   │   │   │       ├── protocolo-de-sesion.md
+│   │   │   │   │       ├── repo-y-derivados-actuales.json
+│   │   │   │   │       ├── repo-y-derivados-actuales.md
+│   │   │   │   │       ├── sesiones.json
+│   │   │   │   │       ├── sesiones.md
+│   │   │   │   │       ├── tiddlers-sesiones.json
+│   │   │   │   │       └── tiddlers-sesiones.md
+│   │   │   │   └── topics.json
 │   │   │   ├── reverse_html
 │   │   │   ├── tiddlers_1.jsonl
 │   │   │   ├── tiddlers_2.jsonl
@@ -120,6 +218,9 @@
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
 │   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
+│   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
+│   │   │   ├── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
 │   │   │   ├── policy
 │   │   │   │   └── canon_policy_bundle.json
 │   │   │   ├── projections
@@ -143,27 +244,42 @@
 │   │   │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
-│   │   │   └── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
+│   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
+│   │   │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
 │   │   ├── 02_detalles_de_sesion
 │   │   │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
-│   │   │   └── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
+│   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
+│   │   │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
 │   │   ├── 03_hipotesis
 │   │   │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
-│   │   │   └── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
+│   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
+│   │   │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
 │   │   ├── 04_balance_de_sesion
 │   │   │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
-│   │   │   └── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
+│   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
+│   │   │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
 │   │   ├── 05_propuesta_de_sesion
 │   │   │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
-│   │   │   └── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
+│   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
+│   │   │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
 │   │   └── 06_diagnoses
 │   │       ├── canon
 │   │       │   └── s65_canon_diagnosis.md
@@ -185,11 +301,226 @@
 │   │       │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.canon-candidates.jsonl
 │   │       │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
 │   │       │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.canon-candidates.jsonl
-│   │       │   └── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │       │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
+│   │       │   ├── m03-s70-operator-menu-and-session-sync-v0.canon-candidates.jsonl
+│   │       │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
+│   │       │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.canon-candidates.jsonl
+│   │       │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
+│   │       │   ├── m04-s72-rust-kernel-reconstruction-plan-gate-v0.canon-candidates.jsonl
+│   │       │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
 │   │       └── tema
 │   └── tmp
 │       ├── admissions
 │       │   ├── admit-20260428012638-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   ├── admit-20260428153824-m03-s69-session-canon-admission-hardening-and-docs-v0.json
+│       │   ├── admit-20260428154424-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   ├── admit-20260428154430-m03-s67-session-canon-admission-orchestrator-v0.json
+│       │   ├── admit-20260428154438-m03-s68-session-canon-admission-integration-fixtures-v0.json
+│       │   ├── admit-20260428154912-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   ├── admit-20260428154919-m03-s67-session-canon-admission-orchestrator-v0.json
+│       │   ├── admit-20260428154927-m03-s68-session-canon-admission-integration-fixtures-v0.json
+│       │   ├── admit-20260428223203-multi-session.json
+│       │   ├── admit-20260428223224-multi-session.json
+│       │   ├── admit-20260428223954-multi-session.json
+│       │   ├── admit-20260428224021-multi-session.json
+│       │   ├── admit-20260428224441-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   ├── admit-20260428224448-m03-s67-session-canon-admission-orchestrator-v0.json
+│       │   ├── admit-20260428224455-m03-s68-session-canon-admission-integration-fixtures-v0.json
+│       │   ├── admit-20260428224501-m03-s69-session-canon-admission-hardening-and-docs-v0.json
+│       │   ├── admit-20260428224607-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   ├── admit-20260428224615-m03-s67-session-canon-admission-orchestrator-v0.json
+│       │   ├── admit-20260428224623-m03-s68-session-canon-admission-integration-fixtures-v0.json
+│       │   ├── admit-20260428224630-m03-s69-session-canon-admission-hardening-and-docs-v0.json
+│       │   ├── admit-20260428224659-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   ├── admit-20260428224705-m03-s67-session-canon-admission-orchestrator-v0.json
+│       │   ├── admit-20260428224712-m03-s68-session-canon-admission-integration-fixtures-v0.json
+│       │   ├── admit-20260428224721-m03-s69-session-canon-admission-hardening-and-docs-v0.json
+│       │   ├── admit-20260429183413-multi-session.json
+│       │   ├── admit-20260429183452-multi-session.json
+│       │   ├── admit-20260429191735-m04-s71-rust-kernel-perimeter-and-invariants-v0.json
+│       │   ├── admit-20260429200205-m04-s72-rust-kernel-reconstruction-plan-gate-v0.json
+│       │   ├── admit-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0.json
+│       │   ├── backups
+│       │   │   ├── admit-20260428153824-m03-s69-session-canon-admission-hardening-and-docs-v0
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   ├── admit-20260428154912-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   ├── admit-20260428154919-m03-s67-session-canon-admission-orchestrator-v0
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   ├── admit-20260428154927-m03-s68-session-canon-admission-integration-fixtures-v0
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   ├── admit-20260428223224-multi-session
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   ├── admit-20260428224021-multi-session
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   ├── admit-20260428224659-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   ├── admit-20260428224705-m03-s67-session-canon-admission-orchestrator-v0
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   ├── admit-20260428224712-m03-s68-session-canon-admission-integration-fixtures-v0
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   ├── admit-20260428224721-m03-s69-session-canon-admission-hardening-and-docs-v0
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── admit-20260429183452-multi-session
+│       │   │       ├── tiddlers_1.jsonl
+│       │   │       ├── tiddlers_2.jsonl
+│       │   │       ├── tiddlers_3.jsonl
+│       │   │       ├── tiddlers_4.jsonl
+│       │   │       ├── tiddlers_5.jsonl
+│       │   │       ├── tiddlers_6.jsonl
+│       │   │       └── tiddlers_7.jsonl
+│       │   ├── generated
+│       │   │   ├── all-contracts-20260428223203
+│       │   │   │   ├── admission_lines.normalized.jsonl
+│       │   │   │   └── admission_lines.raw.jsonl
+│       │   │   ├── all-contracts-20260428223203.canon-candidates.jsonl
+│       │   │   ├── all-contracts-20260428223223
+│       │   │   │   ├── admission_lines.normalized.jsonl
+│       │   │   │   └── admission_lines.raw.jsonl
+│       │   │   ├── all-contracts-20260428223224.canon-candidates.jsonl
+│       │   │   ├── all-contracts-20260428223954
+│       │   │   │   ├── admission_lines.normalized.jsonl
+│       │   │   │   └── admission_lines.raw.jsonl
+│       │   │   ├── all-contracts-20260428223954.canon-candidates.jsonl
+│       │   │   ├── all-contracts-20260428224021
+│       │   │   │   ├── admission_lines.normalized.jsonl
+│       │   │   │   └── admission_lines.raw.jsonl
+│       │   │   └── all-contracts-20260428224021.canon-candidates.jsonl
+│       │   ├── nomenclature
+│       │   │   ├── admit-20260428161135-multi-session.json
+│       │   │   ├── admit-20260428161150-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161157-m03-s67-session-canon-admission-orchestrator-v0.json
+│       │   │   ├── admit-20260428161206-m03-s68-session-canon-admission-integration-fixtures-v0.json
+│       │   │   ├── admit-20260428161213-m03-s69-session-canon-admission-hardening-and-docs-v0.json
+│       │   │   ├── generated
+│       │   │   │   ├── all-contracts-20260428161115
+│       │   │   │   │   ├── admission_lines.normalized.jsonl
+│       │   │   │   │   └── admission_lines.raw.jsonl
+│       │   │   │   ├── all-contracts-20260428161115.canon-candidates.jsonl
+│       │   │   │   ├── all-contracts-20260428161134
+│       │   │   │   │   ├── admission_lines.normalized.jsonl
+│       │   │   │   │   └── admission_lines.raw.jsonl
+│       │   │   │   └── all-contracts-20260428161135.canon-candidates.jsonl
+│       │   │   └── validate-20260428161115-multi-session.json
+│       │   ├── nomenclature_apply
+│       │   │   ├── admit-20260428161551-multi-session.json
+│       │   │   ├── admit-20260428161611-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161616-m03-s67-session-canon-admission-orchestrator-v0.json
+│       │   │   ├── admit-20260428161623-m03-s68-session-canon-admission-integration-fixtures-v0.json
+│       │   │   ├── admit-20260428161630-m03-s69-session-canon-admission-hardening-and-docs-v0.json
+│       │   │   ├── backups
+│       │   │   │   ├── admit-20260428161551-multi-session
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── admit-20260428161611-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── admit-20260428161616-m03-s67-session-canon-admission-orchestrator-v0
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── admit-20260428161623-m03-s68-session-canon-admission-integration-fixtures-v0
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   └── admit-20260428161630-m03-s69-session-canon-admission-hardening-and-docs-v0
+│       │   │   │       ├── tiddlers_1.jsonl
+│       │   │   │       ├── tiddlers_2.jsonl
+│       │   │   │       ├── tiddlers_3.jsonl
+│       │   │   │       ├── tiddlers_4.jsonl
+│       │   │   │       ├── tiddlers_5.jsonl
+│       │   │   │       ├── tiddlers_6.jsonl
+│       │   │   │       └── tiddlers_7.jsonl
+│       │   │   └── generated
+│       │   │       ├── all-contracts-20260428161551
+│       │   │       │   ├── admission_lines.normalized.jsonl
+│       │   │       │   └── admission_lines.raw.jsonl
+│       │   │       └── all-contracts-20260428161551.canon-candidates.jsonl
+│       │   ├── nomenclature_full
+│       │   │   ├── admit-20260428161517-multi-session.json
+│       │   │   └── generated
+│       │   │       ├── all-contracts-20260428161516
+│       │   │       │   ├── admission_lines.normalized.jsonl
+│       │   │       │   └── admission_lines.raw.jsonl
+│       │   │       └── all-contracts-20260428161516.canon-candidates.jsonl
 │       │   ├── s68
 │       │   │   ├── admit-20260428015027-m03-s67-session-canon-admission-orchestrator-v0.json
 │       │   │   ├── admit-20260428015051-m03-s67-session-canon-admission-orchestrator-v0.json
@@ -291,6 +622,68 @@
 │       │   │   ├── admit-20260428133845-m03-s66-session-family-and-canonical-closure-flow-v0.json
 │       │   │   ├── admit-20260428133859-m03-s66-session-family-and-canonical-closure-flow-v0.json
 │       │   │   ├── admit-20260428133910-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161235-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161238-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161240-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161242-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161245-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161252-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161349-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161351-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161353-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161354-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161357-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161404-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260428161410-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429033001-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429033003-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429033004-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429033006-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429033008-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429033014-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429033020-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429174315-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429174320-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429174322-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429174324-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429174328-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429174336-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429174342-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429175034-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429175035-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429175036-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429175038-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429175041-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429175049-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429175055-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429190900-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429190902-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429190903-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429190905-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429190908-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429190916-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429190923-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191144-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191146-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191147-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191148-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191151-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191158-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191204-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191647-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191649-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191651-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191652-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191654-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191704-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429191712-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429200207-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429200222-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429200229-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429200234-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429200241-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429200252-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── admit-20260429200304-m03-s66-session-family-and-canonical-closure-flow-v0.json
 │       │   │   ├── backups
 │       │   │   │   ├── admit-20260428133603-m03-s66-session-family-and-canonical-closure-flow-v0
 │       │   │   │   │   ├── tiddlers_1.jsonl
@@ -308,6 +701,70 @@
 │       │   │   │   │   ├── tiddlers_5.jsonl
 │       │   │   │   │   ├── tiddlers_6.jsonl
 │       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── admit-20260428161410-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── admit-20260429033020-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── admit-20260429174342-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── admit-20260429175055-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── admit-20260429190923-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── admit-20260429191204-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── admit-20260429191712-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── admit-20260429200304-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
 │       │   │   │   ├── rollback-20260428133617-m03-s66-session-family-and-canonical-closure-flow-v0-pre
 │       │   │   │   │   ├── tiddlers_1.jsonl
 │       │   │   │   │   ├── tiddlers_2.jsonl
@@ -316,7 +773,71 @@
 │       │   │   │   │   ├── tiddlers_5.jsonl
 │       │   │   │   │   ├── tiddlers_6.jsonl
 │       │   │   │   │   └── tiddlers_7.jsonl
-│       │   │   │   └── rollback-20260428133921-m03-s66-session-family-and-canonical-closure-flow-v0-pre
+│       │   │   │   ├── rollback-20260428133921-m03-s66-session-family-and-canonical-closure-flow-v0-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── rollback-20260428161416-m03-s66-session-family-and-canonical-closure-flow-v0-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── rollback-20260429033028-m03-s66-session-family-and-canonical-closure-flow-v0-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── rollback-20260429174350-m03-s66-session-family-and-canonical-closure-flow-v0-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── rollback-20260429175100-m03-s66-session-family-and-canonical-closure-flow-v0-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── rollback-20260429190931-m03-s66-session-family-and-canonical-closure-flow-v0-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── rollback-20260429191210-m03-s66-session-family-and-canonical-closure-flow-v0-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   ├── rollback-20260429191720-m03-s66-session-family-and-canonical-closure-flow-v0-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   └── rollback-20260429200312-m03-s66-session-family-and-canonical-closure-flow-v0-pre
 │       │   │   │       ├── tiddlers_1.jsonl
 │       │   │   │       ├── tiddlers_2.jsonl
 │       │   │   │       ├── tiddlers_3.jsonl
@@ -326,19 +847,715 @@
 │       │   │   │       └── tiddlers_7.jsonl
 │       │   │   ├── rollback-20260428133617-m03-s66-session-family-and-canonical-closure-flow-v0.json
 │       │   │   ├── rollback-20260428133921-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── rollback-20260428161416-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── rollback-20260429033028-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── rollback-20260429174350-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── rollback-20260429175100-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── rollback-20260429190931-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── rollback-20260429191210-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── rollback-20260429191720-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── rollback-20260429200312-m03-s66-session-family-and-canonical-closure-flow-v0.json
 │       │   │   ├── validate-20260428133531-missing-source-path.json
 │       │   │   ├── validate-20260428133547-m03-s66-session-family-and-canonical-closure-flow-v0.json
 │       │   │   ├── validate-20260428133842-missing-source-path.json
-│       │   │   └── validate-20260428133857-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── validate-20260428133857-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── validate-20260428161243-missing-source-path.json
+│       │   │   ├── validate-20260428161251-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── validate-20260428161356-missing-source-path.json
+│       │   │   ├── validate-20260428161404-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── validate-20260429033007-missing-source-path.json
+│       │   │   ├── validate-20260429033014-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── validate-20260429174326-missing-source-path.json
+│       │   │   ├── validate-20260429174335-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── validate-20260429175039-missing-source-path.json
+│       │   │   ├── validate-20260429175049-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── validate-20260429190907-missing-source-path.json
+│       │   │   ├── validate-20260429190915-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── validate-20260429191150-missing-source-path.json
+│       │   │   ├── validate-20260429191157-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── validate-20260429191653-missing-source-path.json
+│       │   │   ├── validate-20260429191703-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   │   ├── validate-20260429200238-missing-source-path.json
+│       │   │   └── validate-20260429200251-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   ├── s70
+│       │   │   ├── admit-20260429030948-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── admit-20260429031115-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── admit-20260429031203-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── admit-20260429031853-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── admit-20260429032250-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── admit-20260429033001-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── validate-20260429030939-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── validate-20260429031109-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── validate-20260429031159-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── validate-20260429031848-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── validate-20260429032246-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── validate-20260429032804-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   ├── validate-20260429032945-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   │   └── validate-20260429174656-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   ├── s70_replacement_rollback_fixture
+│       │   │   ├── admit-20260429174904-multi-session.json
+│       │   │   ├── backups
+│       │   │   │   ├── admit-20260429174904-multi-session
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   └── tiddlers_7.jsonl
+│       │   │   │   └── rollback-20260429174919-multi-session-pre
+│       │   │   │       ├── tiddlers_1.jsonl
+│       │   │   │       ├── tiddlers_2.jsonl
+│       │   │   │       ├── tiddlers_3.jsonl
+│       │   │   │       ├── tiddlers_4.jsonl
+│       │   │   │       ├── tiddlers_5.jsonl
+│       │   │   │       ├── tiddlers_6.jsonl
+│       │   │   │       └── tiddlers_7.jsonl
+│       │   │   └── rollback-20260429174919-multi-session.json
+│       │   ├── s70_sync
+│       │   │   ├── admit-20260429174255-multi-session.json
+│       │   │   └── validate-20260429174249-multi-session.json
+│       │   ├── s70_sync_full
+│       │   │   ├── admit-20260429174426-multi-session.json
+│       │   │   ├── admit-20260429174701-multi-session.json
+│       │   │   └── admit-20260429175019-multi-session.json
+│       │   ├── s70_targeted
+│       │   │   └── admit-20260429171626-m03-s70-operator-menu-and-session-sync-v0.json
+│       │   ├── s71
+│       │   │   ├── admit-20260429190825-m04-s71-rust-kernel-perimeter-and-invariants-v0.json
+│       │   │   ├── admit-20260429191411-m04-s71-rust-kernel-perimeter-and-invariants-v0.json
+│       │   │   └── validate-20260429190947-m04-s71-rust-kernel-perimeter-and-invariants-v0.json
+│       │   ├── session_id_probe
+│       │   │   ├── admit-20260428153527-m03-s69-session-canon-admission-hardening-and-docs-v0.json
+│       │   │   └── validate-20260428153527-m03-s69-session-canon-admission-hardening-and-docs-v0.json
 │       │   ├── validate-20260428012630-m03-s66-session-family-and-canonical-closure-flow-v0.json
 │       │   ├── validate-20260428012918-m03-s67-session-canon-admission-orchestrator-v0.json
-│       │   └── validate-20260428015728-m03-s68-session-canon-admission-integration-fixtures-v0.json
+│       │   ├── validate-20260428015728-m03-s68-session-canon-admission-integration-fixtures-v0.json
+│       │   ├── validate-20260428224419-m03-s66-session-family-and-canonical-closure-flow-v0.json
+│       │   ├── validate-20260428224420-m03-s67-session-canon-admission-orchestrator-v0.json
+│       │   ├── validate-20260428224420-m03-s68-session-canon-admission-integration-fixtures-v0.json
+│       │   ├── validate-20260428224421-m03-s69-session-canon-admission-hardening-and-docs-v0.json
+│       │   ├── validate-20260429183352-multi-session.json
+│       │   ├── validate-20260429191735-m04-s71-rust-kernel-perimeter-and-invariants-v0.json
+│       │   ├── validate-20260429200205-m04-s72-rust-kernel-reconstruction-plan-gate-v0.json
+│       │   └── validate-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0.json
+│       ├── html_export
+│       │   ├── export-20260429165825
+│       │   │   ├── tiddlers.export.jsonl
+│       │   │   ├── tiddlers.export.log
+│       │   │   └── tiddlers.export.manifest.json
+│       │   └── export-20260429195756
+│       │       ├── tiddlers.export.jsonl
+│       │       ├── tiddlers.export.log
+│       │       └── tiddlers.export.manifest.json
 │       ├── s69_candidate_generation
 │       │   ├── normalized.jsonl
 │       │   └── raw.jsonl
 │       ├── s69_reverse
 │       │   ├── reverse-report.json
 │       │   └── tiddly-data-converter.derived.html
+│       ├── s70_replacement_rollback_fixture
+│       │   ├── canon
+│       │   │   ├── tiddlers_1.jsonl
+│       │   │   ├── tiddlers_2.jsonl
+│       │   │   ├── tiddlers_3.jsonl
+│       │   │   ├── tiddlers_4.jsonl
+│       │   │   ├── tiddlers_5.jsonl
+│       │   │   ├── tiddlers_6.jsonl
+│       │   │   └── tiddlers_7.jsonl
+│       │   ├── rollback
+│       │   │   └── rollback-20260429174919-multi-session
+│       │   │       ├── canon
+│       │   │       │   ├── tiddlers_1.jsonl
+│       │   │       │   ├── tiddlers_2.jsonl
+│       │   │       │   ├── tiddlers_3.jsonl
+│       │   │       │   ├── tiddlers_4.jsonl
+│       │   │       │   ├── tiddlers_5.jsonl
+│       │   │       │   ├── tiddlers_6.jsonl
+│       │   │       │   └── tiddlers_7.jsonl
+│       │   │       └── reverse_html
+│       │   │           ├── rollback-20260429174919-multi-session.derived.html
+│       │   │           └── rollback-20260429174919-multi-session.reverse-report.json
+│       │   └── work
+│       │       └── admit-20260429174904-multi-session
+│       │           ├── admission_lines.normalized.jsonl
+│       │           ├── admission_lines.raw.jsonl
+│       │           ├── canon
+│       │           │   ├── tiddlers_1.jsonl
+│       │           │   ├── tiddlers_2.jsonl
+│       │           │   ├── tiddlers_3.jsonl
+│       │           │   ├── tiddlers_4.jsonl
+│       │           │   ├── tiddlers_5.jsonl
+│       │           │   ├── tiddlers_6.jsonl
+│       │           │   └── tiddlers_7.jsonl
+│       │           └── reverse_html
+│       │               ├── admit-20260429174904-multi-session.derived.html
+│       │               └── admit-20260429174904-multi-session.reverse-report.json
+│       ├── session_admission
+│       │   ├── admit-20260428153824-m03-s69-session-canon-admission-hardening-and-docs-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428153824-m03-s69-session-canon-admission-hardening-and-docs-v0.derived.html
+│       │   │       └── admit-20260428153824-m03-s69-session-canon-admission-hardening-and-docs-v0.reverse-report.json
+│       │   ├── admit-20260428154424-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428154424-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428154424-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428154430-m03-s67-session-canon-admission-orchestrator-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428154430-m03-s67-session-canon-admission-orchestrator-v0.derived.html
+│       │   │       └── admit-20260428154430-m03-s67-session-canon-admission-orchestrator-v0.reverse-report.json
+│       │   ├── admit-20260428154438-m03-s68-session-canon-admission-integration-fixtures-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428154438-m03-s68-session-canon-admission-integration-fixtures-v0.derived.html
+│       │   │       └── admit-20260428154438-m03-s68-session-canon-admission-integration-fixtures-v0.reverse-report.json
+│       │   ├── admit-20260428154912-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428154912-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428154912-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428154919-m03-s67-session-canon-admission-orchestrator-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428154919-m03-s67-session-canon-admission-orchestrator-v0.derived.html
+│       │   │       └── admit-20260428154919-m03-s67-session-canon-admission-orchestrator-v0.reverse-report.json
+│       │   ├── admit-20260428154927-m03-s68-session-canon-admission-integration-fixtures-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428154927-m03-s68-session-canon-admission-integration-fixtures-v0.derived.html
+│       │   │       └── admit-20260428154927-m03-s68-session-canon-admission-integration-fixtures-v0.reverse-report.json
+│       │   ├── admit-20260428223203-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428223203-multi-session.derived.html
+│       │   │       └── admit-20260428223203-multi-session.reverse-report.json
+│       │   ├── admit-20260428223224-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428223224-multi-session.derived.html
+│       │   │       └── admit-20260428223224-multi-session.reverse-report.json
+│       │   ├── admit-20260428223954-multi-session
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428223954-multi-session.derived.html
+│       │   │       └── admit-20260428223954-multi-session.reverse-report.json
+│       │   ├── admit-20260428224021-multi-session
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224021-multi-session.derived.html
+│       │   │       └── admit-20260428224021-multi-session.reverse-report.json
+│       │   ├── admit-20260428224441-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224441-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428224441-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428224448-m03-s67-session-canon-admission-orchestrator-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224448-m03-s67-session-canon-admission-orchestrator-v0.derived.html
+│       │   │       └── admit-20260428224448-m03-s67-session-canon-admission-orchestrator-v0.reverse-report.json
+│       │   ├── admit-20260428224455-m03-s68-session-canon-admission-integration-fixtures-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224455-m03-s68-session-canon-admission-integration-fixtures-v0.derived.html
+│       │   │       └── admit-20260428224455-m03-s68-session-canon-admission-integration-fixtures-v0.reverse-report.json
+│       │   ├── admit-20260428224501-m03-s69-session-canon-admission-hardening-and-docs-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224501-m03-s69-session-canon-admission-hardening-and-docs-v0.derived.html
+│       │   │       └── admit-20260428224501-m03-s69-session-canon-admission-hardening-and-docs-v0.reverse-report.json
+│       │   ├── admit-20260428224607-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224607-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428224607-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428224615-m03-s67-session-canon-admission-orchestrator-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224615-m03-s67-session-canon-admission-orchestrator-v0.derived.html
+│       │   │       └── admit-20260428224615-m03-s67-session-canon-admission-orchestrator-v0.reverse-report.json
+│       │   ├── admit-20260428224623-m03-s68-session-canon-admission-integration-fixtures-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224623-m03-s68-session-canon-admission-integration-fixtures-v0.derived.html
+│       │   │       └── admit-20260428224623-m03-s68-session-canon-admission-integration-fixtures-v0.reverse-report.json
+│       │   ├── admit-20260428224630-m03-s69-session-canon-admission-hardening-and-docs-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224630-m03-s69-session-canon-admission-hardening-and-docs-v0.derived.html
+│       │   │       └── admit-20260428224630-m03-s69-session-canon-admission-hardening-and-docs-v0.reverse-report.json
+│       │   ├── admit-20260428224659-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224659-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428224659-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428224705-m03-s67-session-canon-admission-orchestrator-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224705-m03-s67-session-canon-admission-orchestrator-v0.derived.html
+│       │   │       └── admit-20260428224705-m03-s67-session-canon-admission-orchestrator-v0.reverse-report.json
+│       │   ├── admit-20260428224712-m03-s68-session-canon-admission-integration-fixtures-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224712-m03-s68-session-canon-admission-integration-fixtures-v0.derived.html
+│       │   │       └── admit-20260428224712-m03-s68-session-canon-admission-integration-fixtures-v0.reverse-report.json
+│       │   ├── admit-20260428224721-m03-s69-session-canon-admission-hardening-and-docs-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428224721-m03-s69-session-canon-admission-hardening-and-docs-v0.derived.html
+│       │   │       └── admit-20260428224721-m03-s69-session-canon-admission-hardening-and-docs-v0.reverse-report.json
+│       │   ├── admit-20260429030948-m03-s70-operator-menu-and-session-sync-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429030948-m03-s70-operator-menu-and-session-sync-v0.derived.html
+│       │   │       └── admit-20260429030948-m03-s70-operator-menu-and-session-sync-v0.reverse-report.json
+│       │   ├── admit-20260429031115-m03-s70-operator-menu-and-session-sync-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429031115-m03-s70-operator-menu-and-session-sync-v0.derived.html
+│       │   │       └── admit-20260429031115-m03-s70-operator-menu-and-session-sync-v0.reverse-report.json
+│       │   ├── admit-20260429031203-m03-s70-operator-menu-and-session-sync-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429031203-m03-s70-operator-menu-and-session-sync-v0.derived.html
+│       │   │       └── admit-20260429031203-m03-s70-operator-menu-and-session-sync-v0.reverse-report.json
+│       │   ├── admit-20260429031853-m03-s70-operator-menu-and-session-sync-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429031853-m03-s70-operator-menu-and-session-sync-v0.derived.html
+│       │   │       └── admit-20260429031853-m03-s70-operator-menu-and-session-sync-v0.reverse-report.json
+│       │   ├── admit-20260429032250-m03-s70-operator-menu-and-session-sync-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429032250-m03-s70-operator-menu-and-session-sync-v0.derived.html
+│       │   │       └── admit-20260429032250-m03-s70-operator-menu-and-session-sync-v0.reverse-report.json
+│       │   ├── admit-20260429033001-m03-s70-operator-menu-and-session-sync-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429033001-m03-s70-operator-menu-and-session-sync-v0.derived.html
+│       │   │       └── admit-20260429033001-m03-s70-operator-menu-and-session-sync-v0.reverse-report.json
+│       │   ├── admit-20260429171626-m03-s70-operator-menu-and-session-sync-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429171626-m03-s70-operator-menu-and-session-sync-v0.derived.html
+│       │   │       └── admit-20260429171626-m03-s70-operator-menu-and-session-sync-v0.reverse-report.json
+│       │   ├── admit-20260429174255-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429174255-multi-session.derived.html
+│       │   │       └── admit-20260429174255-multi-session.reverse-report.json
+│       │   ├── admit-20260429174426-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429174426-multi-session.derived.html
+│       │   │       └── admit-20260429174426-multi-session.reverse-report.json
+│       │   ├── admit-20260429174701-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429174701-multi-session.derived.html
+│       │   │       └── admit-20260429174701-multi-session.reverse-report.json
+│       │   ├── admit-20260429175019-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429175019-multi-session.derived.html
+│       │   │       └── admit-20260429175019-multi-session.reverse-report.json
+│       │   ├── admit-20260429183413-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       └── admit-20260429183413-multi-session.reverse-report.json
+│       │   ├── admit-20260429183452-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429183452-multi-session.derived.html
+│       │   │       └── admit-20260429183452-multi-session.reverse-report.json
+│       │   ├── admit-20260429190825-m04-s71-rust-kernel-perimeter-and-invariants-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       └── admit-20260429190825-m04-s71-rust-kernel-perimeter-and-invariants-v0.reverse-report.json
+│       │   ├── admit-20260429191411-m04-s71-rust-kernel-perimeter-and-invariants-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       └── admit-20260429191411-m04-s71-rust-kernel-perimeter-and-invariants-v0.reverse-report.json
+│       │   ├── admit-20260429191735-m04-s71-rust-kernel-perimeter-and-invariants-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       └── admit-20260429191735-m04-s71-rust-kernel-perimeter-and-invariants-v0.reverse-report.json
+│       │   ├── admit-20260429200205-m04-s72-rust-kernel-reconstruction-plan-gate-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       └── admit-20260429200205-m04-s72-rust-kernel-reconstruction-plan-gate-v0.reverse-report.json
+│       │   └── admit-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0
+│       │       ├── admission_lines.normalized.jsonl
+│       │       ├── admission_lines.raw.jsonl
+│       │       ├── canon
+│       │       │   ├── tiddlers_1.jsonl
+│       │       │   ├── tiddlers_2.jsonl
+│       │       │   ├── tiddlers_3.jsonl
+│       │       │   ├── tiddlers_4.jsonl
+│       │       │   ├── tiddlers_5.jsonl
+│       │       │   ├── tiddlers_6.jsonl
+│       │       │   └── tiddlers_7.jsonl
+│       │       └── reverse_html
+│       │           └── admit-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0.reverse-report.json
 │       ├── session_admission_fixtures
 │       │   ├── canon_base
 │       │   │   ├── tiddlers_1.jsonl
@@ -513,6 +1730,163 @@
 │       │           └── reverse_html
 │       │               ├── rollback-20260428015107-m03-s67-session-canon-admission-orchestrator-v0.derived.html
 │       │               └── rollback-20260428015107-m03-s67-session-canon-admission-orchestrator-v0.reverse-report.json
+│       ├── session_admission_nomenclature
+│       │   ├── admit-20260428161135-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161135-multi-session.derived.html
+│       │   │       └── admit-20260428161135-multi-session.reverse-report.json
+│       │   ├── admit-20260428161150-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161150-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428161150-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428161157-m03-s67-session-canon-admission-orchestrator-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161157-m03-s67-session-canon-admission-orchestrator-v0.derived.html
+│       │   │       └── admit-20260428161157-m03-s67-session-canon-admission-orchestrator-v0.reverse-report.json
+│       │   ├── admit-20260428161206-m03-s68-session-canon-admission-integration-fixtures-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161206-m03-s68-session-canon-admission-integration-fixtures-v0.derived.html
+│       │   │       └── admit-20260428161206-m03-s68-session-canon-admission-integration-fixtures-v0.reverse-report.json
+│       │   └── admit-20260428161213-m03-s69-session-canon-admission-hardening-and-docs-v0
+│       │       ├── admission_lines.normalized.jsonl
+│       │       ├── admission_lines.raw.jsonl
+│       │       ├── canon
+│       │       │   ├── tiddlers_1.jsonl
+│       │       │   ├── tiddlers_2.jsonl
+│       │       │   ├── tiddlers_3.jsonl
+│       │       │   ├── tiddlers_4.jsonl
+│       │       │   ├── tiddlers_5.jsonl
+│       │       │   ├── tiddlers_6.jsonl
+│       │       │   └── tiddlers_7.jsonl
+│       │       └── reverse_html
+│       │           ├── admit-20260428161213-m03-s69-session-canon-admission-hardening-and-docs-v0.derived.html
+│       │           └── admit-20260428161213-m03-s69-session-canon-admission-hardening-and-docs-v0.reverse-report.json
+│       ├── session_admission_nomenclature_apply
+│       │   ├── admit-20260428161551-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161551-multi-session.derived.html
+│       │   │       └── admit-20260428161551-multi-session.reverse-report.json
+│       │   ├── admit-20260428161611-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161611-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428161611-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428161616-m03-s67-session-canon-admission-orchestrator-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161616-m03-s67-session-canon-admission-orchestrator-v0.derived.html
+│       │   │       └── admit-20260428161616-m03-s67-session-canon-admission-orchestrator-v0.reverse-report.json
+│       │   ├── admit-20260428161623-m03-s68-session-canon-admission-integration-fixtures-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161623-m03-s68-session-canon-admission-integration-fixtures-v0.derived.html
+│       │   │       └── admit-20260428161623-m03-s68-session-canon-admission-integration-fixtures-v0.reverse-report.json
+│       │   └── admit-20260428161630-m03-s69-session-canon-admission-hardening-and-docs-v0
+│       │       ├── admission_lines.normalized.jsonl
+│       │       ├── admission_lines.raw.jsonl
+│       │       ├── canon
+│       │       │   ├── tiddlers_1.jsonl
+│       │       │   ├── tiddlers_2.jsonl
+│       │       │   ├── tiddlers_3.jsonl
+│       │       │   ├── tiddlers_4.jsonl
+│       │       │   ├── tiddlers_5.jsonl
+│       │       │   ├── tiddlers_6.jsonl
+│       │       │   └── tiddlers_7.jsonl
+│       │       └── reverse_html
+│       │           ├── admit-20260428161630-m03-s69-session-canon-admission-hardening-and-docs-v0.derived.html
+│       │           └── admit-20260428161630-m03-s69-session-canon-admission-hardening-and-docs-v0.reverse-report.json
+│       ├── session_admission_nomenclature_full
+│       │   └── admit-20260428161517-multi-session
+│       │       ├── admission_lines.normalized.jsonl
+│       │       ├── admission_lines.raw.jsonl
+│       │       ├── canon
+│       │       │   ├── tiddlers_1.jsonl
+│       │       │   ├── tiddlers_2.jsonl
+│       │       │   ├── tiddlers_3.jsonl
+│       │       │   ├── tiddlers_4.jsonl
+│       │       │   ├── tiddlers_5.jsonl
+│       │       │   ├── tiddlers_6.jsonl
+│       │       │   └── tiddlers_7.jsonl
+│       │       └── reverse_html
+│       │           ├── admit-20260428161517-multi-session.derived.html
+│       │           └── admit-20260428161517-multi-session.reverse-report.json
 │       ├── session_admission_s69
 │       │   ├── admit-20260428133732-m03-s66-session-family-and-canonical-closure-flow-v0
 │       │   │   ├── admission_lines.normalized.jsonl
@@ -555,111 +1929,687 @@
 │       │       └── reverse_html
 │       │           ├── admit-20260428133229-m03-s67-session-canon-admission-orchestrator-v0.derived.html
 │       │           └── admit-20260428133229-m03-s67-session-canon-admission-orchestrator-v0.reverse-report.json
-│       └── session_admission_s69_unittest
-│           ├── admit-20260428133533-m03-s66-session-family-and-canonical-closure-flow-v0
-│           │   ├── canon
-│           │   │   ├── tiddlers_1.jsonl
-│           │   │   ├── tiddlers_2.jsonl
-│           │   │   ├── tiddlers_3.jsonl
-│           │   │   ├── tiddlers_4.jsonl
-│           │   │   ├── tiddlers_5.jsonl
-│           │   │   ├── tiddlers_6.jsonl
-│           │   │   └── tiddlers_7.jsonl
-│           │   └── reverse_html
-│           │       ├── admit-20260428133533-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
-│           │       └── admit-20260428133533-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
-│           ├── admit-20260428133549-m03-s66-session-family-and-canonical-closure-flow-v0
+│       ├── session_admission_s69_unittest
+│       │   ├── admit-20260428133533-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428133533-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428133533-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428133549-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428133549-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428133549-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428133603-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428133603-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428133603-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428133845-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428133845-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428133845-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428133859-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428133859-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428133859-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428133910-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428133910-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428133910-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428161245-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161245-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428161245-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428161357-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161357-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428161357-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428161404-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161404-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428161404-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260428161410-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260428161410-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260428161410-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429033008-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429033008-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429033008-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429033014-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429033014-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429033014-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429033020-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429033020-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429033020-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429174328-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429174328-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429174328-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429174336-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429174336-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429174336-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429174342-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429174342-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429174342-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429175041-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429175041-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429175041-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429175049-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429175049-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429175049-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429175055-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429175055-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429175055-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429190908-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429190908-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429190908-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429190916-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429190916-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429190916-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429190923-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429190923-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429190923-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429191151-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429191151-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429191151-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429191158-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429191158-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429191158-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429191204-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429191204-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429191204-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429191654-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429191654-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429191654-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429191704-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429191704-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429191704-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429191712-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429191712-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429191712-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429200241-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429200241-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429200241-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429200252-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429200252-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429200252-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── admit-20260429200304-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429200304-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── admit-20260429200304-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── rollback-20260428133617-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260428133617-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── rollback-20260428133617-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── rollback-20260428133921-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260428133921-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── rollback-20260428133921-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── rollback-20260428161416-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260428161416-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── rollback-20260428161416-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── rollback-20260429033028-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260429033028-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── rollback-20260429033028-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── rollback-20260429174350-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260429174350-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── rollback-20260429174350-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── rollback-20260429175100-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260429175100-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── rollback-20260429175100-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── rollback-20260429190931-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260429190931-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── rollback-20260429190931-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── rollback-20260429191210-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260429191210-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── rollback-20260429191210-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   ├── rollback-20260429191720-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260429191720-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │   │       └── rollback-20260429191720-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       │   └── rollback-20260429200312-m03-s66-session-family-and-canonical-closure-flow-v0
+│       │       ├── canon
+│       │       │   ├── tiddlers_1.jsonl
+│       │       │   ├── tiddlers_2.jsonl
+│       │       │   ├── tiddlers_3.jsonl
+│       │       │   ├── tiddlers_4.jsonl
+│       │       │   ├── tiddlers_5.jsonl
+│       │       │   ├── tiddlers_6.jsonl
+│       │       │   └── tiddlers_7.jsonl
+│       │       └── reverse_html
+│       │           ├── rollback-20260429200312-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
+│       │           └── rollback-20260429200312-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       ├── session_admission_session_id_probe
+│       │   └── admit-20260428153527-m03-s69-session-canon-admission-hardening-and-docs-v0
+│       │       ├── admission_lines.normalized.jsonl
+│       │       ├── admission_lines.raw.jsonl
+│       │       ├── canon
+│       │       │   ├── tiddlers_1.jsonl
+│       │       │   ├── tiddlers_2.jsonl
+│       │       │   ├── tiddlers_3.jsonl
+│       │       │   ├── tiddlers_4.jsonl
+│       │       │   ├── tiddlers_5.jsonl
+│       │       │   ├── tiddlers_6.jsonl
+│       │       │   └── tiddlers_7.jsonl
+│       │       └── reverse_html
+│       │           ├── admit-20260428153527-m03-s69-session-canon-admission-hardening-and-docs-v0.derived.html
+│       │           └── admit-20260428153527-m03-s69-session-canon-admission-hardening-and-docs-v0.reverse-report.json
+│       ├── session_candidate_generation
+│       │   └── m03-s70-operator-menu-and-session-sync-v0
+│       │       ├── admission_lines.normalized.jsonl
+│       │       ├── admission_lines.raw.jsonl
+│       │       └── debug.normalized.jsonl
+│       └── session_sync
+│           ├── s70_candidate_regen
 │           │   ├── admission_lines.normalized.jsonl
-│           │   ├── admission_lines.raw.jsonl
-│           │   ├── canon
-│           │   │   ├── tiddlers_1.jsonl
-│           │   │   ├── tiddlers_2.jsonl
-│           │   │   ├── tiddlers_3.jsonl
-│           │   │   ├── tiddlers_4.jsonl
-│           │   │   ├── tiddlers_5.jsonl
-│           │   │   ├── tiddlers_6.jsonl
-│           │   │   └── tiddlers_7.jsonl
-│           │   └── reverse_html
-│           │       ├── admit-20260428133549-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
-│           │       └── admit-20260428133549-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
-│           ├── admit-20260428133603-m03-s66-session-family-and-canonical-closure-flow-v0
+│           │   └── admission_lines.raw.jsonl
+│           ├── s71_candidate_regen
 │           │   ├── admission_lines.normalized.jsonl
-│           │   ├── admission_lines.raw.jsonl
-│           │   ├── canon
-│           │   │   ├── tiddlers_1.jsonl
-│           │   │   ├── tiddlers_2.jsonl
-│           │   │   ├── tiddlers_3.jsonl
-│           │   │   ├── tiddlers_4.jsonl
-│           │   │   ├── tiddlers_5.jsonl
-│           │   │   ├── tiddlers_6.jsonl
-│           │   │   └── tiddlers_7.jsonl
-│           │   └── reverse_html
-│           │       ├── admit-20260428133603-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
-│           │       └── admit-20260428133603-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
-│           ├── admit-20260428133845-m03-s66-session-family-and-canonical-closure-flow-v0
-│           │   ├── canon
-│           │   │   ├── tiddlers_1.jsonl
-│           │   │   ├── tiddlers_2.jsonl
-│           │   │   ├── tiddlers_3.jsonl
-│           │   │   ├── tiddlers_4.jsonl
-│           │   │   ├── tiddlers_5.jsonl
-│           │   │   ├── tiddlers_6.jsonl
-│           │   │   └── tiddlers_7.jsonl
-│           │   └── reverse_html
-│           │       ├── admit-20260428133845-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
-│           │       └── admit-20260428133845-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
-│           ├── admit-20260428133859-m03-s66-session-family-and-canonical-closure-flow-v0
-│           │   ├── admission_lines.normalized.jsonl
-│           │   ├── admission_lines.raw.jsonl
-│           │   ├── canon
-│           │   │   ├── tiddlers_1.jsonl
-│           │   │   ├── tiddlers_2.jsonl
-│           │   │   ├── tiddlers_3.jsonl
-│           │   │   ├── tiddlers_4.jsonl
-│           │   │   ├── tiddlers_5.jsonl
-│           │   │   ├── tiddlers_6.jsonl
-│           │   │   └── tiddlers_7.jsonl
-│           │   └── reverse_html
-│           │       ├── admit-20260428133859-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
-│           │       └── admit-20260428133859-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
-│           ├── admit-20260428133910-m03-s66-session-family-and-canonical-closure-flow-v0
-│           │   ├── admission_lines.normalized.jsonl
-│           │   ├── admission_lines.raw.jsonl
-│           │   ├── canon
-│           │   │   ├── tiddlers_1.jsonl
-│           │   │   ├── tiddlers_2.jsonl
-│           │   │   ├── tiddlers_3.jsonl
-│           │   │   ├── tiddlers_4.jsonl
-│           │   │   ├── tiddlers_5.jsonl
-│           │   │   ├── tiddlers_6.jsonl
-│           │   │   └── tiddlers_7.jsonl
-│           │   └── reverse_html
-│           │       ├── admit-20260428133910-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
-│           │       └── admit-20260428133910-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
-│           ├── rollback-20260428133617-m03-s66-session-family-and-canonical-closure-flow-v0
-│           │   ├── canon
-│           │   │   ├── tiddlers_1.jsonl
-│           │   │   ├── tiddlers_2.jsonl
-│           │   │   ├── tiddlers_3.jsonl
-│           │   │   ├── tiddlers_4.jsonl
-│           │   │   ├── tiddlers_5.jsonl
-│           │   │   ├── tiddlers_6.jsonl
-│           │   │   └── tiddlers_7.jsonl
-│           │   └── reverse_html
-│           │       ├── rollback-20260428133617-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
-│           │       └── rollback-20260428133617-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
-│           └── rollback-20260428133921-m03-s66-session-family-and-canonical-closure-flow-v0
-│               ├── canon
-│               │   ├── tiddlers_1.jsonl
-│               │   ├── tiddlers_2.jsonl
-│               │   ├── tiddlers_3.jsonl
-│               │   ├── tiddlers_4.jsonl
-│               │   ├── tiddlers_5.jsonl
-│               │   ├── tiddlers_6.jsonl
-│               │   └── tiddlers_7.jsonl
-│               └── reverse_html
-│                   ├── rollback-20260428133921-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
-│                   └── rollback-20260428133921-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│           │   └── admission_lines.raw.jsonl
+│           ├── s72_candidate_generation
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429025748
+│           │   ├── inventory.json
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429025815
+│           │   ├── inventory.json
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429025850
+│           │   ├── inventory.json
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429025946
+│           │   ├── inventory.json
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429030152
+│           │   ├── inventory.json
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429030939
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429031215
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429031906
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429032303
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429032945
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429170052
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── sync-20260429174235
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260429174304
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260429174656
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260429174719
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260429175012
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260429175113
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           └── sync-20260429183328
+│               ├── inventory.json
+│               ├── missing-candidates.canon-candidates.jsonl
+│               ├── normalize
+│               │   ├── admission_lines.normalized.jsonl
+│               │   └── admission_lines.raw.jsonl
+│               ├── replacement-candidates.canon-candidates.jsonl
+│               └── sync-candidates.canon-candidates.jsonl
 ├── docs
 │   ├── Informe_Tecnico_de_Tiddler (Esp).md
 │   ├── refs
@@ -807,8 +2757,10 @@
 │   ├── canon_proposal.py
 │   ├── corpus_governance.py
 │   ├── derive_layers.py
+│   ├── operator_menu.py
 │   ├── path_governance.py
 │   ├── s45_derive_layers.py
+│   ├── session_sync.py
 │   ├── tiddlers_to_jsonl.py
 │   └── validate_corpus_governance.py
 ├── README.md
@@ -846,7 +2798,8 @@
 │   ├── export_s33_regen.sh
 │   ├── export_s33_verify.sh
 │   ├── pick_and_place.sh
-│   └── run_pipeline.sh
+│   ├── run_pipeline.sh
+│   └── tdc.sh
 ├── tests
 │   ├── fixtures
 │   │   ├── baseline

--- a/python_scripts/admit_session_candidates.py
+++ b/python_scripts/admit_session_candidates.py
@@ -1660,6 +1660,7 @@ def _handle_rollback(args: argparse.Namespace) -> int:
             "rejected": 0,
         },
         "dry_run": bool(args.dry_run),
+        "restore_strategy": "id_removal",
         "status": "fail",
         "warnings": [],
     }
@@ -1705,9 +1706,19 @@ def _handle_rollback(args: argparse.Namespace) -> int:
 
     tmp_run_dir = tmp_dir / run_id
     tmp_canon_dir = tmp_run_dir / "canon"
+    raw_backup_dir = _safe_str(admission_report.get("backup_dir"))
+    backup_dir = resolve_repo_path(raw_backup_dir, DEFAULT_REPORT_DIR) if raw_backup_dir else None
+    backup_shards_available = bool(backup_dir and list(backup_dir.glob("tiddlers_*.jsonl")))
 
     try:
-        _copy_canon_shards(canon_dir, tmp_canon_dir)
+        if backup_shards_available and backup_dir is not None:
+            _copy_canon_shards(backup_dir, tmp_canon_dir)
+            report["restore_strategy"] = "backup_dir"
+            report["removed_count"] = len(admitted_ids)
+            report["removed_ids"] = admitted_ids
+            report["restored_replacement_count"] = len(replacement_records)
+        else:
+            _copy_canon_shards(canon_dir, tmp_canon_dir)
     except RuntimeError as exc:
         report["warnings"].append(str(exc))
         report["canon_after_hash"] = report["canon_before_hash"]
@@ -1726,10 +1737,11 @@ def _handle_rollback(args: argparse.Namespace) -> int:
         )
         return 2
 
-    removed_count, removed_ids = _remove_ids_from_canon(tmp_canon_dir, set(admitted_ids))
-    report["removed_count"] = removed_count
-    report["removed_ids"] = removed_ids
-    if replacement_records:
+    if not backup_shards_available:
+        removed_count, removed_ids = _remove_ids_from_canon(tmp_canon_dir, set(admitted_ids))
+        report["removed_count"] = removed_count
+        report["removed_ids"] = removed_ids
+    if replacement_records and not backup_shards_available:
         target_shards = sorted(tmp_canon_dir.glob("tiddlers_*.jsonl"))
         if not target_shards:
             report["warnings"].append("temporary canon has no shard files for replacement restore")

--- a/python_scripts/operator_menu.py
+++ b/python_scripts/operator_menu.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import shutil
 import subprocess
@@ -38,6 +39,9 @@ DEFAULT_TMP_DIR = REPO_ROOT / "data" / "tmp"
 DEFAULT_ADMISSION_TMP_DIR = DEFAULT_TMP_DIR / "session_admission"
 DEFAULT_ADMISSION_REPORT_DIR = DEFAULT_TMP_DIR / "admissions"
 HTML_EXPORT_DIR = DEFAULT_TMP_DIR / "html_export"
+RECONSTRUCTION_DIR = DEFAULT_TMP_DIR / "reconstruction"
+MAIN_SEED_HTML = REPO_ROOT / "data" / "in" / "objeto_de_estudio_trazabilidad_y_desarrollo.html"
+BOOTSTRAP_AUX_HTML = REPO_ROOT / "data" / "in" / "empty-store.html"
 
 
 @dataclass
@@ -53,6 +57,7 @@ class CommandResult:
 class MenuState:
     selected_html: Path | None = None
     last_export_jsonl: Path | None = None
+    last_reconstruction_report: Path | None = None
     last_sync_inventory: dict[str, Any] | None = None
     last_sync_candidate_file: Path | None = None
     last_validate_report: Path | None = None
@@ -150,12 +155,42 @@ def parse_stdout_json(stdout: str) -> dict[str, Any] | None:
     return None
 
 
+def parse_stdout_json_payload(stdout: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return parse_stdout_json(stdout)
+    return payload if isinstance(payload, dict) else None
+
+
 def count_jsonl_lines(path: Path) -> int:
     try:
         with path.open("r", encoding="utf-8") as handle:
             return sum(1 for line in handle if line.strip())
     except OSError:
         return 0
+
+
+def canonical_file_hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.name.encode("utf-8"))
+    digest.update(b"\0")
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def canon_tree_hash(canon_dir: Path = DEFAULT_CANON_DIR) -> str:
+    digest = hashlib.sha256()
+    for shard in canon_shards(canon_dir):
+        digest.update(shard.name.encode("utf-8"))
+        digest.update(b"\0")
+        with shard.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        digest.update(b"\0")
+    return f"sha256:{digest.hexdigest()}"
 
 
 def canon_shards(canon_dir: Path = DEFAULT_CANON_DIR) -> list[Path]:
@@ -198,11 +233,101 @@ def detect_html_files() -> list[Path]:
 
 
 def html_option_label(path: Path) -> str:
-    if path.resolve() == DEFAULT_INPUT_HTML.resolve():
-        return "HTML saved actual"
-    if "empty" in path.name.lower():
-        return "HTML empty / plantilla base"
-    return "HTML detectado"
+    role = source_role_for_html(path)
+    if role == "seed":
+        return "Semilla reusable principal"
+    if role == "bootstrap_aux":
+        return "Superficie auxiliar/base"
+    return "HTML de trabajo"
+
+
+def source_role_for_html(path: Path) -> str:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path
+    if resolved == MAIN_SEED_HTML.resolve():
+        return "seed"
+    if resolved == BOOTSTRAP_AUX_HTML.resolve():
+        return "bootstrap_aux"
+    return "working"
+
+
+def describe_source_role(role: str) -> str:
+    labels = {
+        "seed": "semilla reusable principal",
+        "working": "superficie de trabajo",
+        "bootstrap_aux": "superficie auxiliar/base",
+    }
+    return labels.get(role, role)
+
+
+def run_reconstruction_gate(
+    source_html: Path,
+    mode: str,
+    output_target: Path,
+    *,
+    requires_backup: bool,
+    requires_hash_report: bool,
+    show_result: bool = True,
+) -> tuple[bool, dict[str, Any] | None, CommandResult | None]:
+    if not shutil.which("cargo"):
+        print("Compuerta Rust bloqueada: cargo no esta disponible.")
+        return False, None, None
+
+    role = source_role_for_html(source_html)
+    result = run_command(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "--bin",
+            "audit",
+            "--",
+            "reconstruction-plan",
+            str(REPO_ROOT),
+            "--source-html",
+            str(source_html),
+            "--source-role",
+            role,
+            "--mode",
+            mode,
+            "--output-target",
+            str(output_target),
+            "--requires-backup",
+            "true" if requires_backup else "false",
+            "--requires-hash-report",
+            "true" if requires_hash_report else "false",
+        ],
+        cwd=REPO_ROOT / "rust" / "doctor",
+    )
+    payload = parse_stdout_json_payload(result.stdout)
+    if show_result:
+        verdict = payload.get("verdict") if payload else "sin_json"
+        errors = payload.get("errors") if payload else "-"
+        print("\nCompuerta Rust de plan de reconstruccion:")
+        print(f"- fuente: {display(source_html)} ({describe_source_role(role)})")
+        print(f"- modo: {mode}")
+        print(f"- destino: {display(output_target)}")
+        print(f"- veredicto: {verdict}")
+        print(f"- errores: {errors}")
+        if result.returncode != 0:
+            print_command_result(result, max_chars=1600)
+    return result.returncode == 0, payload, result
+
+
+def write_reconstruction_report(run_dir: Path, payload: dict[str, Any]) -> Path:
+    report_path = run_dir / "reconstruction-report.json"
+    write_json(report_path, payload)
+    return report_path
+
+
+def backup_canon_shards(run_dir: Path) -> Path:
+    backup_dir = run_dir / "canon_before"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    for shard in canon_shards(DEFAULT_CANON_DIR):
+        shutil.copy2(shard, backup_dir / shard.name)
+    return backup_dir
 
 
 def choose_html(state: MenuState) -> Path | None:
@@ -211,11 +336,13 @@ def choose_html(state: MenuState) -> Path | None:
         print(f"HTML actual: {display(state.selected_html)}")
         answer = prompt("Usar este HTML? [Enter = si, c = cambiar] ").strip().lower()
         if answer != "c":
+            print(f"Rol declarado: {describe_source_role(source_role_for_html(state.selected_html))}")
             return state.selected_html
 
     selected = select_path(html_files, "HTML fuente", html_option_label)
     if selected:
         state.selected_html = selected
+        print(f"Rol declarado: {describe_source_role(source_role_for_html(selected))}")
     return selected
 
 
@@ -262,8 +389,17 @@ def summarize_report(path: Path) -> str:
             f"records={payload.get('total_session_records')}, "
             f"existing={len(payload.get('existing_by_id') or [])}, "
             f"missing={len(payload.get('missing_by_id') or [])}, "
-            f"conflicts={len(payload.get('same_id_different_content') or [])}, "
+            f"replaceable={len(payload.get('replaceable_same_id_different_content') or [])}, "
+            f"blocked={len(payload.get('blocked_same_id_different_content') or [])}, "
             f"invalid={len(payload.get('invalid') or [])}"
+        )
+
+    if "gate_verdict" in payload and "canon_before_hash" in payload:
+        return (
+            f"run_id={payload.get('run_id')}, "
+            f"gate={payload.get('gate_verdict')}, "
+            f"shard_exit={payload.get('shard_exit_code')}, "
+            f"canon_modified={payload.get('canon_modified')}"
         )
 
     parts = []
@@ -297,12 +433,26 @@ def option_preparation() -> None:
         ("data/tmp", DEFAULT_TMP_DIR.exists(), display(DEFAULT_TMP_DIR)),
         ("python3", shutil.which("python3") is not None, shutil.which("python3") or ""),
         ("go", shutil.which("go") is not None, shutil.which("go") or ""),
+        ("cargo", shutil.which("cargo") is not None, shutil.which("cargo") or ""),
     ]
     for name, ok, detail in checks:
         state = "OK" if ok else "FALTA"
         suffix = f" - {detail}" if detail else ""
         print(f"- {name}: {state}{suffix}")
     DEFAULT_TMP_DIR.mkdir(parents=True, exist_ok=True)
+
+    if shutil.which("cargo") and (REPO_ROOT / "rust" / "doctor").exists():
+        result = run_command(
+            ["cargo", "run", "--quiet", "--bin", "audit", "--", "perimeter", str(REPO_ROOT)],
+            cwd=REPO_ROOT / "rust" / "doctor",
+        )
+        state = "OK" if result.returncode == 0 else "ERROR"
+        print(f"- rust kernel perimeter: {state}")
+        if result.returncode != 0:
+            print_command_result(result, max_chars=1200)
+    else:
+        print("- rust kernel perimeter: FALTA - cargo o rust/doctor no disponible")
+
     print("\nSiguiente paso recomendado: validar canon o revisar estado del canon.")
 
 
@@ -334,6 +484,13 @@ def option_build_from_html(state: MenuState) -> None:
     print("Flujo: HTML vivo -> JSONL temporal -> shards canonicos locales -> validacion")
     selected = choose_html(state)
     if selected:
+        run_reconstruction_gate(
+            selected,
+            "diagnostic",
+            DEFAULT_TMP_DIR / "reconstruction_plan",
+            requires_backup=False,
+            requires_hash_report=False,
+        )
         print(f"HTML seleccionado: {display(selected)}")
         print("Siguiente paso recomendado: opcion 4 para extraer a JSONL temporal.")
 
@@ -347,6 +504,16 @@ def option_extract_html(state: MenuState) -> None:
     out_jsonl = out_dir / "tiddlers.export.jsonl"
     out_log = out_dir / "tiddlers.export.log"
     manifest = out_dir / "tiddlers.export.manifest.json"
+    gate_ok, _, _ = run_reconstruction_gate(
+        html,
+        "staging",
+        out_dir,
+        requires_backup=False,
+        requires_hash_report=True,
+    )
+    if not gate_ok:
+        print("Extraccion bloqueada por la compuerta Rust. No se escribio salida temporal.")
+        return
     out_dir.mkdir(parents=True, exist_ok=True)
 
     result = run_command(
@@ -391,12 +558,39 @@ def option_shard_jsonl(state: MenuState) -> None:
     if not selected:
         return
 
+    html = choose_html(state)
+    if not html:
+        print("Shardizacion cancelada: se requiere fuente HTML explicita.")
+        return
+
+    run_id = f"reconstruction-{stamp_now()}"
+    run_dir = RECONSTRUCTION_DIR / run_id
+    gate_ok, gate_payload, gate_result = run_reconstruction_gate(
+        html,
+        "write_local_canon",
+        DEFAULT_CANON_DIR,
+        requires_backup=True,
+        requires_hash_report=True,
+    )
+    if not gate_ok:
+        print("Shardizacion bloqueada por la compuerta Rust. No se modifico el canon.")
+        return
+
     print("\nAdvertencia: esta opcion escribe shards en data/out/local.")
     print("JSONL temporal != canon; los shards en data/out/local son el canon local oficial.")
+    print(f"Fuente HTML declarada: {display(html)}")
+    print(f"JSONL temporal: {display(selected)}")
+    print(f"Destino de salida: {display(DEFAULT_CANON_DIR)}")
+    print(f"Backup/reporte: {display(run_dir)}")
     confirmation = prompt("Escribe WRITE CANON para continuar: ").strip()
     if confirmation != "WRITE CANON":
         print("Shardizacion cancelada. No se modifico el canon.")
         return
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    before_hash = canon_tree_hash(DEFAULT_CANON_DIR)
+    backup_dir = backup_canon_shards(run_dir)
+    input_hash = canonical_file_hash(selected)
 
     result = run_command(
         [
@@ -411,6 +605,32 @@ def option_shard_jsonl(state: MenuState) -> None:
         cwd=REPO_ROOT / "go" / "canon",
     )
     print_command_result(result)
+    after_hash = canon_tree_hash(DEFAULT_CANON_DIR)
+    report_path = write_reconstruction_report(
+        run_dir,
+        {
+            "run_id": run_id,
+            "timestamp": stamp_now(),
+            "source_html": as_display_path(html),
+            "source_role": source_role_for_html(html),
+            "input_jsonl": as_display_path(selected),
+            "input_jsonl_hash": input_hash,
+            "output_target": as_display_path(DEFAULT_CANON_DIR),
+            "backup_dir": as_display_path(backup_dir),
+            "canon_before_hash": before_hash,
+            "canon_after_hash": after_hash,
+            "gate_verdict": gate_payload.get("verdict") if gate_payload else None,
+            "gate_report": gate_payload,
+            "gate_exit_code": gate_result.returncode if gate_result else None,
+            "shard_exit_code": result.returncode,
+            "canon_modified": before_hash != after_hash,
+        },
+    )
+    state.last_reconstruction_report = report_path
+    print(f"\nReporte de reconstruccion: {display(report_path)}")
+    print(f"- backup: {display(backup_dir)}")
+    print(f"- hash before: {before_hash}")
+    print(f"- hash after:  {after_hash}")
     if result.returncode == 0:
         option_canon_status()
         print("Siguiente paso recomendado: opcion 6 para validar el canon.")
@@ -451,14 +671,19 @@ def print_inventory_summary(inventory: dict[str, Any]) -> None:
     print("Sessions:")
     print(f"- archivos detectados: {inventory['total_files_scanned']}")
     print(f"- entregables validos: {inventory['total_session_records']}")
-    print(f"- ya existen en canon por ID: {len(inventory['existing_by_id'])}")
+    print(f"- ya existen iguales en canon por ID: {len(inventory['existing_by_id'])}")
     print(f"- faltantes por ID: {len(inventory['missing_by_id'])}")
-    print(f"- conflictos: {len(inventory['same_id_different_content'])}")
+    print(f"- diferencias reemplazables por ID: {len(inventory.get('replaceable_same_id_different_content') or [])}")
+    print(f"- conflictos bloqueantes: {len(inventory.get('blocked_same_id_different_content') or [])}")
     print(f"- invalidos: {len(inventory['invalid'])}")
     print(f"- unsupported: {len(inventory['unsupported'])}")
     print(f"- inventario: {inventory['inventory_path']}")
+    if inventory.get("generated_missing_candidate_file"):
+        print(f"- candidatos faltantes: {inventory['generated_missing_candidate_file']}")
+    if inventory.get("generated_replacement_candidate_file"):
+        print(f"- candidatos de reemplazo: {inventory['generated_replacement_candidate_file']}")
     if inventory.get("generated_candidate_file"):
-        print(f"- candidatos faltantes: {inventory['generated_candidate_file']}")
+        print(f"- candidatos sincronizables: {inventory['generated_candidate_file']}")
 
 
 def print_items(title: str, items: list[dict[str, Any]], limit: int = 40) -> None:
@@ -493,6 +718,12 @@ def run_admission_command(mode: str, candidate_file: Path, extra: list[str] | No
     result = run_command(args, cwd=REPO_ROOT)
     print_command_result(result)
     return result, parse_stdout_json(result.stdout)
+
+
+def sync_admission_extra_args(inventory: dict[str, Any]) -> list[str]:
+    if inventory.get("replaceable_same_id_different_content"):
+        return ["--allow-replacements"]
+    return []
 
 
 def dry_run_report_is_usable(report_path: Path, candidate_file: Path) -> tuple[bool, str]:
@@ -535,12 +766,13 @@ def option_session_sync(state: MenuState) -> None:
         print(
             "\nSincronizacion de sesiones\n"
             "1) Ver faltantes\n"
-            "2) Ver conflictos\n"
-            "3) Ver candidatos generados\n"
-            "4) Validar candidatos\n"
-            "5) Dry-run de admision\n"
-            "6) Apply confirmado\n"
-            "7) Rollback ultimo apply\n"
+            "2) Ver diferencias reemplazables\n"
+            "3) Ver conflictos bloqueantes\n"
+            "4) Ver candidatos generados\n"
+            "5) Validar candidatos\n"
+            "6) Dry-run de admision\n"
+            "7) Apply confirmado\n"
+            "8) Rollback ultimo apply\n"
             "0) Volver"
         )
         choice = prompt("> ").strip()
@@ -549,44 +781,62 @@ def option_session_sync(state: MenuState) -> None:
         if choice == "1":
             print_items("Faltantes por ID", inventory["missing_by_id"])
         elif choice == "2":
-            print_items("Conflictos same_id_different_content", inventory["same_id_different_content"])
-            print_items("Invalidos", inventory["invalid"], limit=20)
+            print_items(
+                "Diferencias reemplazables por mismo ID y source_path",
+                inventory.get("replaceable_same_id_different_content") or [],
+            )
         elif choice == "3":
-            if state.last_sync_candidate_file:
-                print(f"Candidato temporal: {display(state.last_sync_candidate_file)}")
-                print(f"Lineas: {count_jsonl_lines(state.last_sync_candidate_file)}")
-            else:
-                print("No hay faltantes; no se genero archivo de candidatos.")
+            print_items(
+                "Conflictos bloqueantes",
+                inventory.get("blocked_same_id_different_content") or [],
+            )
+            print_items("Invalidos", inventory["invalid"], limit=20)
         elif choice == "4":
+            if state.last_sync_candidate_file:
+                print(f"Candidato sincronizable: {display(state.last_sync_candidate_file)}")
+                print(f"Lineas: {count_jsonl_lines(state.last_sync_candidate_file)}")
+                if inventory.get("replaceable_same_id_different_content"):
+                    print("Modo: incluye reemplazos controlados; se usara --allow-replacements.")
+            else:
+                print("No hay faltantes ni reemplazos; no se genero archivo de candidatos.")
+        elif choice == "5":
             if not state.last_sync_candidate_file:
-                print("No hay candidatos faltantes para validar.")
+                print("No hay candidatos sincronizables para validar.")
                 continue
-            if inventory["same_id_different_content"]:
-                print("Hay conflictos por ID. Resolver antes de validar admision.")
+            if inventory.get("blocked_same_id_different_content"):
+                print("Hay conflictos bloqueantes por ID. Resolver antes de validar admision.")
                 continue
-            result, payload = run_admission_command("validate", state.last_sync_candidate_file)
+            result, payload = run_admission_command(
+                "validate",
+                state.last_sync_candidate_file,
+                sync_admission_extra_args(inventory),
+            )
             if payload and payload.get("report"):
                 state.last_validate_report = (REPO_ROOT / payload["report"]).resolve()
             if result.returncode == 0:
                 print("Validacion OK. Siguiente paso recomendado: dry-run.")
-        elif choice == "5":
+        elif choice == "6":
             if not state.last_sync_candidate_file:
-                print("No hay candidatos faltantes para dry-run.")
+                print("No hay candidatos sincronizables para dry-run.")
                 continue
-            if inventory["same_id_different_content"]:
-                print("Hay conflictos por ID. Resolver antes de dry-run.")
+            if inventory.get("blocked_same_id_different_content"):
+                print("Hay conflictos bloqueantes por ID. Resolver antes de dry-run.")
                 continue
-            result, payload = run_admission_command("dry-run", state.last_sync_candidate_file)
+            result, payload = run_admission_command(
+                "dry-run",
+                state.last_sync_candidate_file,
+                sync_admission_extra_args(inventory),
+            )
             if payload and payload.get("report"):
                 state.last_dry_run_report = (REPO_ROOT / payload["report"]).resolve()
             if result.returncode == 0:
                 print("Dry-run OK. Revisar el reporte antes de apply.")
-        elif choice == "6":
+        elif choice == "7":
             if not state.last_sync_candidate_file:
-                print("No hay candidatos faltantes para apply.")
+                print("No hay candidatos sincronizables para apply.")
                 continue
-            if inventory["same_id_different_content"]:
-                print("Hay conflictos por ID. Apply bloqueado.")
+            if inventory.get("blocked_same_id_different_content"):
+                print("Hay conflictos bloqueantes por ID. Apply bloqueado.")
                 continue
             if not state.last_dry_run_report:
                 print("Apply bloqueado: no hay dry-run previo en esta ejecucion del menu.")
@@ -597,14 +847,20 @@ def option_session_sync(state: MenuState) -> None:
                 continue
             print("\nApply confirmado modificara data/out/local.")
             print(f"- candidatos: {display(state.last_sync_candidate_file)}")
-            print(f"- lineas a insertar: {count_jsonl_lines(state.last_sync_candidate_file)}")
+            print(f"- lineas a sincronizar: {count_jsonl_lines(state.last_sync_candidate_file)}")
+            print(f"- faltantes nuevos: {len(inventory['missing_by_id'])}")
+            print(f"- reemplazos controlados: {len(inventory.get('replaceable_same_id_different_content') or [])}")
             print(f"- dry-run revisable: {display(state.last_dry_run_report)}")
             confirmation = prompt("Escribe APPLY para modificar el canon local: ").strip()
             if confirmation != "APPLY":
                 print("Apply cancelado.")
                 continue
-            run_admission_command("apply", state.last_sync_candidate_file, ["--confirm-apply"])
-        elif choice == "7":
+            run_admission_command(
+                "apply",
+                state.last_sync_candidate_file,
+                [*sync_admission_extra_args(inventory), "--confirm-apply"],
+            )
+        elif choice == "8":
             option_rollback()
         else:
             print("Opcion invalida.")
@@ -686,6 +942,16 @@ def option_reverse(state: MenuState) -> None:
     html = choose_html(state)
     if not html:
         return
+    gate_ok, _, _ = run_reconstruction_gate(
+        html,
+        "reverse_projection",
+        DEFAULT_REVERSE_HTML,
+        requires_backup=False,
+        requires_hash_report=True,
+    )
+    if not gate_ok:
+        print("Reverse bloqueado por la compuerta Rust.")
+        return
     print("\nEjecutando reverse-preflight antes de reverse...")
     preflight = run_preflight("reverse-preflight")
     print_command_result(preflight)
@@ -733,6 +999,7 @@ def option_reports() -> None:
         DEFAULT_TMP_DIR,
         DEFAULT_ADMISSION_REPORT_DIR,
         DEFAULT_SESSION_SYNC_DIR,
+        RECONSTRUCTION_DIR,
         DEFAULT_CANON_DIR / "reverse_html",
     ]
     reports = recent_files(roots, "*.json", limit=16)
@@ -778,7 +1045,7 @@ def option_rollback() -> None:
 
 
 def main_menu() -> None:
-    state = MenuState(selected_html=DEFAULT_INPUT_HTML if DEFAULT_INPUT_HTML.exists() else None)
+    state = MenuState()
     while True:
         print(
             "\nTiddly Data Converter - Operador local\n\n"

--- a/python_scripts/session_sync.py
+++ b/python_scripts/session_sync.py
@@ -3,7 +3,8 @@
 
 This helper does not modify the canon. It reads session artifacts, derives
 canonical identity through the existing canon_preflight normalize command, and
-writes an inventory plus a temporary candidate file for records missing by id.
+writes an inventory plus temporary candidate files for records missing by id
+and same-source replacements.
 """
 
 from __future__ import annotations
@@ -361,20 +362,23 @@ def scan_session_sync(
     canon_index = _load_canon_index(canon_dir)
     existing_by_id: list[dict[str, Any]] = []
     missing_by_id: list[dict[str, Any]] = []
-    same_id_different_content: list[dict[str, Any]] = []
+    replaceable_same_id_different_content: list[dict[str, Any]] = []
+    blocked_same_id_different_content: list[dict[str, Any]] = []
 
     seen_ids: dict[str, str] = {}
     missing_records: list[dict[str, Any]] = []
+    replacement_records: list[dict[str, Any]] = []
+    sync_records: list[dict[str, Any]] = []
 
     for candidate in normalized:
         rec_id = _safe_str(candidate.record.get("id"))
         summary = _summary_record(candidate)
         previous_source = seen_ids.get(rec_id)
         if previous_source and previous_source != summary["source_path"]:
-            same_id_different_content.append(
+            blocked_same_id_different_content.append(
                 {
                     **summary,
-                    "classification": "same_id_different_content",
+                    "classification": "blocked_duplicate_session_id",
                     "message": f"id also derived from {previous_source}",
                 }
             )
@@ -385,6 +389,7 @@ def scan_session_sync(
         if existing is None:
             missing_by_id.append({**summary, "classification": "missing_by_id"})
             missing_records.append(candidate.record)
+            sync_records.append(candidate.record)
             continue
 
         projected = _project_candidate_record_as_admitted(candidate.record)
@@ -398,20 +403,58 @@ def scan_session_sync(
                 }
             )
         else:
-            same_id_different_content.append(
-                {
-                    **summary,
-                    "classification": "same_id_different_content",
-                    "shard": existing.shard,
-                    "line_no": existing.line_no,
-                    "message": "id exists in canon but normalized session artifact differs",
-                }
-            )
+            existing_source_fields = existing.record.get("source_fields") or {}
+            existing_source_path = _safe_str(existing_source_fields.get("source_path"))
+            item = {
+                **summary,
+                "shard": existing.shard,
+                "line_no": existing.line_no,
+            }
+            if existing_source_path == summary["source_path"]:
+                replaceable_same_id_different_content.append(
+                    {
+                        **item,
+                        "classification": "replaceable_same_id_different_content",
+                        "message": (
+                            "id exists in canon with different content and the same source_path; "
+                            "eligible for controlled replacement"
+                        ),
+                    }
+                )
+                replacement_records.append(candidate.record)
+                sync_records.append(candidate.record)
+            else:
+                blocked_same_id_different_content.append(
+                    {
+                        **item,
+                        "classification": "blocked_same_id_different_content",
+                        "existing_source_path": existing_source_path,
+                        "message": (
+                            "id exists in canon with different content but source_path differs; "
+                            "blocked until reviewed"
+                        ),
+                    }
+                )
+
+    generated_missing_candidate_file = None
+    if missing_records:
+        generated_missing_candidate_file = run_dir / "missing-candidates.canon-candidates.jsonl"
+        _write_jsonl(generated_missing_candidate_file, missing_records)
+
+    generated_replacement_candidate_file = None
+    if replacement_records:
+        generated_replacement_candidate_file = run_dir / "replacement-candidates.canon-candidates.jsonl"
+        _write_jsonl(generated_replacement_candidate_file, replacement_records)
 
     generated_candidate_file = None
-    if missing_records:
-        generated_candidate_file = run_dir / "missing-candidates.canon-candidates.jsonl"
-        _write_jsonl(generated_candidate_file, missing_records)
+    if sync_records:
+        generated_candidate_file = run_dir / "sync-candidates.canon-candidates.jsonl"
+        _write_jsonl(generated_candidate_file, sync_records)
+
+    same_id_different_content = [
+        *replaceable_same_id_different_content,
+        *blocked_same_id_different_content,
+    ]
 
     inventory_path = run_dir / "inventory.json"
     inventory = {
@@ -425,8 +468,16 @@ def scan_session_sync(
         "existing_by_id": existing_by_id,
         "missing_by_id": missing_by_id,
         "same_id_different_content": same_id_different_content,
+        "replaceable_same_id_different_content": replaceable_same_id_different_content,
+        "blocked_same_id_different_content": blocked_same_id_different_content,
         "invalid": invalid,
         "unsupported": unsupported,
+        "generated_missing_candidate_file": (
+            as_display_path(generated_missing_candidate_file) if generated_missing_candidate_file else None
+        ),
+        "generated_replacement_candidate_file": (
+            as_display_path(generated_replacement_candidate_file) if generated_replacement_candidate_file else None
+        ),
         "generated_candidate_file": as_display_path(generated_candidate_file) if generated_candidate_file else None,
         "inventory_path": as_display_path(inventory_path),
     }
@@ -436,7 +487,10 @@ def scan_session_sync(
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Scan data/sessions by canonical id and generate missing session candidates."
+        description=(
+            "Scan data/sessions by canonical id and generate missing plus "
+            "controlled replacement session candidates."
+        )
     )
     parser.add_argument("command", choices=["scan"], help="Operation to run")
     parser.add_argument("--sessions-dir", default=as_display_path(DEFAULT_SESSIONS_DIR))
@@ -467,10 +521,14 @@ def main() -> int:
                 "run_id": inventory["run_id"],
                 "inventory": inventory["inventory_path"],
                 "generated_candidate_file": inventory["generated_candidate_file"],
+                "generated_missing_candidate_file": inventory["generated_missing_candidate_file"],
+                "generated_replacement_candidate_file": inventory["generated_replacement_candidate_file"],
                 "total_session_records": inventory["total_session_records"],
                 "existing_by_id": len(inventory["existing_by_id"]),
                 "missing_by_id": len(inventory["missing_by_id"]),
                 "same_id_different_content": len(inventory["same_id_different_content"]),
+                "replaceable_same_id_different_content": len(inventory["replaceable_same_id_different_content"]),
+                "blocked_same_id_different_content": len(inventory["blocked_same_id_different_content"]),
                 "invalid": len(inventory["invalid"]),
                 "unsupported": len(inventory["unsupported"]),
             },

--- a/rust/doctor/src/bin/audit.rs
+++ b/rust/doctor/src/bin/audit.rs
@@ -1,9 +1,13 @@
 //! # audit — CLI mínima del Doctor
 //!
-//! Uso: audit <raw_path>
+//! Uso:
+//!   audit <raw_path>
+//!   audit perimeter <repo_root>
+//!   audit reconstruction-plan <repo_root> --source-html <path> --source-role <role> --mode <mode> --output-target <path> --requires-backup <true|false> --requires-hash-report <true|false>
 //!
 //! Audita la integridad estructural mínima del artefacto raw producido por
-//! el Extractor. Emite el veredicto y el reporte por stderr.
+//! el Extractor, o el perímetro reusable del repositorio. Emite el reporte
+//! raw por stderr y los reportes normativos por JSON en stdout.
 //!
 //! Código de salida:
 //!   0  — veredicto ok o warning (el pipeline puede continuar)
@@ -13,14 +17,88 @@
 //!
 //! Ref: contratos/m01-s12-pipeline-costura.md.json
 
-use std::{env, path::Path, process};
+use std::{collections::HashMap, env, path::Path, process};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("[doctor] uso: audit <raw_path>");
+        eprintln!(
+            "[doctor] uso: audit <raw_path> | audit perimeter <repo_root> | audit reconstruction-plan <repo_root> --source-html <path> --source-role <role> --mode <mode> --output-target <path> --requires-backup <true|false> --requires-hash-report <true|false>"
+        );
         process::exit(1);
     }
+
+    if args[1] == "perimeter" {
+        let repo_root = args.get(2).map(String::as_str).unwrap_or(".");
+        let report = tdc_doctor::audit_perimeter(Path::new(repo_root));
+        let json = serde_json::to_string_pretty(&report).unwrap_or_else(|e| {
+            eprintln!("[doctor] ERROR al serializar reporte de perímetro: {}", e);
+            process::exit(2);
+        });
+        println!("{}", json);
+        eprintln!(
+            "[doctor] perimeter verdict={:?} checks={} errors={}",
+            report.verdict, report.checks_run, report.errors
+        );
+        if report.verdict == tdc_doctor::PerimeterVerdict::Error {
+            process::exit(10);
+        }
+        return;
+    }
+
+    if args[1] == "reconstruction-plan" {
+        let repo_root = args.get(2).map(String::as_str).unwrap_or(".");
+        let flags = parse_flags(&args[3..]).unwrap_or_else(|message| {
+            eprintln!("[doctor] ERROR: {}", message);
+            process::exit(1);
+        });
+        let source_html = required_flag(&flags, "source-html");
+        let source_role = required_flag(&flags, "source-role");
+        let mode = required_flag(&flags, "mode");
+        let output_target = required_flag(&flags, "output-target");
+        let requires_backup = parse_bool_flag(required_flag(&flags, "requires-backup"));
+        let requires_hash_report = parse_bool_flag(required_flag(&flags, "requires-hash-report"));
+
+        let source_role =
+            tdc_doctor::parse_reconstruction_source_role(source_role).unwrap_or_else(|| {
+                eprintln!(
+                    "[doctor] ERROR: source-role inválido '{}'; use seed, working o bootstrap_aux",
+                    source_role
+                );
+                process::exit(1);
+            });
+        let mode = tdc_doctor::parse_reconstruction_mode(mode).unwrap_or_else(|| {
+            eprintln!(
+                "[doctor] ERROR: mode inválido '{}'; use diagnostic, staging, write_local_canon o reverse_projection",
+                mode
+            );
+            process::exit(1);
+        });
+
+        let report = tdc_doctor::audit_reconstruction_plan(
+            Path::new(repo_root),
+            Path::new(source_html),
+            source_role,
+            mode,
+            Path::new(output_target),
+            requires_backup,
+            requires_hash_report,
+        );
+        let json = serde_json::to_string_pretty(&report).unwrap_or_else(|e| {
+            eprintln!("[doctor] ERROR al serializar reporte de plan: {}", e);
+            process::exit(2);
+        });
+        println!("{}", json);
+        eprintln!(
+            "[doctor] reconstruction-plan verdict={:?} checks={} errors={}",
+            report.verdict, report.checks_run, report.errors
+        );
+        if report.verdict == tdc_doctor::ReconstructionPlanVerdict::Rejected {
+            process::exit(10);
+        }
+        return;
+    }
+
     let raw_path = Path::new(&args[1]);
 
     match tdc_doctor::audit(raw_path) {
@@ -50,6 +128,49 @@ fn main() {
             if report.verdict == tdc_doctor::DoctorVerdict::Error {
                 process::exit(10);
             }
+        }
+    }
+}
+
+fn parse_flags(args: &[String]) -> Result<HashMap<String, String>, String> {
+    let mut flags = HashMap::new();
+    let mut index = 0;
+    while index < args.len() {
+        let key = args[index].strip_prefix("--").ok_or_else(|| {
+            format!(
+                "argumento inesperado '{}'; los parámetros del plan usan --clave valor",
+                args[index]
+            )
+        })?;
+        let value = args
+            .get(index + 1)
+            .ok_or_else(|| format!("falta valor para --{}", key))?;
+        if value.starts_with("--") {
+            return Err(format!("falta valor para --{}", key));
+        }
+        flags.insert(key.to_string(), value.clone());
+        index += 2;
+    }
+    Ok(flags)
+}
+
+fn required_flag<'a>(flags: &'a HashMap<String, String>, key: &str) -> &'a str {
+    flags.get(key).map(String::as_str).unwrap_or_else(|| {
+        eprintln!("[doctor] ERROR: falta --{}", key);
+        process::exit(1);
+    })
+}
+
+fn parse_bool_flag(value: &str) -> bool {
+    match value {
+        "true" => true,
+        "false" => false,
+        _ => {
+            eprintln!(
+                "[doctor] ERROR: valor booleano inválido '{}'; use true o false",
+                value
+            );
+            process::exit(1);
         }
     }
 }

--- a/rust/doctor/src/error.rs
+++ b/rust/doctor/src/error.rs
@@ -32,7 +32,11 @@ impl std::fmt::Display for DoctorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             DoctorError::RawFileNotFound(path) => {
-                write!(f, "ERR_RAW_FILE_NOT_FOUND: no se encontró el archivo '{}'", path)
+                write!(
+                    f,
+                    "ERR_RAW_FILE_NOT_FOUND: no se encontró el archivo '{}'",
+                    path
+                )
             }
             DoctorError::RawFileNotReadable(reason) => {
                 write!(f, "ERR_RAW_FILE_NOT_READABLE: {}", reason)

--- a/rust/doctor/src/lib.rs
+++ b/rust/doctor/src/lib.rs
@@ -19,7 +19,7 @@
 //! - No normaliza campos, tags ni contenido textual.
 //! - No valida integridad semántica de dominio (eso es la Ingesta / Canon).
 //! - No modifica el artefacto raw recibido.
-//! - No ejecuta reverse ni depende de la zona Canon/Reversibilidad.
+//! - No ejecuta reverse ni canoniza; solo audita perímetro y planes cuando se invoca como compuerta.
 //! - No reemplaza el esquema del Canon ni absorbe la lógica del núcleo.
 //! - No retiene estado entre ejecuciones.
 //!
@@ -28,10 +28,14 @@
 pub mod error;
 pub mod report;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub use error::DoctorError;
-pub use report::{DoctorReport, DoctorVerdict};
+pub use report::{
+    DoctorReport, DoctorVerdict, PerimeterCheck, PerimeterReport, PerimeterVerdict,
+    ReconstructionMode, ReconstructionPlanInput, ReconstructionPlanReport,
+    ReconstructionPlanVerdict, ReconstructionSourceRole,
+};
 
 /// Audita la integridad estructural mínima del artefacto raw producido por el Extractor HTML.
 ///
@@ -65,20 +69,12 @@ pub fn audit(raw_path: &Path) -> Result<DoctorReport, DoctorError> {
 
     // §8: archivo no legible
     let content = std::fs::read_to_string(raw_path).map_err(|e| {
-        DoctorError::RawFileNotReadable(format!(
-            "'{}': {}",
-            raw_path.to_string_lossy(),
-            e
-        ))
+        DoctorError::RawFileNotReadable(format!("'{}': {}", raw_path.to_string_lossy(), e))
     })?;
 
     // §8: JSON inválido
     let value: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
-        DoctorError::RawNotValidJson(format!(
-            "'{}': {}",
-            raw_path.to_string_lossy(),
-            e
-        ))
+        DoctorError::RawNotValidJson(format!("'{}': {}", raw_path.to_string_lossy(), e))
     })?;
 
     // §8: no es array JSON de objetos tiddler
@@ -181,6 +177,364 @@ pub fn audit(raw_path: &Path) -> Result<DoctorReport, DoctorError> {
     })
 }
 
+/// Audita el perímetro reusable del repositorio sin modificar archivos.
+///
+/// Este chequeo inaugura el perímetro del futuro kernel Rust: valida que las
+/// superficies de entrada, canon, reverse, sesiones y derivados conserven su
+/// autoridad declarada antes de operar el menú local.
+pub fn audit_perimeter(repo_root: &Path) -> PerimeterReport {
+    let root = repo_root;
+    let mut checks: Vec<PerimeterCheck> = Vec::new();
+
+    push_path_check(
+        &mut checks,
+        root,
+        "seed-main-exists",
+        "data/in/objeto_de_estudio_trazabilidad_y_desarrollo.html",
+        ExpectedPathKind::File,
+        "semilla reusable principal de tema",
+    );
+    push_path_check(
+        &mut checks,
+        root,
+        "seed-empty-store-auxiliary-exists",
+        "data/in/empty-store.html",
+        ExpectedPathKind::File,
+        "superficie auxiliar de arranque, no semilla madre",
+    );
+    check_working_html_surfaces(root, &mut checks);
+    push_path_check(
+        &mut checks,
+        root,
+        "sessions-staging-exists",
+        "data/sessions",
+        ExpectedPathKind::Dir,
+        "staging operativo de sesiones",
+    );
+    push_path_check(
+        &mut checks,
+        root,
+        "canon-local-exists",
+        "data/out/local",
+        ExpectedPathKind::Dir,
+        "canon local oficial",
+    );
+    push_path_check(
+        &mut checks,
+        root,
+        "reverse-html-projection-exists",
+        "data/out/local/reverse_html",
+        ExpectedPathKind::Dir,
+        "reverse_html es proyección no autoritativa",
+    );
+    push_path_check(
+        &mut checks,
+        root,
+        "tmp-workspace-exists",
+        "data/tmp",
+        ExpectedPathKind::Dir,
+        "zona temporal de reportes y artefactos intermedios",
+    );
+    push_path_check(
+        &mut checks,
+        root,
+        "operator-wrapper-exists",
+        "shell_scripts/tdc.sh",
+        ExpectedPathKind::File,
+        "único wrapper operativo público",
+    );
+
+    let root_sessions = root.join("sessions");
+    if root_sessions.exists() {
+        push_error(
+            &mut checks,
+            "no-root-sessions-dir",
+            "sessions/ en raíz existe; la ruta oficial es data/sessions",
+        );
+    } else {
+        push_ok(
+            &mut checks,
+            "no-root-sessions-dir",
+            "no existe sessions/ en raíz",
+        );
+    }
+
+    let seed = root.join("data/in/objeto_de_estudio_trazabilidad_y_desarrollo.html");
+    let empty = root.join("data/in/empty-store.html");
+    if seed == empty {
+        push_error(
+            &mut checks,
+            "main-seed-not-empty-store",
+            "la semilla principal no puede ser empty-store.html",
+        );
+    } else {
+        push_ok(
+            &mut checks,
+            "main-seed-not-empty-store",
+            "objeto_de_estudio_trazabilidad_y_desarrollo.html y empty-store.html son superficies distintas",
+        );
+    }
+
+    check_canon_shards(root, &mut checks);
+    check_policy_bundle(root, &mut checks);
+    check_derived_registry(root, &mut checks);
+    check_readme_single_operator(root, &mut checks);
+
+    let errors = checks
+        .iter()
+        .filter(|check| check.status == "error")
+        .count();
+    let verdict = if errors == 0 {
+        PerimeterVerdict::Ok
+    } else {
+        PerimeterVerdict::Error
+    };
+
+    PerimeterReport {
+        verdict,
+        repo_root: root.to_string_lossy().to_string(),
+        checks_run: checks.len(),
+        errors,
+        checks,
+    }
+}
+
+/// Audita un plan de reconstrucción antes de que el menú ejecute extracción,
+/// shardización o reverse.
+///
+/// Rust no reconstruye el canon en S72. Solo emite un veredicto normativo sobre
+/// la intención operacional: fuente HTML explícita, rol declarado, modo,
+/// destino y evidencias mínimas de backup/hash cuando el plan puede tocar el
+/// canon local.
+pub fn audit_reconstruction_plan(
+    repo_root: &Path,
+    source_html_path: &Path,
+    source_role: ReconstructionSourceRole,
+    reconstruction_mode: ReconstructionMode,
+    output_target: &Path,
+    requires_backup: bool,
+    requires_hash_report: bool,
+) -> ReconstructionPlanReport {
+    let root = repo_root;
+    let mut checks: Vec<PerimeterCheck> = Vec::new();
+    let source = resolve_plan_path(root, source_html_path);
+    let target = resolve_plan_path(root, output_target);
+    let data_in = root.join("data/in");
+    let data_tmp = root.join("data/tmp");
+    let canon_dir = root.join("data/out/local");
+    let reverse_html_dir = root.join("data/out/local/reverse_html");
+
+    check_source_html(root, &source, &source_role, &mut checks);
+    check_reconstruction_target(
+        &target,
+        &data_tmp,
+        &canon_dir,
+        &reverse_html_dir,
+        &reconstruction_mode,
+        &mut checks,
+    );
+
+    if source == target {
+        push_error(
+            &mut checks,
+            "plan-source-target-distinct",
+            "source_html_path y output_target no pueden ser la misma ruta",
+        );
+    } else {
+        push_ok(
+            &mut checks,
+            "plan-source-target-distinct",
+            "source_html_path y output_target son rutas distintas",
+        );
+    }
+
+    if path_has_parent_component(source_html_path) || path_has_parent_component(output_target) {
+        push_error(
+            &mut checks,
+            "plan-no-parent-path-components",
+            "el plan no acepta rutas con componentes '..'",
+        );
+    } else {
+        push_ok(
+            &mut checks,
+            "plan-no-parent-path-components",
+            "el plan no usa componentes '..'",
+        );
+    }
+
+    if !path_under(&source, &data_in) {
+        push_error(
+            &mut checks,
+            "plan-source-under-data-in",
+            "source_html_path debe estar bajo data/in",
+        );
+    } else {
+        push_ok(
+            &mut checks,
+            "plan-source-under-data-in",
+            "source_html_path esta bajo data/in",
+        );
+    }
+
+    match reconstruction_mode {
+        ReconstructionMode::WriteLocalCanon => {
+            if requires_backup {
+                push_ok(
+                    &mut checks,
+                    "plan-backup-required",
+                    "write_local_canon declara backup previo",
+                );
+            } else {
+                push_error(
+                    &mut checks,
+                    "plan-backup-required",
+                    "write_local_canon requiere backup previo",
+                );
+            }
+            if requires_hash_report {
+                push_ok(
+                    &mut checks,
+                    "plan-hash-report-required",
+                    "write_local_canon declara reporte de hash before/after",
+                );
+            } else {
+                push_error(
+                    &mut checks,
+                    "plan-hash-report-required",
+                    "write_local_canon requiere reporte de hash before/after",
+                );
+            }
+            push_ok(
+                &mut checks,
+                "plan-post-reconstruction-evidence",
+                "el plan debe validarse despues con strict, reverse-preflight y Rejected: 0 cuando aplique",
+            );
+        }
+        ReconstructionMode::Staging => {
+            if requires_backup {
+                push_error(
+                    &mut checks,
+                    "plan-staging-no-canon-backup",
+                    "staging no debe declarar backup de canon porque no escribe data/out/local",
+                );
+            } else {
+                push_ok(
+                    &mut checks,
+                    "plan-staging-no-canon-backup",
+                    "staging no declara backup de canon",
+                );
+            }
+            if requires_hash_report {
+                push_ok(
+                    &mut checks,
+                    "plan-staging-hash-evidence",
+                    "staging declara evidencia de hash/manifest",
+                );
+            } else {
+                push_error(
+                    &mut checks,
+                    "plan-staging-hash-evidence",
+                    "staging debe producir evidencia de hash/manifest",
+                );
+            }
+        }
+        ReconstructionMode::ReverseProjection => {
+            if requires_backup {
+                push_error(
+                    &mut checks,
+                    "plan-reverse-no-canon-backup",
+                    "reverse_projection no debe declarar backup de canon porque no escribe shards",
+                );
+            } else {
+                push_ok(
+                    &mut checks,
+                    "plan-reverse-no-canon-backup",
+                    "reverse_projection no declara backup de canon",
+                );
+            }
+            if requires_hash_report {
+                push_ok(
+                    &mut checks,
+                    "plan-reverse-report-evidence",
+                    "reverse_projection declara reporte de salida/reverse",
+                );
+            } else {
+                push_error(
+                    &mut checks,
+                    "plan-reverse-report-evidence",
+                    "reverse_projection debe conservar reporte de salida/reverse",
+                );
+            }
+        }
+        ReconstructionMode::Diagnostic => {
+            if requires_backup {
+                push_error(
+                    &mut checks,
+                    "plan-diagnostic-no-canon-backup",
+                    "diagnostic no debe declarar backup de canon",
+                );
+            } else {
+                push_ok(
+                    &mut checks,
+                    "plan-diagnostic-no-canon-backup",
+                    "diagnostic no declara backup de canon",
+                );
+            }
+        }
+    }
+
+    let errors = checks
+        .iter()
+        .filter(|check| check.status == "error")
+        .count();
+    let verdict = if errors > 0 {
+        ReconstructionPlanVerdict::Rejected
+    } else {
+        match reconstruction_mode {
+            ReconstructionMode::WriteLocalCanon => ReconstructionPlanVerdict::AllowedWithBackup,
+            ReconstructionMode::Staging => ReconstructionPlanVerdict::StagingOnly,
+            ReconstructionMode::Diagnostic | ReconstructionMode::ReverseProjection => {
+                ReconstructionPlanVerdict::Allowed
+            }
+        }
+    };
+
+    ReconstructionPlanReport {
+        verdict,
+        repo_root: root.to_string_lossy().to_string(),
+        plan: ReconstructionPlanInput {
+            source_html_path: display_plan_path(root, &source),
+            source_role,
+            reconstruction_mode,
+            output_target: display_plan_path(root, &target),
+            requires_backup,
+            requires_hash_report,
+        },
+        checks_run: checks.len(),
+        errors,
+        checks,
+    }
+}
+
+pub fn parse_reconstruction_source_role(value: &str) -> Option<ReconstructionSourceRole> {
+    match value {
+        "seed" => Some(ReconstructionSourceRole::Seed),
+        "working" => Some(ReconstructionSourceRole::Working),
+        "bootstrap_aux" => Some(ReconstructionSourceRole::BootstrapAux),
+        _ => None,
+    }
+}
+
+pub fn parse_reconstruction_mode(value: &str) -> Option<ReconstructionMode> {
+    match value {
+        "diagnostic" => Some(ReconstructionMode::Diagnostic),
+        "staging" => Some(ReconstructionMode::Staging),
+        "write_local_canon" => Some(ReconstructionMode::WriteLocalCanon),
+        "reverse_projection" => Some(ReconstructionMode::ReverseProjection),
+        _ => None,
+    }
+}
+
 /// Devuelve el nombre del tipo JSON de un valor, para mensajes de error.
 fn json_type_name(v: &serde_json::Value) -> &'static str {
     match v {
@@ -190,5 +544,524 @@ fn json_type_name(v: &serde_json::Value) -> &'static str {
         serde_json::Value::String(_) => "string",
         serde_json::Value::Array(_) => "array",
         serde_json::Value::Object(_) => "object",
+    }
+}
+
+enum ExpectedPathKind {
+    File,
+    Dir,
+}
+
+fn push_path_check(
+    checks: &mut Vec<PerimeterCheck>,
+    root: &Path,
+    check_id: &str,
+    rel_path: &str,
+    expected: ExpectedPathKind,
+    role: &str,
+) {
+    let path = root.join(rel_path);
+    let ok = match expected {
+        ExpectedPathKind::File => path.is_file(),
+        ExpectedPathKind::Dir => path.is_dir(),
+    };
+    if ok {
+        push_ok(checks, check_id, &format!("{}: {}", rel_path, role));
+    } else {
+        push_error(
+            checks,
+            check_id,
+            &format!("falta {} requerido para {}", rel_path, role),
+        );
+    }
+}
+
+fn push_ok(checks: &mut Vec<PerimeterCheck>, check_id: &str, message: &str) {
+    checks.push(PerimeterCheck {
+        check_id: check_id.to_string(),
+        status: "ok".to_string(),
+        message: message.to_string(),
+    });
+}
+
+fn push_error(checks: &mut Vec<PerimeterCheck>, check_id: &str, message: &str) {
+    checks.push(PerimeterCheck {
+        check_id: check_id.to_string(),
+        status: "error".to_string(),
+        message: message.to_string(),
+    });
+}
+
+fn check_working_html_surfaces(root: &Path, checks: &mut Vec<PerimeterCheck>) {
+    let data_in = root.join("data/in");
+    let seed = root.join("data/in/objeto_de_estudio_trazabilidad_y_desarrollo.html");
+    let empty = root.join("data/in/empty-store.html");
+    let entries = match std::fs::read_dir(&data_in) {
+        Ok(entries) => entries,
+        Err(_) => {
+            push_error(
+                checks,
+                "working-html-detected",
+                "no se pudo leer data/in para detectar superficies HTML de trabajo",
+            );
+            return;
+        }
+    };
+
+    let mut working: Vec<String> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() || !is_html_path(&path) {
+            continue;
+        }
+        if path == seed || path == empty {
+            continue;
+        }
+        working.push(display_plan_path(root, &path));
+    }
+
+    if working.is_empty() {
+        push_error(
+            checks,
+            "working-html-detected",
+            "no se encontro HTML de trabajo en data/in distinto de la semilla y empty-store",
+        );
+    } else {
+        push_ok(
+            checks,
+            "working-html-detected",
+            &format!(
+                "HTML de trabajo detectado en data/in: {}",
+                working.join(", ")
+            ),
+        );
+    }
+}
+
+fn check_source_html(
+    root: &Path,
+    source: &Path,
+    source_role: &ReconstructionSourceRole,
+    checks: &mut Vec<PerimeterCheck>,
+) {
+    if source.is_file() {
+        push_ok(
+            checks,
+            "plan-source-html-exists",
+            "source_html_path existe y es archivo",
+        );
+    } else {
+        push_error(
+            checks,
+            "plan-source-html-exists",
+            "source_html_path no existe o no es archivo",
+        );
+    }
+
+    if is_html_path(source) {
+        push_ok(
+            checks,
+            "plan-source-html-extension",
+            "source_html_path tiene extension HTML/HTM",
+        );
+    } else {
+        push_error(
+            checks,
+            "plan-source-html-extension",
+            "source_html_path debe terminar en .html o .htm",
+        );
+    }
+
+    let seed = root.join("data/in/objeto_de_estudio_trazabilidad_y_desarrollo.html");
+    let empty = root.join("data/in/empty-store.html");
+    let role_ok = match source_role {
+        ReconstructionSourceRole::Seed => source == seed,
+        ReconstructionSourceRole::BootstrapAux => source == empty,
+        ReconstructionSourceRole::Working => source != seed && source != empty,
+    };
+
+    if role_ok {
+        push_ok(
+            checks,
+            "plan-source-role-coherent",
+            "source_role coincide con la fuente HTML seleccionada",
+        );
+    } else {
+        push_error(
+            checks,
+            "plan-source-role-coherent",
+            "source_role no coincide con la fuente HTML seleccionada",
+        );
+    }
+}
+
+fn check_reconstruction_target(
+    target: &Path,
+    data_tmp: &Path,
+    canon_dir: &Path,
+    reverse_html_dir: &Path,
+    reconstruction_mode: &ReconstructionMode,
+    checks: &mut Vec<PerimeterCheck>,
+) {
+    match reconstruction_mode {
+        ReconstructionMode::Diagnostic => {
+            if path_under(target, data_tmp) {
+                push_ok(
+                    checks,
+                    "plan-target-diagnostic",
+                    "diagnostic apunta a data/tmp",
+                );
+            } else {
+                push_error(
+                    checks,
+                    "plan-target-diagnostic",
+                    "diagnostic debe apuntar a data/tmp",
+                );
+            }
+        }
+        ReconstructionMode::Staging => {
+            if path_under(target, data_tmp) && target != canon_dir {
+                push_ok(checks, "plan-target-staging", "staging apunta a data/tmp");
+            } else {
+                push_error(
+                    checks,
+                    "plan-target-staging",
+                    "staging debe escribir solo bajo data/tmp",
+                );
+            }
+        }
+        ReconstructionMode::WriteLocalCanon => {
+            if target == canon_dir {
+                push_ok(
+                    checks,
+                    "plan-target-local-canon",
+                    "write_local_canon apunta exactamente a data/out/local",
+                );
+            } else {
+                push_error(
+                    checks,
+                    "plan-target-local-canon",
+                    "write_local_canon debe apuntar exactamente a data/out/local",
+                );
+            }
+        }
+        ReconstructionMode::ReverseProjection => {
+            if path_under(target, reverse_html_dir) {
+                push_ok(
+                    checks,
+                    "plan-target-reverse-projection",
+                    "reverse_projection apunta a data/out/local/reverse_html",
+                );
+            } else {
+                push_error(
+                    checks,
+                    "plan-target-reverse-projection",
+                    "reverse_projection debe apuntar bajo data/out/local/reverse_html",
+                );
+            }
+        }
+    }
+}
+
+fn resolve_plan_path(root: &Path, value: &Path) -> PathBuf {
+    if value.is_absolute() {
+        value.to_path_buf()
+    } else {
+        root.join(value)
+    }
+}
+
+fn display_plan_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .map(|relative| relative.to_string_lossy().to_string())
+        .unwrap_or_else(|_| path.to_string_lossy().to_string())
+}
+
+fn is_html_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("html") || ext.eq_ignore_ascii_case("htm"))
+        .unwrap_or(false)
+}
+
+fn path_under(path: &Path, parent: &Path) -> bool {
+    path == parent || path.starts_with(parent)
+}
+
+fn path_has_parent_component(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+}
+
+fn check_canon_shards(root: &Path, checks: &mut Vec<PerimeterCheck>) {
+    let canon_dir = root.join("data/out/local");
+    let mut shard_numbers: Vec<u32> = Vec::new();
+    let entries = match std::fs::read_dir(&canon_dir) {
+        Ok(entries) => entries,
+        Err(_) => {
+            push_error(
+                checks,
+                "canon-shards-readable",
+                "no se pudo leer data/out/local para validar shards",
+            );
+            return;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let file_name = entry.file_name().to_string_lossy().to_string();
+        if let Some(number) = shard_number(&file_name) {
+            shard_numbers.push(number);
+        }
+    }
+
+    shard_numbers.sort_unstable();
+    if shard_numbers.is_empty() {
+        push_error(
+            checks,
+            "canon-shards-contiguous",
+            "no se encontraron shards data/out/local/tiddlers_*.jsonl",
+        );
+        return;
+    }
+
+    let expected: Vec<u32> = (1..=shard_numbers.len() as u32).collect();
+    if shard_numbers == expected {
+        push_ok(
+            checks,
+            "canon-shards-contiguous",
+            &format!(
+                "shards canónicos contiguos detectados: {}",
+                shard_numbers.len()
+            ),
+        );
+    } else {
+        push_error(
+            checks,
+            "canon-shards-contiguous",
+            &format!("shards no contiguos: {:?}", shard_numbers),
+        );
+    }
+}
+
+fn shard_number(file_name: &str) -> Option<u32> {
+    let prefix = "tiddlers_";
+    let suffix = ".jsonl";
+    if !file_name.starts_with(prefix) || !file_name.ends_with(suffix) {
+        return None;
+    }
+    file_name[prefix.len()..file_name.len() - suffix.len()]
+        .parse::<u32>()
+        .ok()
+}
+
+fn check_policy_bundle(root: &Path, checks: &mut Vec<PerimeterCheck>) {
+    let path = root.join("data/sessions/00_contratos/policy/canon_policy_bundle.json");
+    let value = match read_json_object(&path) {
+        Ok(value) => value,
+        Err(message) => {
+            push_error(checks, "policy-bundle-readable", &message);
+            return;
+        }
+    };
+    push_ok(
+        checks,
+        "policy-bundle-readable",
+        "canon_policy_bundle.json es JSON válido",
+    );
+
+    expect_json_string(
+        checks,
+        &value,
+        "policy-source-of-truth",
+        "local_output_root",
+        "data/out/local",
+    );
+    expect_json_string(
+        checks,
+        &value,
+        "policy-session-staging",
+        "session_semantic_close_default",
+        "data_sessions_staging",
+    );
+    expect_json_string(
+        checks,
+        &value,
+        "policy-reverse-html-root",
+        "reverse_html_root",
+        "data/out/local/reverse_html",
+    );
+
+    let direct_write = value
+        .get("direct_canon_write_default")
+        .and_then(|item| item.as_str())
+        .unwrap_or("");
+    if direct_write.contains("prohibited") {
+        push_ok(
+            checks,
+            "policy-direct-canon-write-prohibited",
+            "la política prohíbe escritura directa al canon por defecto",
+        );
+    } else {
+        push_error(
+            checks,
+            "policy-direct-canon-write-prohibited",
+            "direct_canon_write_default no declara prohibición por defecto",
+        );
+    }
+}
+
+fn check_derived_registry(root: &Path, checks: &mut Vec<PerimeterCheck>) {
+    let path = root.join("data/sessions/00_contratos/projections/derived_layers_registry.json");
+    let value = match read_json_object(&path) {
+        Ok(value) => value,
+        Err(message) => {
+            push_error(checks, "derived-registry-readable", &message);
+            return;
+        }
+    };
+    push_ok(
+        checks,
+        "derived-registry-readable",
+        "derived_layers_registry.json es JSON válido",
+    );
+
+    expect_json_string(
+        checks,
+        &value,
+        "registry-source-layer-canon",
+        "source_of_truth_layer",
+        "canon",
+    );
+    expect_layer_class_bool(
+        checks,
+        &value,
+        "registry-canon-authoritative",
+        "canon",
+        "is_canonical",
+        true,
+    );
+    expect_layer_class_bool(
+        checks,
+        &value,
+        "registry-session-staging-noncanonical",
+        "session_staging",
+        "is_canonical",
+        false,
+    );
+    expect_layer_class_bool(
+        checks,
+        &value,
+        "registry-derived-noncanonical",
+        "derived",
+        "is_canonical",
+        false,
+    );
+    expect_layer_class_bool(
+        checks,
+        &value,
+        "registry-reverse-projection-noncanonical",
+        "reverse_projection",
+        "is_canonical",
+        false,
+    );
+}
+
+fn check_readme_single_operator(root: &Path, checks: &mut Vec<PerimeterCheck>) {
+    let readme_path = root.join("README.md");
+    let text = match std::fs::read_to_string(&readme_path) {
+        Ok(text) => text,
+        Err(_) => {
+            push_error(checks, "readme-readable", "no se pudo leer README.md");
+            return;
+        }
+    };
+    push_ok(checks, "readme-readable", "README.md legible");
+
+    if text.contains("shell_scripts/tdc.sh") {
+        push_ok(
+            checks,
+            "readme-single-operator-wrapper",
+            "README apunta al wrapper operativo único shell_scripts/tdc.sh",
+        );
+    } else {
+        push_error(
+            checks,
+            "readme-single-operator-wrapper",
+            "README no menciona shell_scripts/tdc.sh como entry point operativo",
+        );
+    }
+
+    let mentions_obsolete_wrapper = text.contains("`scripts/tdc.sh`")
+        || text.lines().any(|line| line.trim() == "scripts/tdc.sh");
+    if mentions_obsolete_wrapper {
+        push_error(
+            checks,
+            "readme-no-obsolete-scripts-wrapper",
+            "README todavía menciona scripts/tdc.sh",
+        );
+    } else {
+        push_ok(
+            checks,
+            "readme-no-obsolete-scripts-wrapper",
+            "README no menciona el wrapper obsoleto scripts/tdc.sh",
+        );
+    }
+}
+
+fn read_json_object(path: &Path) -> Result<serde_json::Value, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("no se pudo leer '{}': {}", path.display(), e))?;
+    serde_json::from_str(&content)
+        .map_err(|e| format!("JSON inválido en '{}': {}", path.display(), e))
+}
+
+fn expect_json_string(
+    checks: &mut Vec<PerimeterCheck>,
+    value: &serde_json::Value,
+    check_id: &str,
+    key: &str,
+    expected: &str,
+) {
+    let actual = value.get(key).and_then(|item| item.as_str());
+    if actual == Some(expected) {
+        push_ok(checks, check_id, &format!("{} == {}", key, expected));
+    } else {
+        push_error(
+            checks,
+            check_id,
+            &format!("{} esperado {:?}, encontrado {:?}", key, expected, actual),
+        );
+    }
+}
+
+fn expect_layer_class_bool(
+    checks: &mut Vec<PerimeterCheck>,
+    value: &serde_json::Value,
+    check_id: &str,
+    class_name: &str,
+    key: &str,
+    expected: bool,
+) {
+    let actual = value
+        .get("layer_classes")
+        .and_then(|item| item.get(class_name))
+        .and_then(|item| item.get(key))
+        .and_then(|item| item.as_bool());
+    if actual == Some(expected) {
+        push_ok(
+            checks,
+            check_id,
+            &format!("layer_classes.{}.{} == {}", class_name, key, expected),
+        );
+    } else {
+        push_error(
+            checks,
+            check_id,
+            &format!(
+                "layer_classes.{}.{} esperado {}, encontrado {:?}",
+                class_name, key, expected, actual
+            ),
+        );
     }
 }

--- a/rust/doctor/src/report.rs
+++ b/rust/doctor/src/report.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 /// Veredicto de auditoría del Doctor.
 ///
 /// Determina si el artefacto raw puede continuar el pipeline.
@@ -33,4 +35,84 @@ pub struct DoctorReport {
 
     /// Fallos de integridad estructural detectados durante la auditoría.
     pub errors: Vec<String>,
+}
+
+/// Veredicto del perímetro Rust del repositorio.
+///
+/// Este veredicto no reemplaza `canon_preflight`; solo confirma invariantes
+/// estructurales de autoridad, entradas y capas antes de operar el pipeline.
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PerimeterVerdict {
+    Ok,
+    Error,
+}
+
+/// Resultado individual de un chequeo de perímetro.
+#[derive(Debug, Serialize)]
+pub struct PerimeterCheck {
+    pub check_id: String,
+    pub status: String,
+    pub message: String,
+}
+
+/// Reporte de perímetro reusable del repositorio.
+#[derive(Debug, Serialize)]
+pub struct PerimeterReport {
+    pub verdict: PerimeterVerdict,
+    pub repo_root: String,
+    pub checks_run: usize,
+    pub errors: usize,
+    pub checks: Vec<PerimeterCheck>,
+}
+
+/// Rol declarado de una fuente HTML de reconstrucción.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconstructionSourceRole {
+    Seed,
+    Working,
+    BootstrapAux,
+}
+
+/// Modo solicitado para una operación de reconstrucción.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconstructionMode {
+    Diagnostic,
+    Staging,
+    WriteLocalCanon,
+    ReverseProjection,
+}
+
+/// Veredicto normativo de un plan de reconstrucción.
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconstructionPlanVerdict {
+    Allowed,
+    AllowedWithBackup,
+    StagingOnly,
+    Rejected,
+}
+
+/// Entrada normalizada del plan de reconstrucción.
+#[derive(Debug, Serialize)]
+pub struct ReconstructionPlanInput {
+    pub source_html_path: String,
+    pub source_role: ReconstructionSourceRole,
+    pub reconstruction_mode: ReconstructionMode,
+    pub output_target: String,
+    pub requires_backup: bool,
+    pub requires_hash_report: bool,
+}
+
+/// Reporte normativo previo a ejecutar reconstrucción, shardización o reverse.
+#[derive(Debug, Serialize)]
+pub struct ReconstructionPlanReport {
+    pub verdict: ReconstructionPlanVerdict,
+    pub repo_root: String,
+    pub plan: ReconstructionPlanInput,
+    pub checks_run: usize,
+    pub errors: usize,
+    pub checks: Vec<PerimeterCheck>,
 }

--- a/rust/doctor/tests/test_doctor.rs
+++ b/rust/doctor/tests/test_doctor.rs
@@ -8,12 +8,73 @@
 //!
 //! Ref: contratos/m01-s04-doctor-contract.md §10
 
-use std::path::Path;
-use tdc_doctor::{audit, DoctorError, DoctorVerdict};
+use std::path::{Path, PathBuf};
+use tdc_doctor::{
+    audit, audit_perimeter, audit_reconstruction_plan, DoctorError, DoctorVerdict,
+    PerimeterVerdict, ReconstructionMode, ReconstructionPlanVerdict, ReconstructionSourceRole,
+};
 
 /// Ruta base a los fixtures compartidos del repositorio.
 fn fixtures_dir() -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures")
+}
+
+fn temp_repo_root(name: &str) -> PathBuf {
+    let mut root = std::env::temp_dir();
+    root.push(format!("tdc_doctor_{}_{}", name, std::process::id()));
+    if root.exists() {
+        std::fs::remove_dir_all(&root).expect("cleanup temp repo root");
+    }
+    root
+}
+
+fn write_file(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    std::fs::write(path, content).expect("write fixture file");
+}
+
+fn write_minimal_perimeter_fixture(root: &Path) {
+    write_file(
+        &root.join("data/in/objeto_de_estudio_trazabilidad_y_desarrollo.html"),
+        "<html>seed</html>",
+    );
+    write_file(&root.join("data/in/empty-store.html"), "<html>empty</html>");
+    write_file(
+        &root.join("data/in/tiddly-data-converter (Saved).html"),
+        "<html>saved</html>",
+    );
+    std::fs::create_dir_all(root.join("data/sessions")).expect("sessions dir");
+    std::fs::create_dir_all(root.join("data/tmp")).expect("tmp dir");
+    std::fs::create_dir_all(root.join("data/out/local/reverse_html")).expect("reverse dir");
+    write_file(&root.join("data/out/local/tiddlers_1.jsonl"), "{}\n");
+    write_file(&root.join("shell_scripts/tdc.sh"), "#!/usr/bin/env bash\n");
+    write_file(
+        &root.join("README.md"),
+        "# tdc\n\n```bash\nshell_scripts/tdc.sh\n```\n",
+    );
+    write_file(
+        &root.join("data/sessions/00_contratos/policy/canon_policy_bundle.json"),
+        r#"{
+          "local_output_root": "data/out/local",
+          "session_semantic_close_default": "data_sessions_staging",
+          "reverse_html_root": "data/out/local/reverse_html",
+          "direct_canon_write_default": "prohibited_by_default_requires_local_admission"
+        }"#,
+    );
+    write_file(
+        &root.join("data/sessions/00_contratos/projections/derived_layers_registry.json"),
+        r#"{
+          "source_of_truth_layer": "canon",
+          "layer_classes": {
+            "canon": {"is_canonical": true},
+            "session_staging": {"is_canonical": false},
+            "derived": {"is_canonical": false},
+            "reverse_projection": {"is_canonical": false}
+          }
+        }"#,
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -55,36 +116,52 @@ fn test_artefacto_minimo_correcto_produce_veredicto_ok() {
         "se esperaba veredicto Ok, se obtuvo: {:?}",
         resultado.verdict
     );
-    assert!(resultado.errors.is_empty(), "no debe haber errores: {:?}", resultado.errors);
+    assert!(
+        resultado.errors.is_empty(),
+        "no debe haber errores: {:?}",
+        resultado.errors
+    );
 }
 
 /// §10 criterio: audit() devuelve Ok(DoctorReport) con verdict Warning ante título vacío.
 #[test]
 fn test_titulo_vacio_produce_veredicto_warning() {
     let ruta = fixtures_dir().join("raw_tiddlers_empty_title.json");
-    let resultado = audit(&ruta).expect("audit() debería devolver Ok para fixture con título vacío");
+    let resultado =
+        audit(&ruta).expect("audit() debería devolver Ok para fixture con título vacío");
     assert_eq!(
         resultado.verdict,
         DoctorVerdict::Warning,
         "se esperaba veredicto Warning, se obtuvo: {:?}",
         resultado.verdict
     );
-    assert!(resultado.errors.is_empty(), "no debe haber errores bloqueantes: {:?}", resultado.errors);
-    assert!(!resultado.warnings.is_empty(), "debe haber al menos un warning");
+    assert!(
+        resultado.errors.is_empty(),
+        "no debe haber errores bloqueantes: {:?}",
+        resultado.errors
+    );
+    assert!(
+        !resultado.warnings.is_empty(),
+        "debe haber al menos un warning"
+    );
 }
 
 /// §10 criterio: audit() devuelve Ok(DoctorReport) con verdict Error ante tiddler sin campo title.
 #[test]
 fn test_tiddler_sin_titulo_produce_veredicto_error() {
     let ruta = fixtures_dir().join("raw_tiddlers_no_title.json");
-    let resultado = audit(&ruta).expect("audit() debería devolver Ok incluso con errores de integridad");
+    let resultado =
+        audit(&ruta).expect("audit() debería devolver Ok incluso con errores de integridad");
     assert_eq!(
         resultado.verdict,
         DoctorVerdict::Error,
         "se esperaba veredicto Error, se obtuvo: {:?}",
         resultado.verdict
     );
-    assert!(!resultado.errors.is_empty(), "debe haber al menos un error de integridad");
+    assert!(
+        !resultado.errors.is_empty(),
+        "debe haber al menos un error de integridad"
+    );
 }
 
 /// §10 criterio: DoctorReport siempre incluye tiddler_count, warnings y errors.
@@ -110,4 +187,139 @@ fn test_reporte_siempre_tiene_campos_minimos() {
         0,
         "fixture mínimo no debe tener errors"
     );
+}
+
+#[test]
+fn test_perimetro_minimo_reusable_produce_veredicto_ok() {
+    let root = temp_repo_root("perimeter_ok");
+    write_minimal_perimeter_fixture(&root);
+
+    let report = audit_perimeter(&root);
+    assert_eq!(report.verdict, PerimeterVerdict::Ok);
+    assert_eq!(report.errors, 0);
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.check_id == "seed-main-exists" && check.status == "ok"));
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.check_id == "registry-derived-noncanonical" && check.status == "ok"));
+
+    std::fs::remove_dir_all(root).expect("cleanup perimeter ok fixture");
+}
+
+#[test]
+fn test_perimetro_bloquea_sessions_en_raiz() {
+    let root = temp_repo_root("perimeter_root_sessions");
+    write_minimal_perimeter_fixture(&root);
+    std::fs::create_dir_all(root.join("sessions")).expect("root sessions dir");
+
+    let report = audit_perimeter(&root);
+    assert_eq!(report.verdict, PerimeterVerdict::Error);
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.check_id == "no-root-sessions-dir" && check.status == "error"));
+
+    std::fs::remove_dir_all(root).expect("cleanup perimeter root sessions fixture");
+}
+
+#[test]
+fn test_plan_reconstruccion_staging_desde_html_working_detectado() {
+    let root = temp_repo_root("reconstruction_staging");
+    write_minimal_perimeter_fixture(&root);
+    let source = root.join("data/in/tema-cambiante.html");
+    write_file(&source, "<html>working topic</html>");
+
+    let report = audit_reconstruction_plan(
+        &root,
+        &source,
+        ReconstructionSourceRole::Working,
+        ReconstructionMode::Staging,
+        &root.join("data/tmp/html_export/run-1"),
+        false,
+        true,
+    );
+
+    assert_eq!(report.verdict, ReconstructionPlanVerdict::StagingOnly);
+    assert_eq!(report.errors, 0);
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.check_id == "plan-source-role-coherent" && check.status == "ok"));
+
+    std::fs::remove_dir_all(root).expect("cleanup reconstruction staging fixture");
+}
+
+#[test]
+fn test_plan_reconstruccion_bloquea_write_local_canon_sin_backup() {
+    let root = temp_repo_root("reconstruction_no_backup");
+    write_minimal_perimeter_fixture(&root);
+    let source = root.join("data/in/tiddly-data-converter (Saved).html");
+
+    let report = audit_reconstruction_plan(
+        &root,
+        &source,
+        ReconstructionSourceRole::Working,
+        ReconstructionMode::WriteLocalCanon,
+        &root.join("data/out/local"),
+        false,
+        true,
+    );
+
+    assert_eq!(report.verdict, ReconstructionPlanVerdict::Rejected);
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.check_id == "plan-backup-required" && check.status == "error"));
+
+    std::fs::remove_dir_all(root).expect("cleanup reconstruction no backup fixture");
+}
+
+#[test]
+fn test_plan_reconstruccion_bloquea_rol_seed_en_html_working() {
+    let root = temp_repo_root("reconstruction_role_mismatch");
+    write_minimal_perimeter_fixture(&root);
+    let source = root.join("data/in/tiddly-data-converter (Saved).html");
+
+    let report = audit_reconstruction_plan(
+        &root,
+        &source,
+        ReconstructionSourceRole::Seed,
+        ReconstructionMode::Diagnostic,
+        &root.join("data/tmp/reconstruction_plan"),
+        false,
+        false,
+    );
+
+    assert_eq!(report.verdict, ReconstructionPlanVerdict::Rejected);
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.check_id == "plan-source-role-coherent" && check.status == "error"));
+
+    std::fs::remove_dir_all(root).expect("cleanup reconstruction role mismatch fixture");
+}
+
+#[test]
+fn test_plan_reconstruccion_write_local_canon_exige_hash_y_backup() {
+    let root = temp_repo_root("reconstruction_write_ok");
+    write_minimal_perimeter_fixture(&root);
+    let source = root.join("data/in/objeto_de_estudio_trazabilidad_y_desarrollo.html");
+
+    let report = audit_reconstruction_plan(
+        &root,
+        &source,
+        ReconstructionSourceRole::Seed,
+        ReconstructionMode::WriteLocalCanon,
+        &root.join("data/out/local"),
+        true,
+        true,
+    );
+
+    assert_eq!(report.verdict, ReconstructionPlanVerdict::AllowedWithBackup);
+    assert_eq!(report.errors, 0);
+
+    std::fs::remove_dir_all(root).expect("cleanup reconstruction write ok fixture");
 }

--- a/tests/fixtures/s65/test_s65_microsoft_copilot_flow.py
+++ b/tests/fixtures/s65/test_s65_microsoft_copilot_flow.py
@@ -43,15 +43,12 @@ class S65MicrosoftCopilotFlowTests(unittest.TestCase):
     LEGACY_DIR = REPO_ROOT / "data" / "out" / "local" / "copilot_agent"
     CONTRACT_PATH = (
         REPO_ROOT
-        / "contratos"
+        / "data"
+        / "sessions"
+        / "00_contratos"
         / "m03-s65-microsoft-copilot-execution-surface-and-readme-hardening-v0.md.json"
     )
-    SESSION_TITLES = {
-        "#### 🌀 Sesión 65 = microsoft-copilot-execution-surface-and-readme-hardening-v0",
-        "#### 🌀🧪 Hipótesis de sesión 65 = microsoft-copilot-execution-surface-and-readme-hardening-v0",
-        "#### 🌀🧾 Procedencia de sesión 65 = microsoft-copilot-execution-surface-and-readme-hardening-v0",
-        "contratos/m03-s65-microsoft-copilot-execution-surface-and-readme-hardening-v0.md.json",
-    }
+    CONTRACT_TITLE = "#### 🌀 Contrato de sesión 65 = microsoft-copilot-execution-surface-and-readme-hardening-v0"
 
     # ── entrypoint and official path ─────────────────────────────────────────
 
@@ -79,12 +76,12 @@ class S65MicrosoftCopilotFlowTests(unittest.TestCase):
         """S65 must leave an importable contract in contratos/."""
         self.assertTrue(self.CONTRACT_PATH.exists(), "S65 contract file is missing")
 
-    def test_s65_family_is_absorbed_in_canon(self) -> None:
-        """Canon must include the full minimal S65 family, including the contract node."""
+    def test_s65_contract_is_absorbed_or_staged(self) -> None:
+        """S65 contract must be staged in data/sessions or already present in canon."""
         titles = {record.get("title") for record in load_canon_records()}
         self.assertTrue(
-            self.SESSION_TITLES.issubset(titles),
-            f"S65 canon family incomplete: {sorted(self.SESSION_TITLES - titles)}",
+            self.CONTRACT_TITLE in titles or self.CONTRACT_PATH.exists(),
+            "S65 contract is neither staged under data/sessions nor present in canon",
         )
 
     # ── required artifacts ────────────────────────────────────────────────────
@@ -190,19 +187,19 @@ class S65MicrosoftCopilotFlowTests(unittest.TestCase):
 
     # ── documentation alignment ───────────────────────────────────────────────
 
-    def test_readme_documents_verified_derive_layers_command(self) -> None:
+    def test_readme_documents_single_operator_menu(self) -> None:
         readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
-        self.assertIn("--audit-dir data/out/local/audit", readme)
-        self.assertIn("--export-dir data/out/local/export", readme)
-        self.assertIn("--microsoft-copilot-dir data/out/local/microsoft_copilot", readme)
+        self.assertIn("shell_scripts/tdc.sh", readme)
+        self.assertIn("Generación de derivados", readme)
+        self.assertIn("Los derivados no son fuente de verdad", readme)
 
-    def test_readme_lists_spec_and_copilot_agent_outputs(self) -> None:
-        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
-        self.assertIn("data/out/local/microsoft_copilot/spec/**/*.md", readme)
-        self.assertIn("data/out/local/microsoft_copilot/spec/**/*.json", readme)
-        self.assertIn("data/out/local/microsoft_copilot/copilot_agent/corpus.txt", readme)
-        self.assertIn("data/out/local/microsoft_copilot/copilot_agent/entities.json", readme)
-        self.assertIn("data/out/local/microsoft_copilot/copilot_agent/relations.csv", readme)
+    def test_data_readme_lists_spec_and_copilot_agent_outputs(self) -> None:
+        data_readme = (REPO_ROOT / "data" / "README.md").read_text(encoding="utf-8")
+        self.assertIn("data/out/local/microsoft_copilot", data_readme)
+        self.assertIn("copilot_agent/", data_readme)
+        self.assertIn("corpus.txt", data_readme)
+        self.assertIn("entities.json", data_readme)
+        self.assertIn("relations.csv", data_readme)
 
     def test_data_readme_mentions_copilot_agent_sublayer(self) -> None:
         data_readme = (REPO_ROOT / "data" / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
# PR: inspect(inspect): endurecimiento Rust m04 — perimetro e invariantes mas compuerta de plan de reconstruccion verificada

```text
Commit: feat(inspect): agrega audit_perimeter y compuerta reconstruction-plan en rust/doctor con roles de fuente explicitos, backup y reporte hash
Meta: Es:listo|V:1|R:3|Md:estable|B:inspect|Ctx:transversal|Pr:P1|Sz:L|Est:5|Dr:-2|Dc:+2
Arch: Sb:Lenguajes dev|Ea:Implementación|Cx:Orquestación segura|Lg:RUST, PYTHON|Mdls:rust/doctor, operator_menu.py, shell_scripts/tdc.sh, README.md, tests/fixtures/s65
```

---

## Metadatos

| Campo | Valor |
|-------|-------|
| Estado | listo |
| Vuelta | 1 |
| Radio | 3 |
| Madurez | estable |
| Bloque | inspect |
| ContextoCambio | transversal |
| Priority | P1 |
| Size | L |
| Estimate | 5 |
| Delta-r | -2 |
| Delta-c | +2 |

---

## Tablero y Arquitectura

| Campo | Valor |
|-------|-------|
| StatusTablero | Lenguajes dev |
| EstadoArquitectonico | Implementación |
| Caja | Orquestación segura |
| Lenguajes | RUST, PYTHON |
| Modulos | rust/doctor, operator_menu.py, shell_scripts/tdc.sh, README.md, tests/fixtures/s65 |

---

## Objetivo

Inaugurar el kernel Rust de auditoría en doctor mediante dos compuertas cohesivas: (S71) validación de perímetro e invariantes del repositorio, y (S72) compuerta normativa del plan de reconstrucción antes de tocar canon o reverse. Ambas compuertas se integran en el menú operativo único sin crear entry points paralelos ni mover la autoridad del canon fuera de Go.

---

## Resultado integrado

doctor adquiere `audit_perimeter` y `audit_reconstruction_plan`. El subcomando `perimeter` valida semilla reusable, HTML actual, canon, reverse, staging de sesiones y autoridad de derivados. El subcomando `reconstruction-plan` emite veredictos `allowed`, `staging_only`, `allowed_with_backup` o `rejected` antes de cualquier shardización o reverse. El menú obliga a seleccionar HTML desde in y declarar rol (`seed`, `working`, `bootstrap_aux`). La shardización a local conserva backup y hash before/after cuando se autoriza `WRITE CANON`. El README conserva tdc.sh como único comando público. `canon_preflight strict` y `reverse-preflight` siguen pasando sobre el canon actual.

---

## Acciones realizadas

**S71 — rust-kernel-perimeter-and-invariants-v0**

- Agregado `audit_perimeter` a doctor con estructuras serializables de reporte de perímetro.
- El binario `audit` mantiene su modo histórico y agrega subcomando interno `perimeter`.
- Agregados tests Rust para perímetro reusable OK y bloqueo de `sessions/` en raíz.
- La opción 1 del menú operador ejecuta el chequeo Rust y muestra `rust kernel perimeter: OK`.
- README.md actualizado minimamente sin nuevos comandos públicos.
- test_s65_microsoft_copilot_flow.py ajustado para expectativa documental S65 vigente y ruta sessions.
- Corrección de formato Rust con `cargo fmt`.

**S72 — rust-kernel-reconstruction-plan-gate-v0**

- Agregadas estructuras Rust: `ReconstructionSourceRole`, `ReconstructionMode`, `ReconstructionPlanVerdict` y reporte de plan.
- Agregado `audit_reconstruction_plan` en doctor.
- CLI interna `audit` acepta subcomando `reconstruction-plan`.
- El perímetro Rust detecta superficies HTML bajo in sin depender de nombre literal fijo.
- El menú obliga a seleccionar HTML desde in y declarar rol (`seed`, `working`, `bootstrap_aux`).
- La extracción HTML a JSONL temporal pasa por la compuerta en modo `staging`.
- La shardización a local pasa por la compuerta en modo `write_local_canon` con backup y reporte hash before/after.
- El reverse pasa por la compuerta en modo `reverse_projection` antes del reverse-preflight.
- Corrección de formato Rust con `cargo fmt`.

---

## Archivos modificados / añadidos

- doctor — `audit_perimeter`, estructuras de reporte de perímetro, `audit_reconstruction_plan`, estructuras `ReconstructionSourceRole`, `ReconstructionMode`, `ReconstructionPlanVerdict`
- operator_menu.py — integración de chequeo de perímetro en opción 1; selección explícita de HTML; compuerta en flujo de shardización y reverse
- tdc.sh — ajuste de orquestación para compuerta de reconstrucción
- README.md — actualización mínima; único comando público conservado
- test_s65_microsoft_copilot_flow.py — ajuste expectativa documental vigente

> **Nota:** sessions está excluido por .gitignore y no se versiona. Los contratos de sesión S71 y S72 existen localmente bajo 00_contratos, 02_detalles_de_sesion y 04_balance_de_sesion como evidencia de trazabilidad no canónica.

---

## Comprobaciones sugeridas

- `cargo test` en doctor pasa con tests de perímetro y planes de reconstrucción permitidos/rechazados.
- `cargo run --bin audit -- perimeter <repo>` devuelve `verdict: ok` en el repositorio actual.
- `audit reconstruction-plan` emite los cuatro veredictos: `allowed`, `staging_only`, `allowed_with_backup`, `rejected`.
- Opción 1 del menú muestra `rust kernel perimeter: OK`.
- El menú bloquea shardización si la compuerta Rust rechaza el plan.
- La opción de shardización conserva backup y hashes before/after cuando se autoriza `WRITE CANON`.
- `canon_preflight strict` pasa sobre el canon actual.
- `reverse-preflight` pasa sobre el canon actual.
- Suite Python/unittest y fixtures S65 pasan con expectativa documental actual.
- README.md conserva un único bloque ejecutable: tdc.sh.
- Líneas candidatas S71 y S72 bajo sessions (local), no admitidas al canon. Admisión canónica: no ejecutada. Reverse autoritativo: no ejecutado.

---

## Notas para el revisor

- Rust fortalece perímetro e intención operacional; Go ejecuta canon/reverse; Python orquesta al humano. División de responsabilidades conservada intacta.
- `objeto_de_estudio_trazabilidad_y_desarrollo.html` es la semilla reusable principal. `empty-store.html` queda confirmado como auxiliar.
- local sigue siendo canon. Derivados y `reverse_html` son no autoritativos.
- El reporte de reconstrucción no implementa rollback automático: solo conserva backup y hashes. Riesgo documentado en balance S72.
- La compuerta valida el plan operacional, no la calidad semántica del HTML de entrada.
- Toda integración humana pasa por el menú único. No se creó segundo entry point.
- Sesiones S71 y S72: familias completas localmente (contrato, detalles, balance). sessions gitignored — evidencia local únicamente.
