### PR TITLE
feat:rust-kernel arc, operator-menu, quality-gates, modal-projection, sequential-canon-regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,23 @@ El menú centraliza el flujo operativo actual:
 - Preparación del entorno
 - Chequeo del perímetro Rust de entradas, canon, reverse y capas no autoritativas
 - Compuerta Rust del plan de reconstrucción antes de tocar canon o reverse
+- Compuerta Rust de coherencia HTML → JSONL temporal antes de shardizar
+- Compuerta Rust de calidad de línea canónica y deriva de plantillas
+- Perfiles Rust de hardening focal por familia e incompletas priorizadas
+- Inspector Rust de estructura interna de nodos
+- Auditoría Rust de proyección modal canónica para assets, código, ecuaciones, referencias y payloads estructurados
+- Proyección modal integrada en la exportación canónica para assets, código, ecuaciones, referencias y payloads estructurados
 - Revisión del estado del canon
 - Construcción del canon desde HTML
 - Extracción HTML a JSONL temporal
-- Shardización hacia el canon local
+- Shardización secuencial hacia el canon local con máximo 100 líneas por archivo y evidencia `canon_before` / `canon_after`
 - Validación strict y reverse-preflight
 - Sincronización de entregables de sesiones por ID
 - Generación de derivados
 - Reverse hacia HTML derivado
 - Revisión de reportes y métricas
 - Rollback de admisiones cuando aplique
+- Rollback guiado de reconstrucciones cuando existe backup verificable
 
 ## Rutas De Autoridad
 
@@ -47,6 +54,8 @@ El menú centraliza el flujo operativo actual:
 | `data/out/local/tiddlers_*.jsonl` | canon oficial local |
 | `data/sessions/` | staging operativo de entregables de sesión |
 | `data/tmp/` | temporales, reportes e inventarios |
+| `data/tmp/reconstruction/` | evidencia de reconstrucción: gates, backups, before/after y rollback |
+| `data/tmp/canonical_quality/` | reportes no destructivos de calidad de líneas y estructura interna |
 | `data/out/local/reverse_html/` | HTML derivado y reportes de reverse |
 
 ## Reglas
@@ -57,5 +66,15 @@ El menú centraliza el flujo operativo actual:
 - Los derivados no son fuente de verdad.
 - Reverse no corrige ni redefine el canon.
 - La reconstrucción desde HTML exige fuente explícita, destino explícito, backup y reporte de hash cuando puede escribir `data/out/local`.
+- El JSONL temporal que se shardiza debe corresponder al HTML declarado mediante manifiesto de export con `source_html_path`, `source_html_sha256`, `output_path` y hash real.
+- Toda shardización autorizada usa partición secuencial `tiddlers_<n>.jsonl` con máximo 100 líneas por shard y deja `canon_before/`, `canon_after/` y `reconstruction-report.json` bajo `data/tmp/reconstruction/<run_id>/`.
+- Si el canon local fue reiniciado y no hay shards previos, la reconstrucción puede continuar con evidencia before/after, pero `rollback_ready` queda falso porque no existe canon previo real que restaurar.
+- Después de shardizar, el menú ejecuta `canon_preflight --mode strict` y `canon_preflight --mode reverse-preflight`; si fallan, bloquea continuidad operativa.
+- Los derivados solo se generan como continuidad operativa cuando existe reverse ejecutado con `Rejected: 0`.
+- El rollback de reconstrucción restaura únicamente desde `canon_before/` asociado a un reporte `rollback_ready`, y valida strict + reverse-preflight tras restaurar.
+- El canonical-line gate y el deep-node inspector de Rust clasifican calidad, riqueza interna, perfiles por familia, triage de incompletas y deriva de plantillas; no admiten líneas ni reescriben nodos.
+- La separación entre JSON estructural, fragmentos recuperables y JSON pedagógico es evidencia no destructiva; no promueve payloads ni corrige canon por sí sola.
+- `content` es una proyección derivada no autoritativa: puede describir `plain`, `asset`, `code_blocks`, `equations`, `references` y `structured_payload`, pero reverse sigue leyendo `text`, `source_tags` y `source_fields`.
+- La deuda modal de assets S76/S77 queda absorbida por regeneración canónica completa cuando el canon se exporta de nuevo desde HTML y se valida con compuertas duras.
 - La admisión de sesiones es manual, validada y reversible.
 - La condición crítica para admisión y reverse es `Rejected: 0`.

--- a/esquemas/canon/derived_field_rules.md
+++ b/esquemas/canon/derived_field_rules.md
@@ -12,6 +12,9 @@ projections only.
 - `source_tags` remains the authoritative reversible tag source for TiddlyWiki output.
 - `tags` remains the existing semantic tag projection introduced by S36.
 - `content.plain` is derived and non-authoritative.
+- `content.asset`, `content.code_blocks`, `content.equations`,
+  `content.references` and `content.structured_payload` are derived and
+  non-authoritative modal projections.
 - `normalized_tags` is derived and non-authoritative.
 - No derived field may silently correct, overwrite, or replace its source.
 
@@ -36,6 +39,34 @@ available in the node, currently `text`.
 ### Reverse rule
 
 Future reverse must continue reading `text`, never `content.plain`.
+
+## Modal Content Projections
+
+### Source
+
+Modal projections are derived only from fields already preserved in the canon:
+`text`, `content_type`, `modality`, `encoding`, `is_binary`,
+`is_reference_only`, `raw_payload_ref`, `asset_id` and `mime_type`.
+
+### Policy
+
+- Binary/image assets may emit `content.asset` with payload reference, MIME,
+  encoding, payload presence and deterministic payload hash/size when the
+  embedded payload is available.
+- Textual nodes may emit `content.code_blocks`, `content.equations` and
+  `content.references` when conservative syntax is detected.
+- Valid full JSON payloads may emit `content.structured_payload`; partial,
+  recoverable or pedagogical JSON remains audit evidence, not canonical
+  promotion.
+- Mixed nodes declare `content.projection_kind: "mixed"` and a deterministic
+  `content.modalities` list.
+- Projections organize existing evidence; they do not summarize or replace the
+  original source text.
+
+### Reverse rule
+
+Reverse must continue reading `text`, `source_tags` and `source_fields`.
+Modal projections are inspection and validation helpers only.
 
 ## `normalized_tags`
 
@@ -72,6 +103,8 @@ Future reverse must continue reading `text`, never `content.plain`.
 Derived projections are asymmetric by contract:
 
 - `content.plain` cannot override `text`.
+- Modal projections cannot override `text`, payload identity, source tags or
+  source fields.
 - `normalized_tags` cannot override `tags` or `source_tags`.
 - Validation may reject inconsistent derived values, but only recomputation from
   source fields can repair them.

--- a/estructura.txt
+++ b/estructura.txt
@@ -27,11 +27,6 @@
 │   │   │   │   ├── chunks_ai_1.jsonl
 │   │   │   │   ├── chunks_ai_2.jsonl
 │   │   │   │   ├── chunks_ai_3.jsonl
-│   │   │   │   ├── chunks_ai_4.jsonl
-│   │   │   │   ├── chunks_ai_5.jsonl
-│   │   │   │   ├── chunks_ai_6.jsonl
-│   │   │   │   ├── chunks_ai_7.jsonl
-│   │   │   │   ├── chunks_ai_8.jsonl
 │   │   │   │   ├── manifest.json
 │   │   │   │   ├── reports
 │   │   │   │   │   ├── chunk_qc_report.json
@@ -67,7 +62,6 @@
 │   │   │   │   ├── tiddlers_enriched_6.jsonl
 │   │   │   │   ├── tiddlers_enriched_7.jsonl
 │   │   │   │   └── tiddlers_enriched_8.jsonl
-│   │   │   ├── export
 │   │   │   ├── microsoft_copilot
 │   │   │   │   ├── artifacts.csv
 │   │   │   │   ├── bundles
@@ -128,174 +122,107 @@
 │   │   │   │   │       └── tiddlers-sesiones.md
 │   │   │   │   └── topics.json
 │   │   │   ├── reverse_html
+│   │   │   │   ├── reverse-report.json
+│   │   │   │   └── tiddly-data-converter.derived.html
 │   │   │   ├── tiddlers_1.jsonl
 │   │   │   ├── tiddlers_2.jsonl
 │   │   │   ├── tiddlers_3.jsonl
 │   │   │   ├── tiddlers_4.jsonl
 │   │   │   ├── tiddlers_5.jsonl
 │   │   │   ├── tiddlers_6.jsonl
-│   │   │   └── tiddlers_7.jsonl
+│   │   │   ├── tiddlers_7.jsonl
+│   │   │   └── tiddlers_8.jsonl
 │   │   └── remote
 │   ├── README.md
 │   ├── sessions
 │   │   ├── 00_contratos
-│   │   │   ├── context_relations
-│   │   │   │   └── context_relations_rules.md
-│   │   │   ├── estructura_de_commits_tiddly-data-converter.JSON
-│   │   │   ├── export_contract
-│   │   │   │   └── export_contract_rules.md
-│   │   │   ├── identity
-│   │   │   │   └── identity_rules.md
-│   │   │   ├── m01-s01-extractor-contract.md.json
-│   │   │   ├── m01-s02-extractor-bootstrap.md.json
-│   │   │   ├── m01-s03-extractor-env-wsl.md.json
-│   │   │   ├── m01-s04-doctor-contract.md.json
-│   │   │   ├── m01-s05-ingesta-contract.md.json
-│   │   │   ├── m01-s06-ingesta-go-env-wsl.mc.json
-│   │   │   ├── m01-s07-ingesta-bootstrap.md.json
-│   │   │   ├── m01-s08-ingesta-data-triage.md.json
-│   │   │   ├── m01-s09-ingesta-timestamp-policy.md.json
-│   │   │   ├── m01-s10-doctor-audit.md.json
-│   │   │   ├── m01-s11-ingesta-dedup-triage.md.json
-│   │   │   ├── m01-s12-pipeline-costura.md.json
-│   │   │   ├── m01-s13-canon-bootstrap.md.json
-│   │   │   ├── m01-s14-bridge-ingesta-canon.md.json
-│   │   │   ├── m01-s15-canon-collision-acceptance.md.json
-│   │   │   ├── m01-s16-canon-jsonl-writer.md.json
-│   │   │   ├── m01-s17-canon-admit-v0.md.json
-│   │   │   ├── m01-s17-post-merge-actions-verification.md.json
-│   │   │   ├── m01-s18-canon-schema-v0.md.json
-│   │   │   ├── m02-s19-canon-jsonl-gate-v0.md.json
-│   │   │   ├── m02-s20-canon-gate-e2e-smoke.md.json
-│   │   │   ├── m02-s21-canon-gate-acceptance-matrix.md.json
-│   │   │   ├── m02-s22-canon-gate-batch-audit-v0.md.json
-│   │   │   ├── m02-s23-canon-gate-batch-report-v0.md.json
-│   │   │   ├── m02-s24-canon-gate-batch-emit-v0.md.json
-│   │   │   ├── m02-s24-canon-gate-verdict-v0.md.json
-│   │   │   ├── m02-s25-canon-gate-batch-contract-v1.md.json
-│   │   │   ├── m02-s26-canon-gate-batch-report-persist-v0.md.json
-│   │   │   ├── m02-s27-canon-gate-batch-report-persist-v0.md.json
-│   │   │   ├── m02-s28-canon-gate-batch-accumulation-semantics-v0.md.json
-│   │   │   ├── m02-s29-canon-accumulator-truth-pin-and-impl-v0.md.json
-│   │   │   ├── m02-s30-canon-uuidv5-and-memory-policy-v0.md.json
-│   │   │   ├── m02-s31-canon-accumulate-replay-verify-and-ci-v0.md.json
-│   │   │   ├── m02-s32-canon-freeze-baseline-oracle-and-first-jsonl-v0.md.json
-│   │   │   ├── m02-s33-single-jsonl-functional-tiddlers-from-real-html-v0.md.json
-│   │   │   ├── m02-s34-canon-node-structural-identity-v0.md.json
-│   │   │   ├── m02-s35-canon-node-reading-mode-and-typing-v0.md.json
-│   │   │   ├── m02-s36-canon-semantic-function-and-asset-separation-v0.md.json
-│   │   │   ├── m02-s37-canon-document-context-and-relations-v0.md.json
-│   │   │   ├── m02-s38-canon-export-contract-hardening-v0.md.json
-│   │   │   ├── m02-s39-canon-executable-policy-and-reverse-readiness-v0.md.json
-│   │   │   ├── m02-s40-canon-guarded-local-session-test-v0.md.json
-│   │   │   ├── m02-s41-canon-minimal-derived-hardening-for-reverse-v0.md.json
-│   │   │   ├── m02-s42-canon-minimal-deterministic-reverse-v0.md.json
-│   │   │   ├── m03-s43-canon-robust-textual-reverse-v0.md.json
-│   │   │   ├── m03-s44-canon-sharded-homogeneous-records-and-robust-reverse-v0.md.json
-│   │   │   ├── m03-s45-canon-enriched-ai-projection-v0.md.json
-│   │   │   ├── m03-s46-ai-projection-v1-hardening-local.md.json
-│   │   │   ├── m03-s47-normative-self-audit-and-projection-refinement-v0.md.json
-│   │   │   ├── m03-s48-canonical-enrichment-target-scope-v0.md.json
-│   │   │   ├── m03-s49-mcp-onedrive-canon-proposals-v0.md.json
-│   │   │   ├── m03-s50-rutas-manifests-reverse-governance-v0.md.json
-│   │   │   ├── m03-s50a-session-identity-repair-v0.md.json
-│   │   │   ├── m03-s51-canon-semantic-hardening-v0.md.json
-│   │   │   ├── m03-s52-chunking-structure-traceability-v0.md.json
-│   │   │   ├── m03-s53-instructions-normative-harmonization-v0.md.json
-│   │   │   ├── m03-s54-semantic-microchunk-historical-provenance-v0.md.json
-│   │   │   ├── m03-s55-corpus-governance-state-lineage-v0.md.json
-│   │   │   ├── m03-s56-direct-canon-session-dependency-tiddlers-v0.md.json
-│   │   │   ├── m03-s57-canon-direct-close-governance-v0.md.json
-│   │   │   ├── m03-s58-route-fix-readme-structural-cleanup.md.json
-│   │   │   ├── m03-s59-microsoft-copilot-projection-governance-v0.md.json
-│   │   │   ├── m03-s60-microsoft-copilot-derived-projection-mvp-v0.md.json
-│   │   │   ├── m03-s61-microsoft-copilot-json-csv-txt-projection-mvp-v0.md.json
-│   │   │   ├── m03-s62-copilot-agent-three-master-files-pack-v0.md.json
-│   │   │   ├── m03-s63-copilot-agent-generator-integration-and-canonicalization-v0.md.json
-│   │   │   ├── m03-s64-copilot-agent-semantic-compression-and-reversible-canon-hardening-v0.md.json
 │   │   │   ├── m03-s65-microsoft-copilot-execution-surface-and-readme-hardening-v0.md.json
-│   │   │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
 │   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
 │   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
 │   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
 │   │   │   ├── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │   │   ├── m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.md.json
+│   │   │   ├── m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.md.json
+│   │   │   ├── m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.md.json
+│   │   │   ├── m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.md.json
+│   │   │   ├── m04-s77-canonical-staging-and-controlled-modal-admission-v0.md.json
+│   │   │   ├── m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.md.json
 │   │   │   ├── policy
 │   │   │   │   └── canon_policy_bundle.json
-│   │   │   ├── projections
-│   │   │   │   └── derived_layers_registry.json
-│   │   │   ├── reverse
-│   │   │   │   └── reverse_contract_rules.md
-│   │   │   ├── semantic
-│   │   │   │   └── semantic_rules.md
-│   │   │   ├── typing
-│   │   │   │   └── node_reading_mode_rules.md
-│   │   │   └── validation
-│   │   │       ├── s37-local-checks.md
-│   │   │       ├── s38-local-checks.md
-│   │   │       ├── s39-local-checks.md
-│   │   │       ├── s40-local-checks.md
-│   │   │       ├── s41-local-checks.md
-│   │   │       ├── s42-local-checks.md
-│   │   │       ├── s43-local-checks.md
-│   │   │       └── s44-local-checks.md
+│   │   │   └── projections
+│   │   │       └── derived_layers_registry.json
 │   │   ├── 01_procedencia
-│   │   │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
 │   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
 │   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
 │   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
-│   │   │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │   │   ├── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │   │   ├── m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.md.json
+│   │   │   ├── m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.md.json
+│   │   │   ├── m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.md.json
+│   │   │   ├── m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.md.json
+│   │   │   ├── m04-s77-canonical-staging-and-controlled-modal-admission-v0.md.json
+│   │   │   └── m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.md.json
 │   │   ├── 02_detalles_de_sesion
-│   │   │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
 │   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
 │   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
 │   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
-│   │   │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │   │   ├── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │   │   ├── m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.md.json
+│   │   │   ├── m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.md.json
+│   │   │   ├── m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.md.json
+│   │   │   ├── m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.md.json
+│   │   │   ├── m04-s77-canonical-staging-and-controlled-modal-admission-v0.md.json
+│   │   │   └── m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.md.json
 │   │   ├── 03_hipotesis
-│   │   │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
 │   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
 │   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
 │   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
-│   │   │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │   │   ├── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │   │   ├── m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.md.json
+│   │   │   ├── m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.md.json
+│   │   │   ├── m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.md.json
+│   │   │   ├── m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.md.json
+│   │   │   ├── m04-s77-canonical-staging-and-controlled-modal-admission-v0.md.json
+│   │   │   └── m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.md.json
 │   │   ├── 04_balance_de_sesion
-│   │   │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
 │   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
 │   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
 │   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
-│   │   │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │   │   ├── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │   │   ├── m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.md.json
+│   │   │   ├── m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.md.json
+│   │   │   ├── m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.md.json
+│   │   │   ├── m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.md.json
+│   │   │   ├── m04-s77-canonical-staging-and-controlled-modal-admission-v0.md.json
+│   │   │   └── m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.md.json
 │   │   ├── 05_propuesta_de_sesion
-│   │   │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │   │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │   │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.md.json
 │   │   │   ├── m03-s69-session-canon-admission-hardening-and-docs-v0.md.json
 │   │   │   ├── m03-s70-operator-menu-and-session-sync-v0.md.json
 │   │   │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
-│   │   │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │   │   ├── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │   │   ├── m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.md.json
+│   │   │   ├── m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.md.json
+│   │   │   ├── m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.md.json
+│   │   │   ├── m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.md.json
+│   │   │   ├── m04-s77-canonical-staging-and-controlled-modal-admission-v0.md.json
+│   │   │   └── m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.md.json
 │   │   └── 06_diagnoses
-│   │       ├── canon
-│   │       │   └── s65_canon_diagnosis.md
-│   │       ├── derivados
-│   │       │   └── s65_derivatives_diagnosis.md
-│   │       ├── hipotesis
-│   │       │   └── s65_hypothesis_trace.md
 │   │       ├── module
 │   │       ├── project
-│   │       ├── repositorio
-│   │       │   └── s65_repo_diagnosis.md
 │   │       ├── reverse
-│   │       ├── s65_validation_report.md
 │   │       ├── sesion
-│   │       │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.canon-candidates.jsonl
-│   │       │   ├── m03-s66-session-family-and-canonical-closure-flow-v0.md.json
 │   │       │   ├── m03-s67-session-canon-admission-orchestrator-v0.canon-candidates.jsonl
 │   │       │   ├── m03-s67-session-canon-admission-orchestrator-v0.md.json
 │   │       │   ├── m03-s68-session-canon-admission-integration-fixtures-v0.canon-candidates.jsonl
@@ -307,7 +234,19 @@
 │   │       │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.canon-candidates.jsonl
 │   │       │   ├── m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json
 │   │       │   ├── m04-s72-rust-kernel-reconstruction-plan-gate-v0.canon-candidates.jsonl
-│   │       │   └── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │       │   ├── m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json
+│   │       │   ├── m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.canon-candidates.jsonl
+│   │       │   ├── m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.md.json
+│   │       │   ├── m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.canon-candidates.jsonl
+│   │       │   ├── m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.md.json
+│   │       │   ├── m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.canon-candidates.jsonl
+│   │       │   ├── m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.md.json
+│   │       │   ├── m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.canon-candidates.jsonl
+│   │       │   ├── m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.md.json
+│   │       │   ├── m04-s77-canonical-staging-and-controlled-modal-admission-v0.canon-candidates.jsonl
+│   │       │   ├── m04-s77-canonical-staging-and-controlled-modal-admission-v0.md.json
+│   │       │   ├── m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.canon-candidates.jsonl
+│   │       │   └── m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.md.json
 │   │       └── tema
 │   └── tmp
 │       ├── admissions
@@ -340,6 +279,21 @@
 │       │   ├── admit-20260429191735-m04-s71-rust-kernel-perimeter-and-invariants-v0.json
 │       │   ├── admit-20260429200205-m04-s72-rust-kernel-reconstruction-plan-gate-v0.json
 │       │   ├── admit-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0.json
+│       │   ├── admit-20260429204036-multi-session.json
+│       │   ├── admit-20260429204315-multi-session.json
+│       │   ├── admit-20260429204600-multi-session.json
+│       │   ├── admit-20260429204620-multi-session.json
+│       │   ├── admit-20260429234828-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   ├── admit-20260429234846-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   ├── admit-20260430000325-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   ├── admit-20260430000633-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   ├── admit-20260430125654-m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.json
+│       │   ├── admit-20260430125755-m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.json
+│       │   ├── admit-20260501024223-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.json
+│       │   ├── admit-20260501024356-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.json
+│       │   ├── admit-20260501024649-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.json
+│       │   ├── admit-20260501143758-multi-session.json
+│       │   ├── admit-20260501143828-multi-session.json
 │       │   ├── backups
 │       │   │   ├── admit-20260428153824-m03-s69-session-canon-admission-hardening-and-docs-v0
 │       │   │   │   ├── tiddlers_1.jsonl
@@ -421,14 +375,39 @@
 │       │   │   │   ├── tiddlers_5.jsonl
 │       │   │   │   ├── tiddlers_6.jsonl
 │       │   │   │   └── tiddlers_7.jsonl
-│       │   │   └── admit-20260429183452-multi-session
+│       │   │   ├── admit-20260429183452-multi-session
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   ├── admit-20260429204620-multi-session
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   ├── admit-20260429234846-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── admit-20260501143828-multi-session
 │       │   │       ├── tiddlers_1.jsonl
 │       │   │       ├── tiddlers_2.jsonl
 │       │   │       ├── tiddlers_3.jsonl
 │       │   │       ├── tiddlers_4.jsonl
 │       │   │       ├── tiddlers_5.jsonl
 │       │   │       ├── tiddlers_6.jsonl
-│       │   │       └── tiddlers_7.jsonl
+│       │   │       ├── tiddlers_7.jsonl
+│       │   │       └── tiddlers_8.jsonl
 │       │   ├── generated
 │       │   │   ├── all-contracts-20260428223203
 │       │   │   │   ├── admission_lines.normalized.jsonl
@@ -925,6 +904,45 @@
 │       │   │   ├── admit-20260429190825-m04-s71-rust-kernel-perimeter-and-invariants-v0.json
 │       │   │   ├── admit-20260429191411-m04-s71-rust-kernel-perimeter-and-invariants-v0.json
 │       │   │   └── validate-20260429190947-m04-s71-rust-kernel-perimeter-and-invariants-v0.json
+│       │   ├── s73
+│       │   │   ├── admit-20260429234337-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   │   ├── admit-20260429234424-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   │   ├── validate-20260429234337-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   │   └── validate-20260429234416-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   ├── s75
+│       │   │   ├── admit-20260430132403-m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.json
+│       │   │   ├── admit-20260430132520-m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.json
+│       │   │   ├── validate-20260430132403-m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.json
+│       │   │   └── validate-20260430132513-m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.json
+│       │   ├── s77
+│       │   │   ├── admit-20260501135003-m04-s77-canonical-staging-and-controlled-modal-admission-v0.json
+│       │   │   ├── admit-20260501135050-m04-s77-canonical-staging-and-controlled-modal-admission-v0.json
+│       │   │   ├── validate-20260501134949-m04-s77-canonical-staging-and-controlled-modal-admission-v0.json
+│       │   │   └── validate-20260501135045-m04-s77-canonical-staging-and-controlled-modal-admission-v0.json
+│       │   ├── s78-final-candidates
+│       │   │   ├── admit-20260501142959-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.json
+│       │   │   ├── admit-20260501143051-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.json
+│       │   │   ├── admit-20260501143149-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.json
+│       │   │   ├── admit-20260501143459-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.json
+│       │   │   ├── validate-20260501142950-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.json
+│       │   │   ├── validate-20260501143041-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.json
+│       │   │   ├── validate-20260501143142-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.json
+│       │   │   └── validate-20260501143454-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.json
+│       │   ├── s78-regeneration-s73
+│       │   │   ├── admit-20260501142454-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   │   ├── admit-20260501142506-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   │   ├── backups
+│       │   │   │   └── admit-20260501142506-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0
+│       │   │   │       ├── tiddlers_1.jsonl
+│       │   │   │       ├── tiddlers_2.jsonl
+│       │   │   │       ├── tiddlers_3.jsonl
+│       │   │   │       ├── tiddlers_4.jsonl
+│       │   │   │       ├── tiddlers_5.jsonl
+│       │   │   │       ├── tiddlers_6.jsonl
+│       │   │   │       ├── tiddlers_7.jsonl
+│       │   │   │       └── tiddlers_8.jsonl
+│       │   │   ├── validate-20260501142400-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   │   └── validate-20260501142445-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
 │       │   ├── session_id_probe
 │       │   │   ├── admit-20260428153527-m03-s69-session-canon-admission-hardening-and-docs-v0.json
 │       │   │   └── validate-20260428153527-m03-s69-session-canon-admission-hardening-and-docs-v0.json
@@ -938,16 +956,127 @@
 │       │   ├── validate-20260429183352-multi-session.json
 │       │   ├── validate-20260429191735-m04-s71-rust-kernel-perimeter-and-invariants-v0.json
 │       │   ├── validate-20260429200205-m04-s72-rust-kernel-reconstruction-plan-gate-v0.json
-│       │   └── validate-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0.json
+│       │   ├── validate-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0.json
+│       │   ├── validate-20260429204557-multi-session.json
+│       │   ├── validate-20260430000325-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   ├── validate-20260430000633-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.json
+│       │   ├── validate-20260430125639-m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.json
+│       │   ├── validate-20260430125749-m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.json
+│       │   ├── validate-20260501024206-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.json
+│       │   ├── validate-20260501024345-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.json
+│       │   └── validate-20260501024638-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.json
+│       ├── canonical_quality
+│       │   ├── quality-20260430125315
+│       │   │   ├── canonical-line-gate.json
+│       │   │   └── deep-node-inspect.json
+│       │   ├── quality-20260430132045
+│       │   │   ├── canonical-line-gate.json
+│       │   │   └── deep-node-inspect.json
+│       │   └── quality-20260501145458
+│       │       ├── canonical-line-gate.json
+│       │       └── deep-node-inspect.json
 │       ├── html_export
 │       │   ├── export-20260429165825
 │       │   │   ├── tiddlers.export.jsonl
 │       │   │   ├── tiddlers.export.log
 │       │   │   └── tiddlers.export.manifest.json
-│       │   └── export-20260429195756
-│       │       ├── tiddlers.export.jsonl
+│       │   ├── export-20260429195756
+│       │   │   ├── tiddlers.export.jsonl
+│       │   │   ├── tiddlers.export.log
+│       │   │   └── tiddlers.export.manifest.json
+│       │   ├── export-20260429203949
+│       │   │   ├── tiddlers.export.jsonl
+│       │   │   ├── tiddlers.export.log
+│       │   │   └── tiddlers.export.manifest.json
+│       │   ├── export-20260429204142
+│       │   │   ├── tiddlers.export.jsonl
+│       │   │   ├── tiddlers.export.log
+│       │   │   └── tiddlers.export.manifest.json
+│       │   ├── export-20260429225724
+│       │   │   ├── tiddlers.export.jsonl
+│       │   │   ├── tiddlers.export.log
+│       │   │   └── tiddlers.export.manifest.json
+│       │   ├── export-20260429234713
+│       │   │   ├── tiddlers.export.jsonl
+│       │   │   ├── tiddlers.export.log
+│       │   │   └── tiddlers.export.manifest.json
+│       │   └── export-s78-20260501142151
 │       │       ├── tiddlers.export.log
 │       │       └── tiddlers.export.manifest.json
+│       ├── reconstruction
+│       │   ├── diagnostic-20260429225708
+│       │   │   └── gate-report.json
+│       │   ├── diagnostic-20260429234706
+│       │   │   └── gate-report.json
+│       │   ├── export-20260429225724
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── export-20260429234713
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reconstruction-20260429204236
+│       │   │   ├── canon_before
+│       │   │   └── reconstruction-report.json
+│       │   ├── reconstruction-20260429234809
+│       │   │   └── gate-report.json
+│       │   ├── reconstruction-s78-20260501142151
+│       │   │   ├── applied-base-reverse-preflight-report.json
+│       │   │   ├── applied-base-shard-report.json
+│       │   │   ├── applied-base-strict-report.json
+│       │   │   ├── canon_after
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   └── tiddlers_8.jsonl
+│       │   │   ├── canon_after_with_s73
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   └── tiddlers_8.jsonl
+│       │   │   ├── canon_before
+│       │   │   ├── downstream-derive-output.txt
+│       │   │   ├── downstream-governance-report.json
+│       │   │   ├── final-canonical-line-gate.json
+│       │   │   ├── final-reverse-preflight-report.json
+│       │   │   ├── final-reverse-report.json
+│       │   │   ├── final-strict-report.json
+│       │   │   ├── reconstruction-report.json
+│       │   │   ├── reverse_staged
+│       │   │   │   ├── staged.derived.html
+│       │   │   │   └── staged.reverse-report.json
+│       │   │   ├── staged-reverse-preflight-report.json
+│       │   │   ├── staged-shard-report.json
+│       │   │   ├── staged-strict-report.json
+│       │   │   ├── staged_canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   └── tiddlers_8.jsonl
+│       │   │   ├── staging-gate.json
+│       │   │   └── write-local-canon-gate.json
+│       │   ├── reverse-20260429225812
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reverse-20260429235100
+│       │   │   └── gate-report.json
+│       │   ├── reverse-20260429235111
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   └── reverse-20260501144136
+│       │       ├── gate-report.json
+│       │       └── reconstruction-report.json
 │       ├── s69_candidate_generation
 │       │   ├── normalized.jsonl
 │       │   └── raw.jsonl
@@ -991,6 +1120,64 @@
 │       │           └── reverse_html
 │       │               ├── admit-20260429174904-multi-session.derived.html
 │       │               └── admit-20260429174904-multi-session.reverse-report.json
+│       ├── s74-canonical-line-gate.json
+│       ├── s74-deep-node-inspect.json
+│       ├── s74-session-candidates-line-gate-final.json
+│       ├── s75-candidates-canonical-line-gate.json
+│       ├── s75-deep-node-triage.json
+│       ├── s75-family-template-hardening.json
+│       ├── s76-canonical-modal-line-gate.json
+│       ├── s76-deep-node-inspect.json
+│       ├── s76-modal-export
+│       │   ├── canonical-line-gate.json
+│       │   ├── export.log.jsonl
+│       │   ├── local-normalized-modal.jsonl
+│       │   ├── manifest.json
+│       │   └── tiddlers.export.jsonl
+│       ├── s76-normalized-modal-line-gate.json
+│       ├── s76-session-candidates-line-gate.json
+│       ├── s77-modal-admission
+│       │   └── s77-modal-assets-minimal
+│       │       ├── canonical-line-gate.after.json
+│       │       ├── canonical-line-gate.before.json
+│       │       ├── comparison-report.json
+│       │       ├── modal-assets.patch.jsonl
+│       │       └── staged-canon
+│       │           ├── tiddlers_1.jsonl
+│       │           ├── tiddlers_2.jsonl
+│       │           ├── tiddlers_3.jsonl
+│       │           ├── tiddlers_4.jsonl
+│       │           ├── tiddlers_5.jsonl
+│       │           ├── tiddlers_6.jsonl
+│       │           └── tiddlers_7.jsonl
+│       ├── s77-probe
+│       │   ├── modal-assets-staged-canon
+│       │   │   ├── tiddlers_1.jsonl
+│       │   │   ├── tiddlers_2.jsonl
+│       │   │   ├── tiddlers_3.jsonl
+│       │   │   ├── tiddlers_4.jsonl
+│       │   │   ├── tiddlers_5.jsonl
+│       │   │   ├── tiddlers_6.jsonl
+│       │   │   └── tiddlers_7.jsonl
+│       │   └── probe-report.json
+│       ├── s77-session-candidates
+│       │   └── normalize
+│       │       ├── admission_lines.normalized.jsonl
+│       │       └── admission_lines.raw.jsonl
+│       ├── s77-session-candidates-final
+│       │   └── normalize
+│       │       ├── admission_lines.normalized.jsonl
+│       │       └── admission_lines.raw.jsonl
+│       ├── s78-regeneration
+│       │   ├── source-probe
+│       │   │   ├── saved
+│       │   │   │   ├── tiddlers.export.log
+│       │   │   │   └── tiddlers.export.manifest.json
+│       │   │   └── seed
+│       │   │       ├── tiddlers.export.jsonl
+│       │   │       ├── tiddlers.export.log
+│       │   │       └── tiddlers.export.manifest.json
+│       │   └── staging
 │       ├── session_admission
 │       │   ├── admit-20260428153824-m03-s69-session-canon-admission-hardening-and-docs-v0
 │       │   │   ├── admission_lines.normalized.jsonl
@@ -1476,6 +1663,7 @@
 │       │   │   │   ├── tiddlers_6.jsonl
 │       │   │   │   └── tiddlers_7.jsonl
 │       │   │   └── reverse_html
+│       │   │       ├── admit-20260429183413-multi-session.derived.html
 │       │   │       └── admit-20260429183413-multi-session.reverse-report.json
 │       │   ├── admit-20260429183452-multi-session
 │       │   │   ├── admission_lines.normalized.jsonl
@@ -1503,6 +1691,7 @@
 │       │   │   │   ├── tiddlers_6.jsonl
 │       │   │   │   └── tiddlers_7.jsonl
 │       │   │   └── reverse_html
+│       │   │       ├── admit-20260429190825-m04-s71-rust-kernel-perimeter-and-invariants-v0.derived.html
 │       │   │       └── admit-20260429190825-m04-s71-rust-kernel-perimeter-and-invariants-v0.reverse-report.json
 │       │   ├── admit-20260429191411-m04-s71-rust-kernel-perimeter-and-invariants-v0
 │       │   │   ├── admission_lines.normalized.jsonl
@@ -1516,6 +1705,7 @@
 │       │   │   │   ├── tiddlers_6.jsonl
 │       │   │   │   └── tiddlers_7.jsonl
 │       │   │   └── reverse_html
+│       │   │       ├── admit-20260429191411-m04-s71-rust-kernel-perimeter-and-invariants-v0.derived.html
 │       │   │       └── admit-20260429191411-m04-s71-rust-kernel-perimeter-and-invariants-v0.reverse-report.json
 │       │   ├── admit-20260429191735-m04-s71-rust-kernel-perimeter-and-invariants-v0
 │       │   │   ├── admission_lines.normalized.jsonl
@@ -1529,6 +1719,7 @@
 │       │   │   │   ├── tiddlers_6.jsonl
 │       │   │   │   └── tiddlers_7.jsonl
 │       │   │   └── reverse_html
+│       │   │       ├── admit-20260429191735-m04-s71-rust-kernel-perimeter-and-invariants-v0.derived.html
 │       │   │       └── admit-20260429191735-m04-s71-rust-kernel-perimeter-and-invariants-v0.reverse-report.json
 │       │   ├── admit-20260429200205-m04-s72-rust-kernel-reconstruction-plan-gate-v0
 │       │   │   ├── admission_lines.normalized.jsonl
@@ -1542,20 +1733,368 @@
 │       │   │   │   ├── tiddlers_6.jsonl
 │       │   │   │   └── tiddlers_7.jsonl
 │       │   │   └── reverse_html
+│       │   │       ├── admit-20260429200205-m04-s72-rust-kernel-reconstruction-plan-gate-v0.derived.html
 │       │   │       └── admit-20260429200205-m04-s72-rust-kernel-reconstruction-plan-gate-v0.reverse-report.json
-│       │   └── admit-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0
-│       │       ├── admission_lines.normalized.jsonl
-│       │       ├── admission_lines.raw.jsonl
-│       │       ├── canon
-│       │       │   ├── tiddlers_1.jsonl
-│       │       │   ├── tiddlers_2.jsonl
-│       │       │   ├── tiddlers_3.jsonl
-│       │       │   ├── tiddlers_4.jsonl
-│       │       │   ├── tiddlers_5.jsonl
-│       │       │   ├── tiddlers_6.jsonl
-│       │       │   └── tiddlers_7.jsonl
-│       │       └── reverse_html
-│       │           └── admit-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0.reverse-report.json
+│       │   ├── admit-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0.derived.html
+│       │   │       └── admit-20260429200448-m04-s72-rust-kernel-reconstruction-plan-gate-v0.reverse-report.json
+│       │   ├── admit-20260429204036-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   └── admission_lines.raw.jsonl
+│       │   ├── admit-20260429204315-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429204315-multi-session.derived.html
+│       │   │       └── admit-20260429204315-multi-session.reverse-report.json
+│       │   ├── admit-20260429204600-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429204600-multi-session.derived.html
+│       │   │       └── admit-20260429204600-multi-session.reverse-report.json
+│       │   ├── admit-20260429204620-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429204620-multi-session.derived.html
+│       │   │       └── admit-20260429204620-multi-session.reverse-report.json
+│       │   ├── admit-20260429234828-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429234828-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.derived.html
+│       │   │       └── admit-20260429234828-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.reverse-report.json
+│       │   ├── admit-20260429234846-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429234846-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.derived.html
+│       │   │       └── admit-20260429234846-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.reverse-report.json
+│       │   ├── admit-20260430000325-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260430000325-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.derived.html
+│       │   │       └── admit-20260430000325-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.reverse-report.json
+│       │   ├── admit-20260430000633-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260430000633-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.derived.html
+│       │   │       └── admit-20260430000633-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.reverse-report.json
+│       │   ├── admit-20260430125654-m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260430125654-m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.derived.html
+│       │   │       └── admit-20260430125654-m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.reverse-report.json
+│       │   ├── admit-20260430125755-m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260430125755-m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.derived.html
+│       │   │       └── admit-20260430125755-m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.reverse-report.json
+│       │   ├── admit-20260430132403-m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260430132403-m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.derived.html
+│       │   │       └── admit-20260430132403-m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.reverse-report.json
+│       │   ├── admit-20260430132520-m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260430132520-m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.derived.html
+│       │   │       └── admit-20260430132520-m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.reverse-report.json
+│       │   ├── admit-20260501024223-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260501024223-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.derived.html
+│       │   │       └── admit-20260501024223-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.reverse-report.json
+│       │   ├── admit-20260501024356-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260501024356-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.derived.html
+│       │   │       └── admit-20260501024356-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.reverse-report.json
+│       │   ├── admit-20260501024649-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260501024649-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.derived.html
+│       │   │       └── admit-20260501024649-m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.reverse-report.json
+│       │   ├── admit-20260501135003-m04-s77-canonical-staging-and-controlled-modal-admission-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260501135003-m04-s77-canonical-staging-and-controlled-modal-admission-v0.derived.html
+│       │   │       └── admit-20260501135003-m04-s77-canonical-staging-and-controlled-modal-admission-v0.reverse-report.json
+│       │   ├── admit-20260501135050-m04-s77-canonical-staging-and-controlled-modal-admission-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260501135050-m04-s77-canonical-staging-and-controlled-modal-admission-v0.derived.html
+│       │   │       └── admit-20260501135050-m04-s77-canonical-staging-and-controlled-modal-admission-v0.reverse-report.json
+│       │   ├── admit-20260501143758-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   └── tiddlers_8.jsonl
+│       │   │   └── reverse_html
+│       │   │       └── admit-20260501143758-multi-session.reverse-report.json
+│       │   ├── admit-20260501143828-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   └── tiddlers_8.jsonl
+│       │   │   └── reverse_html
+│       │   │       └── admit-20260501143828-multi-session.reverse-report.json
+│       │   ├── s78-final-candidates
+│       │   │   ├── admit-20260501142959-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0
+│       │   │   │   ├── admission_lines.normalized.jsonl
+│       │   │   │   ├── admission_lines.raw.jsonl
+│       │   │   │   ├── canon
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   └── tiddlers_8.jsonl
+│       │   │   │   └── reverse_html
+│       │   │   │       ├── admit-20260501142959-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.derived.html
+│       │   │   │       └── admit-20260501142959-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.reverse-report.json
+│       │   │   ├── admit-20260501143051-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0
+│       │   │   │   ├── admission_lines.normalized.jsonl
+│       │   │   │   ├── admission_lines.raw.jsonl
+│       │   │   │   ├── canon
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   └── tiddlers_8.jsonl
+│       │   │   │   └── reverse_html
+│       │   │   │       └── admit-20260501143051-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.reverse-report.json
+│       │   │   ├── admit-20260501143149-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0
+│       │   │   │   ├── admission_lines.normalized.jsonl
+│       │   │   │   ├── admission_lines.raw.jsonl
+│       │   │   │   ├── canon
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   └── tiddlers_8.jsonl
+│       │   │   │   └── reverse_html
+│       │   │   │       ├── admit-20260501143149-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.derived.html
+│       │   │   │       └── admit-20260501143149-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.reverse-report.json
+│       │   │   └── admit-20260501143459-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0
+│       │   │       ├── admission_lines.normalized.jsonl
+│       │   │       ├── admission_lines.raw.jsonl
+│       │   │       ├── canon
+│       │   │       │   ├── tiddlers_1.jsonl
+│       │   │       │   ├── tiddlers_2.jsonl
+│       │   │       │   ├── tiddlers_3.jsonl
+│       │   │       │   ├── tiddlers_4.jsonl
+│       │   │       │   ├── tiddlers_5.jsonl
+│       │   │       │   ├── tiddlers_6.jsonl
+│       │   │       │   ├── tiddlers_7.jsonl
+│       │   │       │   └── tiddlers_8.jsonl
+│       │   │       └── reverse_html
+│       │   │           ├── admit-20260501143459-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.derived.html
+│       │   │           └── admit-20260501143459-m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.reverse-report.json
+│       │   └── s78-regeneration-s73
+│       │       ├── admit-20260501142454-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0
+│       │       │   ├── admission_lines.normalized.jsonl
+│       │       │   ├── admission_lines.raw.jsonl
+│       │       │   ├── canon
+│       │       │   │   ├── tiddlers_1.jsonl
+│       │       │   │   ├── tiddlers_2.jsonl
+│       │       │   │   ├── tiddlers_3.jsonl
+│       │       │   │   ├── tiddlers_4.jsonl
+│       │       │   │   ├── tiddlers_5.jsonl
+│       │       │   │   ├── tiddlers_6.jsonl
+│       │       │   │   ├── tiddlers_7.jsonl
+│       │       │   │   └── tiddlers_8.jsonl
+│       │       │   └── reverse_html
+│       │       │       ├── admit-20260501142454-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.derived.html
+│       │       │       └── admit-20260501142454-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.reverse-report.json
+│       │       └── admit-20260501142506-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0
+│       │           ├── admission_lines.normalized.jsonl
+│       │           ├── admission_lines.raw.jsonl
+│       │           ├── canon
+│       │           │   ├── tiddlers_1.jsonl
+│       │           │   ├── tiddlers_2.jsonl
+│       │           │   ├── tiddlers_3.jsonl
+│       │           │   ├── tiddlers_4.jsonl
+│       │           │   ├── tiddlers_5.jsonl
+│       │           │   ├── tiddlers_6.jsonl
+│       │           │   ├── tiddlers_7.jsonl
+│       │           │   └── tiddlers_8.jsonl
+│       │           └── reverse_html
+│       │               ├── admit-20260501142506-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.derived.html
+│       │               └── admit-20260501142506-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.reverse-report.json
 │       ├── session_admission_fixtures
 │       │   ├── canon_base
 │       │   │   ├── tiddlers_1.jsonl
@@ -2462,6 +3001,35 @@
 │       │       └── reverse_html
 │       │           ├── rollback-20260429200312-m03-s66-session-family-and-canonical-closure-flow-v0.derived.html
 │       │           └── rollback-20260429200312-m03-s66-session-family-and-canonical-closure-flow-v0.reverse-report.json
+│       ├── session_admission_s73
+│       │   ├── admit-20260429234337-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   └── tiddlers_7.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260429234337-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.derived.html
+│       │   │       └── admit-20260429234337-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.reverse-report.json
+│       │   └── admit-20260429234424-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0
+│       │       ├── admission_lines.normalized.jsonl
+│       │       ├── admission_lines.raw.jsonl
+│       │       ├── canon
+│       │       │   ├── tiddlers_1.jsonl
+│       │       │   ├── tiddlers_2.jsonl
+│       │       │   ├── tiddlers_3.jsonl
+│       │       │   ├── tiddlers_4.jsonl
+│       │       │   ├── tiddlers_5.jsonl
+│       │       │   ├── tiddlers_6.jsonl
+│       │       │   └── tiddlers_7.jsonl
+│       │       └── reverse_html
+│       │           ├── admit-20260429234424-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.derived.html
+│       │           └── admit-20260429234424-m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.reverse-report.json
 │       ├── session_admission_session_id_probe
 │       │   └── admit-20260428153527-m03-s69-session-canon-admission-hardening-and-docs-v0
 │       │       ├── admission_lines.normalized.jsonl
@@ -2493,6 +3061,97 @@
 │           │   └── normalize
 │           │       ├── admission_lines.normalized.jsonl
 │           │       └── admission_lines.raw.jsonl
+│           ├── s73-candidates
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── s73-candidates-regenerated
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── s73-candidates-regenerated-after-derived-fix
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── s73-candidates-regenerated-after-s65-fix
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── s74-canonical-line-gate-and-deep-node-inspector
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s74-canonical-line-gate-and-deep-node-inspector-final
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s75-family-template-hardening
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s75-family-template-hardening-final
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s76-modal-projection
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── s76-modal-projection-final
+│           │   └── normalize
+│           │       ├── admission_lines.normalized.jsonl
+│           │       └── admission_lines.raw.jsonl
+│           ├── s78-final
+│           │   ├── s78-final-session-sync
+│           │   │   ├── inventory.json
+│           │   │   ├── missing-candidates.canon-candidates.jsonl
+│           │   │   ├── normalize
+│           │   │   │   ├── admission_lines.normalized.jsonl
+│           │   │   │   └── admission_lines.raw.jsonl
+│           │   │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   │   └── sync-candidates.canon-candidates.jsonl
+│           │   ├── s78-final-session-sync-2
+│           │   │   ├── inventory.json
+│           │   │   ├── missing-candidates.canon-candidates.jsonl
+│           │   │   ├── normalize
+│           │   │   │   ├── admission_lines.normalized.jsonl
+│           │   │   │   └── admission_lines.raw.jsonl
+│           │   │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   │   └── sync-candidates.canon-candidates.jsonl
+│           │   └── s78-final-session-sync-3
+│           │       ├── inventory.json
+│           │       ├── missing-candidates.canon-candidates.jsonl
+│           │       ├── normalize
+│           │       │   ├── admission_lines.normalized.jsonl
+│           │       │   └── admission_lines.raw.jsonl
+│           │       ├── replacement-candidates.canon-candidates.jsonl
+│           │       └── sync-candidates.canon-candidates.jsonl
+│           ├── s78-regeneration-s73
+│           │   └── s78-regeneration-s73-scan
+│           │       ├── inventory.json
+│           │       ├── missing-candidates.canon-candidates.jsonl
+│           │       ├── normalize
+│           │       │   ├── admission_lines.normalized.jsonl
+│           │       │   └── admission_lines.raw.jsonl
+│           │       ├── replacement-candidates.canon-candidates.jsonl
+│           │       ├── s73-only.canon-candidates.jsonl
+│           │       └── sync-candidates.canon-candidates.jsonl
 │           ├── sync-20260429025748
 │           │   ├── inventory.json
 │           │   └── normalize
@@ -2602,7 +3261,45 @@
 │           │   │   └── admission_lines.raw.jsonl
 │           │   ├── replacement-candidates.canon-candidates.jsonl
 │           │   └── sync-candidates.canon-candidates.jsonl
-│           └── sync-20260429183328
+│           ├── sync-20260429183328
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260429204017
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260429204309
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260429204525
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260429234814
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           └── sync-20260501143719
 │               ├── inventory.json
 │               ├── missing-candidates.canon-candidates.jsonl
 │               ├── normalize
@@ -2653,7 +3350,8 @@
 │   │   │   ├── admit
 │   │   │   │   └── main.go
 │   │   │   ├── export_tiddlers
-│   │   │   │   └── main.go
+│   │   │   │   ├── main.go
+│   │   │   │   └── main_test.go
 │   │   │   └── reverse_tiddlers
 │   │   │       └── main.go
 │   │   ├── go.mod
@@ -2761,6 +3459,7 @@
 │   ├── path_governance.py
 │   ├── s45_derive_layers.py
 │   ├── session_sync.py
+│   ├── stage_modal_delta.py
 │   ├── tiddlers_to_jsonl.py
 │   └── validate_corpus_governance.py
 ├── README.md
@@ -2770,9 +3469,12 @@
 │   ├── doctor
 │   │   ├── Cargo.lock
 │   │   ├── Cargo.toml
+│   │   ├── data
+│   │   │   └── tmp
 │   │   ├── src
 │   │   │   ├── bin
 │   │   │   │   └── audit.rs
+│   │   │   ├── canon_quality.rs
 │   │   │   ├── error.rs
 │   │   │   ├── lib.rs
 │   │   │   └── report.rs
@@ -2887,11 +3589,14 @@
 │   │   │   ├── __init__.py
 │   │   │   ├── __pycache__
 │   │   │   └── test_s65_microsoft_copilot_flow.py
-│   │   └── s69
-│   │       ├── __init__.py
+│   │   ├── s69
+│   │   │   ├── __init__.py
+│   │   │   ├── __pycache__
+│   │   │   ├── run_session_admission_test.sh
+│   │   │   └── test_session_admission.py
+│   │   └── s77
 │   │       ├── __pycache__
-│   │       ├── run_session_admission_test.sh
-│   │       └── test_session_admission.py
+│   │       └── test_stage_modal_delta.py
 │   ├── golden
 │   │   ├── baseline
 │   │   │   └── v1

--- a/go/bridge/cmd/export_tiddlers/main.go
+++ b/go/bridge/cmd/export_tiddlers/main.go
@@ -1,21 +1,23 @@
 // cmd/export_tiddlers/main.go — S33 CLI: export functional tiddlers from real HTML
 //
 // Usage:
-//   export_tiddlers --html <path> --out <jsonl_path> [--log <log_path>] [--manifest <manifest_path>] [--run-id <id>]
+//
+//	export_tiddlers --html <path> --out <jsonl_path> [--log <log_path>] [--manifest <manifest_path>] [--run-id <id>]
 //
 // This CLI implements the S33 Bridge→Canon costura:
-//   1. Extract raw tiddlers from TiddlyWiki HTML (Go adapter)
-//   2. Apply filtering rules (exclude system tiddlers)
-//   3. Ingest raw tiddlers to pre-canonical shape
-//   4. Convert via Bridge to CanonEntry
-//   5. Export as JSONL (1 tiddler = 1 line) with S19 gate
-//   6. Write export log and manifest
+//  1. Extract raw tiddlers from TiddlyWiki HTML (Go adapter)
+//  2. Apply filtering rules (exclude system tiddlers)
+//  3. Ingest raw tiddlers to pre-canonical shape
+//  4. Convert via Bridge to CanonEntry
+//  5. Export as JSONL (1 tiddler = 1 line) with S19 gate
+//  6. Write export log and manifest
 //
 // Exit codes:
-//   0 — export completed successfully
-//   1 — usage error
-//   2 — extraction error (HTML parse failure)
-//   4 — export error
+//
+//	0 — export completed successfully
+//	1 — usage error
+//	2 — extraction error (HTML parse failure)
+//	4 — export error
 //
 // Contract reference: contratos/m01-s33-single-jsonl-functional-tiddlers-from-real-html-v0.md.json
 // Ref: S14 — bridge is the integration layer
@@ -23,9 +25,12 @@
 package main
 
 import (
+	"crypto/sha256"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/tiddly-data-converter/bridge"
@@ -49,6 +54,15 @@ func main() {
 
 	if *runID == "" {
 		*runID = fmt.Sprintf("s33-run-%s", time.Now().UTC().Format("20060102T150405Z"))
+	}
+	sourceHTMLPath, err := filepath.Abs(*htmlPath)
+	if err != nil {
+		sourceHTMLPath = *htmlPath
+	}
+	sourceHTMLSHA256, err := fileSHA256Label(*htmlPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[export_tiddlers] ERROR: cannot hash %s: %v\n", *htmlPath, err)
+		os.Exit(2)
 	}
 
 	// ─── Step 1: Extract from HTML ─────────────────────────────────────────
@@ -104,6 +118,8 @@ func main() {
 	}
 
 	exportResult.Manifest.OutputPath = *outPath
+	exportResult.Manifest.SourceHTMLPath = sourceHTMLPath
+	exportResult.Manifest.SourceHTMLSHA256 = sourceHTMLSHA256
 
 	fmt.Fprintf(os.Stderr, "[export_tiddlers] Exported: %d lines, excluded: %d\n",
 		exportResult.Manifest.ExportedCount, exportResult.Manifest.ExcludedCount)
@@ -186,4 +202,18 @@ func ingestFromRaws(raws []ingesta.RawTiddler) ([]ingesta.Tiddler, *ingesta.Inge
 	}
 
 	return tiddlers, report
+}
+
+func fileSHA256Label(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("sha256:%x", hash.Sum(nil)), nil
 }

--- a/go/bridge/cmd/export_tiddlers/main_test.go
+++ b/go/bridge/cmd/export_tiddlers/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileSHA256Label(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "source.html")
+	if err := os.WriteFile(path, []byte("abc"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	got, err := fileSHA256Label(path)
+	if err != nil {
+		t.Fatalf("fileSHA256Label: %v", err)
+	}
+
+	want := "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+	if got != want {
+		t.Fatalf("hash = %q, want %q", got, want)
+	}
+}

--- a/go/canon/cmd/shard_canon/main.go
+++ b/go/canon/cmd/shard_canon/main.go
@@ -11,7 +11,8 @@ import (
 
 func main() {
 	input := flag.String("input", "", "Path to a temporary monolithic canonical JSONL file (required)")
-	outDir := flag.String("out-dir", "", "Directory where tiddlers_1..7.jsonl will be written (required)")
+	outDir := flag.String("out-dir", "", "Directory where tiddlers_<n>.jsonl shards will be written (required)")
+	maxLines := flag.Int("max-lines", canon.DefaultCanonShardMaxLines, "Maximum non-empty JSONL lines per shard")
 	flag.Parse()
 
 	if *input == "" || *outDir == "" {
@@ -20,7 +21,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	report, err := canon.WriteShardSet(*input, *outDir)
+	report, err := canon.WriteShardSetWithMaxLines(*input, *outDir, *maxLines)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[shard_canon] ERROR: %v\n", err)
 		os.Exit(2)

--- a/go/canon/derived_fields.go
+++ b/go/canon/derived_fields.go
@@ -1,10 +1,72 @@
 package canon
 
-import "strings"
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
 
 // ContentProjection carries auxiliary non-authoritative content views.
 type ContentProjection struct {
-	Plain *string `json:"plain,omitempty"`
+	ProjectionKind    string                       `json:"projection_kind,omitempty"`
+	Modalities        []string                     `json:"modalities,omitempty"`
+	Plain             *string                      `json:"plain,omitempty"`
+	Asset             *AssetContentProjection      `json:"asset,omitempty"`
+	CodeBlocks        []CodeBlockProjection        `json:"code_blocks,omitempty"`
+	Equations         []EquationProjection         `json:"equations,omitempty"`
+	References        []ReferenceProjection        `json:"references,omitempty"`
+	StructuredPayload *StructuredPayloadProjection `json:"structured_payload,omitempty"`
+}
+
+// AssetContentProjection describes a binary/reference payload without
+// duplicating the authoritative payload stored in Text.
+type AssetContentProjection struct {
+	AssetID             string `json:"asset_id,omitempty"`
+	MimeType            string `json:"mime_type,omitempty"`
+	Encoding            string `json:"encoding,omitempty"`
+	PayloadRef          string `json:"payload_ref,omitempty"`
+	PayloadPresent      bool   `json:"payload_present"`
+	PayloadByteCount    int    `json:"payload_byte_count,omitempty"`
+	PayloadSHA256       string `json:"payload_sha256,omitempty"`
+	SourceTextByteCount int    `json:"source_text_byte_count,omitempty"`
+}
+
+// CodeBlockProjection describes fenced code detected in textual content.
+type CodeBlockProjection struct {
+	Language  string `json:"language,omitempty"`
+	Text      string `json:"text"`
+	LineCount int    `json:"line_count"`
+	ByteCount int    `json:"byte_count"`
+	Source    string `json:"source"`
+}
+
+// EquationProjection describes explicit LaTeX/TiddlyWiki equation spans.
+type EquationProjection struct {
+	Notation string `json:"notation"`
+	Text     string `json:"text"`
+	Source   string `json:"source"`
+}
+
+// ReferenceProjection preserves reference targets discovered in text.
+type ReferenceProjection struct {
+	Kind   string `json:"kind"`
+	Target string `json:"target"`
+	Label  string `json:"label,omitempty"`
+	Source string `json:"source"`
+}
+
+// StructuredPayloadProjection summarizes a valid structured payload without
+// treating the summary as authoritative content.
+type StructuredPayloadProjection struct {
+	Format       string   `json:"format"`
+	Source       string   `json:"source"`
+	TopLevelType string   `json:"top_level_type"`
+	TopLevelKeys []string `json:"top_level_keys,omitempty"`
+	ArrayLength  *int     `json:"array_length,omitempty"`
 }
 
 // ApplyDerivedProjections computes S41 derived helper fields.
@@ -13,13 +75,57 @@ func ApplyDerivedProjections(e *CanonEntry) {
 		return
 	}
 
-	if plain := DeriveContentPlain(*e); plain != nil {
-		e.Content = &ContentProjection{Plain: plain}
-	} else {
-		e.Content = nil
+	e.Content = DeriveContentProjection(*e)
+	e.NormalizedTags = DeriveNormalizedTags(*e)
+}
+
+// DeriveContentProjection builds a conservative, non-authoritative content
+// projection for the material already preserved in the canonical node.
+func DeriveContentProjection(e CanonEntry) *ContentProjection {
+	projection := &ContentProjection{}
+	modalities := make(map[string]bool)
+
+	if plain := DeriveContentPlain(e); plain != nil {
+		projection.Plain = plain
+		if e.ContentType != ContentTypeJSON && e.Modality != ModalityMetadata {
+			modalities[ModalityText] = true
+		}
 	}
 
-	e.NormalizedTags = DeriveNormalizedTags(*e)
+	if asset := DeriveAssetProjection(e); asset != nil {
+		projection.Asset = asset
+		modalities[RoleAsset] = true
+	}
+
+	if e.Text != nil && !e.IsBinary {
+		if blocks := ExtractCodeBlocks(*e.Text); len(blocks) > 0 {
+			projection.CodeBlocks = blocks
+			modalities[ModalityCode] = true
+		}
+		if equations := ExtractEquations(*e.Text); len(equations) > 0 {
+			projection.Equations = equations
+			modalities[ModalityEquation] = true
+		}
+		if references := ExtractReferences(*e.Text); len(references) > 0 {
+			projection.References = references
+			modalities["reference"] = true
+		}
+		if structured := DeriveStructuredPayload(e); structured != nil {
+			projection.StructuredPayload = structured
+			modalities["structured_payload"] = true
+		}
+	}
+
+	projection.Modalities = orderedModalities(modalities)
+	if len(projection.Modalities) == 0 {
+		return nil
+	}
+	if len(projection.Modalities) == 1 {
+		projection.ProjectionKind = projection.Modalities[0]
+	} else {
+		projection.ProjectionKind = ModalityMixed
+	}
+	return projection
 }
 
 // DeriveContentPlain builds a deterministic plain-text projection from the
@@ -45,6 +151,258 @@ func DeriveContentPlain(e CanonEntry) *string {
 		return nil
 	}
 	return &normalized
+}
+
+// DeriveAssetProjection builds a payload index for asset-like nodes. It never
+// duplicates the payload; Text remains the reversible source.
+func DeriveAssetProjection(e CanonEntry) *AssetContentProjection {
+	isAssetLike := e.IsBinary || e.IsReferenceOnly || e.AssetID != "" ||
+		e.Modality == ModalityImage || e.Modality == ModalityBinary ||
+		e.ContentType == ContentTypePNG || e.ContentType == ContentTypeJPEG ||
+		e.ContentType == ContentTypeSVG || e.ContentType == ContentTypeOctetStream
+	if !isAssetLike {
+		return nil
+	}
+
+	projection := &AssetContentProjection{
+		AssetID:    e.AssetID,
+		MimeType:   firstNonEmpty(e.MimeType, e.ContentType),
+		Encoding:   e.Encoding,
+		PayloadRef: e.RawPayloadRef,
+	}
+	if e.Text == nil || strings.TrimSpace(*e.Text) == "" {
+		return projection
+	}
+
+	payload := strings.TrimSpace(*e.Text)
+	projection.PayloadPresent = true
+	projection.SourceTextByteCount = len([]byte(payload))
+
+	if e.Encoding == EncodingBase64 {
+		if decoded, ok := decodeBase64Payload(payload); ok {
+			projection.PayloadByteCount = len(decoded)
+			sum := sha256.Sum256(decoded)
+			projection.PayloadSHA256 = fmt.Sprintf("sha256:%x", sum[:])
+			return projection
+		}
+	}
+
+	sum := sha256.Sum256([]byte(payload))
+	projection.PayloadByteCount = len([]byte(payload))
+	projection.PayloadSHA256 = fmt.Sprintf("sha256:%x", sum[:])
+	return projection
+}
+
+// ExtractCodeBlocks detects fenced code blocks without interpreting the code.
+func ExtractCodeBlocks(text string) []CodeBlockProjection {
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	var blocks []CodeBlockProjection
+	inFence := false
+	language := ""
+	startLine := 0
+	var body []string
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") {
+			if !inFence {
+				inFence = true
+				language = strings.TrimSpace(strings.TrimPrefix(trimmed, "```"))
+				startLine = i + 1
+				body = nil
+				continue
+			}
+
+			blockText := strings.TrimRight(strings.Join(body, "\n"), "\n")
+			if strings.TrimSpace(blockText) != "" {
+				blocks = append(blocks, CodeBlockProjection{
+					Language:  language,
+					Text:      blockText,
+					LineCount: len(strings.Split(blockText, "\n")),
+					ByteCount: len([]byte(blockText)),
+					Source:    fmt.Sprintf("fenced_code_block:%d", startLine),
+				})
+				if len(blocks) >= 20 {
+					return blocks
+				}
+			}
+			inFence = false
+			language = ""
+			body = nil
+			continue
+		}
+		if inFence {
+			body = append(body, line)
+		}
+	}
+	return blocks
+}
+
+var (
+	displayEquationRe = regexp.MustCompile(`(?s)\$\$(.+?)\$\$`)
+	parenEquationRe   = regexp.MustCompile(`(?s)\\\((.+?)\\\)|\\\[(.+?)\\\]`)
+	latexWidgetRe     = regexp.MustCompile(`(?s)<\$latex\b([^>]*)>(.*?)</\$latex>|<\$latex\b([^>]*)/>`)
+	markdownLinkRe    = regexp.MustCompile(`\[[^\]\n]+\]\(([^)\s]+)\)`)
+	tiddlyLinkRe      = regexp.MustCompile(`\[\[([^\]\n]+)\]\]`)
+	bareURLRe         = regexp.MustCompile(`https?://[^\s<>)"\]]+`)
+	doiRe             = regexp.MustCompile(`(?i)\b10\.\d{4,9}/[-._;()/:A-Z0-9]+`)
+)
+
+// ExtractEquations detects explicit equation spans. It is conservative and
+// only recognizes standard LaTeX delimiters or the TiddlyWiki latex widget.
+func ExtractEquations(text string) []EquationProjection {
+	var equations []EquationProjection
+	seen := make(map[string]bool)
+	add := func(notation, body, source string) {
+		body = strings.TrimSpace(body)
+		if body == "" {
+			return
+		}
+		key := notation + "\x00" + body
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		equations = append(equations, EquationProjection{
+			Notation: notation,
+			Text:     body,
+			Source:   source,
+		})
+	}
+
+	for _, match := range displayEquationRe.FindAllStringSubmatch(text, -1) {
+		add("latex_display", match[1], "delimiter:$$")
+		if len(equations) >= 20 {
+			return equations
+		}
+	}
+	for _, match := range parenEquationRe.FindAllStringSubmatch(text, -1) {
+		body := match[1]
+		notation := "latex_inline"
+		source := "delimiter:\\(\\)"
+		if body == "" {
+			body = match[2]
+			notation = "latex_display"
+			source = "delimiter:\\[\\]"
+		}
+		add(notation, body, source)
+		if len(equations) >= 20 {
+			return equations
+		}
+	}
+	for _, match := range latexWidgetRe.FindAllStringSubmatch(text, -1) {
+		body := latexWidgetText(match)
+		add("tiddlywiki_latex_widget", body, "widget:<$latex>")
+		if len(equations) >= 20 {
+			return equations
+		}
+	}
+	return equations
+}
+
+// ExtractReferences detects links and reference identifiers while preserving
+// labels when the source syntax exposes them.
+func ExtractReferences(text string) []ReferenceProjection {
+	var refs []ReferenceProjection
+	seen := make(map[string]bool)
+	add := func(kind, target, label, source string) {
+		target = strings.TrimSpace(target)
+		label = strings.TrimSpace(label)
+		if target == "" {
+			return
+		}
+		key := kind + "\x00" + target + "\x00" + label
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		refs = append(refs, ReferenceProjection{
+			Kind:   kind,
+			Target: target,
+			Label:  label,
+			Source: source,
+		})
+	}
+
+	for _, match := range markdownLinkRe.FindAllStringSubmatchIndex(text, -1) {
+		label := text[match[0]+1 : match[2]-2]
+		target := text[match[2]:match[3]]
+		add(referenceKindForTarget(target), target, label, "markdown_link")
+		if len(refs) >= 50 {
+			return refs
+		}
+	}
+	for _, match := range tiddlyLinkRe.FindAllStringSubmatch(text, -1) {
+		label, target := splitTiddlyWikiLink(match[1])
+		add("tiddlywiki_link", target, label, "tw_link")
+		if len(refs) >= 50 {
+			return refs
+		}
+	}
+	for _, target := range bareURLRe.FindAllString(text, -1) {
+		add("url", strings.TrimRight(target, ".,;:"), "", "bare_url")
+		if len(refs) >= 50 {
+			return refs
+		}
+	}
+	for _, target := range doiRe.FindAllString(text, -1) {
+		add("doi", strings.TrimRight(target, ".,;:"), "", "doi")
+		if len(refs) >= 50 {
+			return refs
+		}
+	}
+	return refs
+}
+
+// DeriveStructuredPayload summarizes fully valid JSON payloads. Partial or
+// pedagogical JSON stays under Rust deep-node inspection rather than being
+// promoted here.
+func DeriveStructuredPayload(e CanonEntry) *StructuredPayloadProjection {
+	if e.Text == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*e.Text)
+	if trimmed == "" {
+		return nil
+	}
+	if e.ContentType != ContentTypeJSON && !looksLikeJSON(trimmed) {
+		return nil
+	}
+
+	var value interface{}
+	if err := json.Unmarshal([]byte(trimmed), &value); err != nil {
+		return nil
+	}
+	projection := &StructuredPayloadProjection{
+		Format: "json",
+		Source: "text",
+	}
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		projection.TopLevelType = "object"
+		for key := range typed {
+			projection.TopLevelKeys = append(projection.TopLevelKeys, key)
+		}
+		sort.Strings(projection.TopLevelKeys)
+		if len(projection.TopLevelKeys) > 20 {
+			projection.TopLevelKeys = projection.TopLevelKeys[:20]
+		}
+	case []interface{}:
+		projection.TopLevelType = "array"
+		n := len(typed)
+		projection.ArrayLength = &n
+	case string:
+		projection.TopLevelType = "string"
+	case float64:
+		projection.TopLevelType = "number"
+	case bool:
+		projection.TopLevelType = "bool"
+	case nil:
+		projection.TopLevelType = "null"
+	default:
+		projection.TopLevelType = "unknown"
+	}
+	return projection
 }
 
 // DeriveNormalizedTags builds a deterministic normalized tag projection for
@@ -91,4 +449,98 @@ func NormalizeTagsForComparison(tags []string) []string {
 		return nil
 	}
 	return normalized
+}
+
+func orderedModalities(values map[string]bool) []string {
+	order := []string{
+		ModalityText,
+		RoleAsset,
+		ModalityCode,
+		ModalityEquation,
+		"reference",
+		"structured_payload",
+	}
+	var modalities []string
+	for _, item := range order {
+		if values[item] {
+			modalities = append(modalities, item)
+			delete(values, item)
+		}
+	}
+	var extra []string
+	for item := range values {
+		extra = append(extra, item)
+	}
+	sort.Strings(extra)
+	return append(modalities, extra...)
+}
+
+func decodeBase64Payload(payload string) ([]byte, bool) {
+	cleaned := strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\r', '\t', ' ':
+			return -1
+		default:
+			return r
+		}
+	}, payload)
+	decoded, err := base64.StdEncoding.DecodeString(cleaned)
+	if err != nil {
+		return nil, false
+	}
+	return decoded, true
+}
+
+func latexWidgetText(match []string) string {
+	for _, rawAttrs := range []string{match[1], match[3]} {
+		if rawAttrs == "" {
+			continue
+		}
+		if value := attrValue(rawAttrs, "text"); value != "" {
+			return value
+		}
+	}
+	return match[2]
+}
+
+func attrValue(attrs, name string) string {
+	needle := name + "=\""
+	start := strings.Index(attrs, needle)
+	if start < 0 {
+		return ""
+	}
+	start += len(needle)
+	end := strings.Index(attrs[start:], "\"")
+	if end < 0 {
+		return ""
+	}
+	return attrs[start : start+end]
+}
+
+func splitTiddlyWikiLink(raw string) (label string, target string) {
+	parts := strings.SplitN(raw, "|", 2)
+	if len(parts) == 2 {
+		return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+	}
+	return "", strings.TrimSpace(raw)
+}
+
+func referenceKindForTarget(target string) string {
+	lower := strings.ToLower(strings.TrimSpace(target))
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return "url"
+	}
+	if strings.HasPrefix(lower, "doi:") || doiRe.MatchString(lower) {
+		return "doi"
+	}
+	return "reference"
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/go/canon/derived_fields_test.go
+++ b/go/canon/derived_fields_test.go
@@ -32,6 +32,90 @@ func TestDeriveContentPlain_BinaryNode(t *testing.T) {
 	}
 }
 
+func TestDeriveContentProjection_AssetImage(t *testing.T) {
+	text := "aGVsbG8="
+	entry := CanonEntry{
+		ID:            "11111111-1111-4111-8111-111111111111",
+		Text:          &text,
+		ContentType:   ContentTypePNG,
+		Modality:      ModalityImage,
+		Encoding:      EncodingBase64,
+		IsBinary:      true,
+		RawPayloadRef: "node:11111111-1111-4111-8111-111111111111",
+		AssetID:       "asset:11111111-1111-4111-8111-111111111111",
+		MimeType:      ContentTypePNG,
+	}
+
+	got := DeriveContentProjection(entry)
+	if got == nil || got.Asset == nil {
+		t.Fatalf("asset projection missing: %+v", got)
+	}
+	if got.Plain != nil {
+		t.Fatalf("binary asset must not emit content.plain: %+v", got.Plain)
+	}
+	if got.ProjectionKind != RoleAsset {
+		t.Fatalf("projection_kind = %q, want %q", got.ProjectionKind, RoleAsset)
+	}
+	if got.Asset.PayloadByteCount != 5 {
+		t.Fatalf("payload byte count = %d, want 5", got.Asset.PayloadByteCount)
+	}
+	wantHash := "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	if got.Asset.PayloadSHA256 != wantHash {
+		t.Fatalf("payload hash = %q, want %q", got.Asset.PayloadSHA256, wantHash)
+	}
+}
+
+func TestDeriveContentProjection_CodeEquationReferenceAndMixed(t *testing.T) {
+	text := "Ver [paper](https://example.org/paper) y la ecuacion $$E=mc^2$$:\n\n```go\nfmt.Println(\"ok\")\n```"
+	entry := CanonEntry{
+		Text:        &text,
+		ContentType: ContentTypeMarkdown,
+		Modality:    ModalityMixed,
+	}
+
+	got := DeriveContentProjection(entry)
+	if got == nil {
+		t.Fatal("content projection is nil")
+	}
+	if got.ProjectionKind != ModalityMixed {
+		t.Fatalf("projection_kind = %q, want %q", got.ProjectionKind, ModalityMixed)
+	}
+	if len(got.CodeBlocks) != 1 || got.CodeBlocks[0].Language != "go" {
+		t.Fatalf("code_blocks = %+v", got.CodeBlocks)
+	}
+	if len(got.Equations) != 1 || got.Equations[0].Text != "E=mc^2" {
+		t.Fatalf("equations = %+v", got.Equations)
+	}
+	if len(got.References) == 0 || got.References[0].Target != "https://example.org/paper" {
+		t.Fatalf("references = %+v", got.References)
+	}
+	wantModalities := []string{"text", "code", "equation", "reference"}
+	if !stringSliceEqual(got.Modalities, wantModalities) {
+		t.Fatalf("modalities = %v, want %v", got.Modalities, wantModalities)
+	}
+}
+
+func TestDeriveContentProjection_StructuredJSONPayload(t *testing.T) {
+	text := `{"meta":{"memory_policy":"active"},"items":[1,2]}`
+	entry := CanonEntry{
+		Text:        &text,
+		ContentType: ContentTypeJSON,
+		Modality:    ModalityMetadata,
+	}
+
+	got := DeriveContentProjection(entry)
+	if got == nil || got.StructuredPayload == nil {
+		t.Fatalf("structured payload projection missing: %+v", got)
+	}
+	if got.ProjectionKind != "structured_payload" {
+		t.Fatalf("projection_kind = %q, want structured_payload", got.ProjectionKind)
+	}
+	wantKeys := []string{"items", "meta"}
+	if !stringSliceEqual(got.StructuredPayload.TopLevelKeys, wantKeys) {
+		t.Fatalf("top_level_keys = %v, want %v", got.StructuredPayload.TopLevelKeys, wantKeys)
+	}
+}
+
 func TestNormalizeTagsForComparison_CaseDiacriticsEmojiAndDuplicates(t *testing.T) {
 	input := []string{
 		"  ÁRBOL  ",

--- a/go/canon/exporter_tiddler.go
+++ b/go/canon/exporter_tiddler.go
@@ -103,9 +103,11 @@ type ExportManifest struct {
 	ExcludedCount        int `json:"excluded_count"`
 	ExportedCount        int `json:"exported_count"`
 	// S38: per-rule exclusion tracking.
-	ExcludedByRule map[string]int `json:"excluded_by_rule"`
-	SHA256         string         `json:"sha256"`
-	OutputPath     string         `json:"output_path"`
+	ExcludedByRule   map[string]int `json:"excluded_by_rule"`
+	SHA256           string         `json:"sha256"`
+	OutputPath       string         `json:"output_path"`
+	SourceHTMLPath   string         `json:"source_html_path,omitempty"`
+	SourceHTMLSHA256 string         `json:"source_html_sha256,omitempty"`
 	// S35 conteos
 	ContentTypeCounts  map[string]int `json:"content_type_counts,omitempty"`
 	ModalityCounts     map[string]int `json:"modality_counts,omitempty"`

--- a/go/canon/exporter_tiddler_test.go
+++ b/go/canon/exporter_tiddler_test.go
@@ -224,7 +224,13 @@ func TestExportTiddlersJSONL_DerivedProjections(t *testing.T) {
 	if !stringSliceEqual(first.NormalizedTags, wantTags) {
 		t.Fatalf("first normalized_tags = %v, want %v", first.NormalizedTags, wantTags)
 	}
-	if second.Content != nil {
-		t.Fatalf("second content should be nil for binary node, got %+v", second.Content)
+	if second.Content == nil || second.Content.Asset == nil {
+		t.Fatalf("second content.asset should be present for binary node, got %+v", second.Content)
+	}
+	if second.Content.Plain != nil {
+		t.Fatalf("second content.plain should stay nil for binary node, got %+v", second.Content.Plain)
+	}
+	if second.Content.Asset.MimeType != ContentTypePNG || !second.Content.Asset.PayloadPresent {
+		t.Fatalf("second asset projection = %+v", second.Content.Asset)
 	}
 }

--- a/go/canon/policy_test.go
+++ b/go/canon/policy_test.go
@@ -244,6 +244,129 @@ func TestValidateStrict_InconsistentContentPlain(t *testing.T) {
 	}
 }
 
+func TestValidateStrict_InconsistentContentAsset(t *testing.T) {
+	txt := "aGVsbG8="
+	entry := CanonEntry{
+		SchemaVersion:  SchemaV0,
+		Key:            "Asset",
+		Title:          "Asset",
+		Text:           &txt,
+		ContentType:    ContentTypePNG,
+		Modality:       ModalityImage,
+		Encoding:       EncodingBase64,
+		IsBinary:       true,
+		RolePrimary:    RoleAsset,
+		RawPayloadRef:  "node:asset",
+		AssetID:        "asset:asset",
+		MimeType:       ContentTypePNG,
+		SourceType:     strPtr(ContentTypePNG),
+		SourcePosition: strPtr("html:block0:tiddler1"),
+		Content: &ContentProjection{
+			Asset: &AssetContentProjection{
+				AssetID:        "asset:asset",
+				MimeType:       ContentTypePNG,
+				Encoding:       EncodingBase64,
+				PayloadRef:     "node:asset",
+				PayloadPresent: true,
+				PayloadSHA256:  "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			},
+		},
+	}
+	if err := BuildNodeIdentity(&entry); err != nil {
+		t.Fatalf("BuildNodeIdentity: %v", err)
+	}
+	data, _ := json.Marshal(entry)
+	report := ValidateCanonJSONL(strings.NewReader(string(data)+"\n"), DefaultCanonPolicy())
+
+	if report.OK() {
+		t.Fatal("expected failure for inconsistent content.asset")
+	}
+	found := false
+	for _, issue := range report.Issues {
+		if issue.RuleID == "inconsistent-derived-content-asset" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected inconsistent-derived-content-asset issue")
+	}
+}
+
+func TestValidateStrict_ContentCodeBlocksRequireText(t *testing.T) {
+	entry := CanonEntry{
+		SchemaVersion: SchemaV0,
+		Key:           "Code",
+		Title:         "Code",
+		ContentType:   ContentTypeMarkdown,
+		Content: &ContentProjection{
+			CodeBlocks: []CodeBlockProjection{{
+				Language:  "go",
+				Text:      "fmt.Println(\"ok\")",
+				LineCount: 1,
+				ByteCount: 17,
+				Source:    "fenced_code_block:1",
+			}},
+		},
+	}
+	if err := BuildNodeIdentity(&entry); err != nil {
+		t.Fatalf("BuildNodeIdentity: %v", err)
+	}
+	data, _ := json.Marshal(entry)
+	report := ValidateCanonJSONL(strings.NewReader(string(data)+"\n"), DefaultCanonPolicy())
+
+	if report.OK() {
+		t.Fatal("expected failure for code projection without source text")
+	}
+	found := false
+	for _, issue := range report.Issues {
+		if issue.RuleID == "inconsistent-derived-content-code-blocks" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected inconsistent-derived-content-code-blocks issue")
+	}
+}
+
+func TestValidateStrict_InconsistentContentProjectionKind(t *testing.T) {
+	txt := "Hello world"
+	plain := "Hello world"
+	entry := CanonEntry{
+		SchemaVersion: SchemaV0,
+		Key:           "Text",
+		Title:         "Text",
+		Text:          &txt,
+		ContentType:   ContentTypePlain,
+		Content: &ContentProjection{
+			ProjectionKind: RoleAsset,
+			Modalities:     []string{RoleAsset},
+			Plain:          &plain,
+		},
+	}
+	if err := BuildNodeIdentity(&entry); err != nil {
+		t.Fatalf("BuildNodeIdentity: %v", err)
+	}
+	data, _ := json.Marshal(entry)
+	report := ValidateCanonJSONL(strings.NewReader(string(data)+"\n"), DefaultCanonPolicy())
+
+	if report.OK() {
+		t.Fatal("expected failure for inconsistent projection kind")
+	}
+	foundKind := false
+	foundModalities := false
+	for _, issue := range report.Issues {
+		if issue.RuleID == "inconsistent-derived-content-projection-kind" {
+			foundKind = true
+		}
+		if issue.RuleID == "inconsistent-derived-content-modalities" {
+			foundModalities = true
+		}
+	}
+	if !foundKind || !foundModalities {
+		t.Fatalf("expected projection kind and modalities issues, got %+v", report.Issues)
+	}
+}
+
 func TestValidateStrict_InconsistentNormalizedTags(t *testing.T) {
 	txt := "Hello"
 	entry := CanonEntry{

--- a/go/canon/reading_mode.go
+++ b/go/canon/reading_mode.go
@@ -1,23 +1,24 @@
 // Package canon — reading_mode.go
 //
-// S35 — canon-node-reading-mode-and-typing-v0
+// # S35 — canon-node-reading-mode-and-typing-v0
 //
 // Defines the reading mode and minimal typing layer for each node in the
 // canonical JSONL export. Every exported line must expose five reading mode
 // fields:
 //
-//   content_type      — what type of content the node carries
-//   modality          — how the node should be read (primary channel)
-//   encoding          — how the payload is represented
-//   is_binary         — whether the content requires binary treatment
-//   is_reference_only — whether the node is a reference/pointer, not content
+//	content_type      — what type of content the node carries
+//	modality          — how the node should be read (primary channel)
+//	encoding          — how the payload is represented
+//	is_binary         — whether the content requires binary treatment
+//	is_reference_only — whether the node is a reference/pointer, not content
 //
 // These five fields are complementary, not redundant.
 //
 // Dependencies on prior sessions (not reopened here):
-//   S33 — JSONL functional export (1 tiddler = 1 line)
-//   S34 — structural identity (id, key, title, canonical_slug, version_id)
-//   S30 — UUIDv5 and canonical JSON
+//
+//	S33 — JSONL functional export (1 tiddler = 1 line)
+//	S34 — structural identity (id, key, title, canonical_slug, version_id)
+//	S30 — UUIDv5 and canonical JSON
 //
 // Design principles:
 //   - Prefer fidelity over sophistication
@@ -39,18 +40,18 @@ import (
 
 // Content type catalogue (S35 §16.1).
 const (
-	ContentTypePlain         = "text/plain"
-	ContentTypeMarkdown      = "text/markdown"
-	ContentTypeHTML          = "text/html"
-	ContentTypeTiddlyWiki    = "text/vnd.tiddlywiki"
-	ContentTypeJSON          = "application/json"
-	ContentTypeCSV           = "text/csv"
-	ContentTypePNG           = "image/png"
-	ContentTypeJPEG          = "image/jpeg"
-	ContentTypeSVG           = "image/svg+xml"
-	ContentTypeOctetStream   = "application/octet-stream"
-	ContentTypeTiddler       = "application/x-tiddler"
-	ContentTypeUnknown       = "unknown"
+	ContentTypePlain       = "text/plain"
+	ContentTypeMarkdown    = "text/markdown"
+	ContentTypeHTML        = "text/html"
+	ContentTypeTiddlyWiki  = "text/vnd.tiddlywiki"
+	ContentTypeJSON        = "application/json"
+	ContentTypeCSV         = "text/csv"
+	ContentTypePNG         = "image/png"
+	ContentTypeJPEG        = "image/jpeg"
+	ContentTypeSVG         = "image/svg+xml"
+	ContentTypeOctetStream = "application/octet-stream"
+	ContentTypeTiddler     = "application/x-tiddler"
+	ContentTypeUnknown     = "unknown"
 )
 
 // Modality catalogue (S35 §16.2).
@@ -141,6 +142,14 @@ func DetectModality(contentType string, e CanonEntry) string {
 
 	switch contentType {
 	case ContentTypePlain, ContentTypeMarkdown, ContentTypeHTML, ContentTypeTiddlyWiki:
+		if e.Text != nil {
+			if blocks := ExtractCodeBlocks(*e.Text); isDominatedByCodeBlock(*e.Text, blocks) {
+				return ModalityCode
+			}
+			if hasMixedTextModalSignals(*e.Text) {
+				return ModalityMixed
+			}
+		}
 		return ModalityText
 	case ContentTypeJSON:
 		return ModalityMetadata
@@ -362,6 +371,55 @@ func isExplicitEquation(e CanonEntry) bool {
 	}
 
 	return false
+}
+
+func hasMixedTextModalSignals(text string) bool {
+	signals := 0
+	if len(ExtractCodeBlocks(text)) > 0 {
+		signals++
+	}
+	if len(ExtractEquations(text)) > 0 {
+		signals++
+	}
+	if len(ExtractReferences(text)) > 0 {
+		signals++
+	}
+	return signals > 0 && hasPlainTextOutsideModalBlocks(text)
+}
+
+func hasPlainTextOutsideModalBlocks(text string) bool {
+	withoutCode := removeFencedCodeBlocks(text)
+	withoutEquations := displayEquationRe.ReplaceAllString(withoutCode, " ")
+	withoutEquations = parenEquationRe.ReplaceAllString(withoutEquations, " ")
+	withoutLinks := markdownLinkRe.ReplaceAllString(withoutEquations, " ")
+	withoutLinks = tiddlyLinkRe.ReplaceAllString(withoutLinks, " ")
+	withoutLinks = bareURLRe.ReplaceAllString(withoutLinks, " ")
+	withoutLinks = doiRe.ReplaceAllString(withoutLinks, " ")
+	return strings.TrimSpace(withoutLinks) != ""
+}
+
+func isDominatedByCodeBlock(text string, blocks []CodeBlockProjection) bool {
+	if len(blocks) != 1 {
+		return false
+	}
+	trimmed := strings.TrimSpace(text)
+	return strings.HasPrefix(trimmed, "```") && strings.HasSuffix(trimmed, "```")
+}
+
+func removeFencedCodeBlocks(text string) string {
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	var kept []string
+	inFence := false
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inFence = !inFence
+			continue
+		}
+		if !inFence {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
 }
 
 // looksLikeBase64 checks if text content appears to be base64-encoded.

--- a/go/canon/reading_mode_test.go
+++ b/go/canon/reading_mode_test.go
@@ -219,6 +219,24 @@ func TestDetectModality_TiddlyWiki_NotEquation(t *testing.T) {
 	}
 }
 
+func TestDetectModality_CodeFencePrimary(t *testing.T) {
+	text := "```go\nfmt.Println(\"ok\")\n```"
+	e := CanonEntry{Key: "code", Title: "Code", Text: &text}
+	got := DetectModality(ContentTypeMarkdown, e)
+	if got != ModalityCode {
+		t.Errorf("DetectModality = %q, want %q", got, ModalityCode)
+	}
+}
+
+func TestDetectModality_MixedTextWithReferenceAndCode(t *testing.T) {
+	text := "Ver [[Nodo técnico]]\n\n```sh\ntdc doctor\n```"
+	e := CanonEntry{Key: "mixed", Title: "Mixed", Text: &text}
+	got := DetectModality(ContentTypeMarkdown, e)
+	if got != ModalityMixed {
+		t.Errorf("DetectModality = %q, want %q", got, ModalityMixed)
+	}
+}
+
 // Binary → modality binary.
 func TestDetectModality_Binary(t *testing.T) {
 	text := "raw bytes"

--- a/go/canon/shard_canon.go
+++ b/go/canon/shard_canon.go
@@ -7,164 +7,79 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 )
 
 const (
-	SessionTitlePrefix    = "#### 🌀 Sesión "
-	HypothesisTitlePrefix = "#### 🌀🧪 Hipótesis de sesión "
-	ProvenanceTitlePrefix = "#### 🌀🧾 Procedencia de sesión "
-
-	auxShardMaxLines = 144
+	// DefaultCanonShardMaxLines is the local canon shard policy for S78+.
+	// Shards are sequential tiddlers_<n>.jsonl files and each contains at most
+	// this many non-empty JSONL lines.
+	DefaultCanonShardMaxLines = 100
 )
 
-var auxShardOrder = []int{1, 5, 6, 7}
-
-var shard3PinnedTitles = map[string]struct{}{
-	"#### 🌀📦 Hipótesis de dependencias = m01":   {},
-	"#### 🌀📦 Política de dependencias":          {},
-	"#### 🌀📦 Procedencia de dependencias = m01": {},
-	"#### 🌀📦 Registro de dependencias críticas": {},
-}
-
-var shard4PinnedTitles = map[string]struct{}{
-	"#### 📚 Diccionario 🌀.csv":       {},
-	"#### referencias especificas 🌀": {},
-}
-
-var shard4ReferenceTitlePattern = regexp.MustCompile(`^\d{2}\. `)
-
-// ShardCanonReport captures the deterministic shard layout inferred from the
-// authoritative S44 corpus.
+// ShardCanonReport captures the deterministic shard layout produced from a
+// monolithic canonical JSONL stream.
 type ShardCanonReport struct {
-	LinesRead        int            `json:"lines_read"`
-	SessionCount     int            `json:"session_count"`
-	HypothesisCount  int            `json:"hypothesis_count"`
-	ProvenanceCount  int            `json:"provenance_count"`
-	RemainingCount   int            `json:"remaining_count"`
-	ShardLineCounts  map[string]int `json:"shard_line_counts"`
-	AuxShardMaxLines int            `json:"aux_shard_max_lines"`
-	ShardOrder       []string       `json:"shard_order"`
+	LinesRead       int            `json:"lines_read"`
+	ShardLineCounts map[string]int `json:"shard_line_counts"`
+	ShardMaxLines   int            `json:"shard_max_lines"`
+	ShardOrder      []string       `json:"shard_order"`
+	PolicyID        string         `json:"policy_id"`
 }
 
 type shardCanonLine struct {
 	Title string `json:"title"`
 }
 
-// ShardCanonJSONL splits a canonical JSONL stream into the S44 shard layout:
-// session records in shard 2, hypotheses in 3, provenance in 4, and the
-// remaining corpus in order across shards 1, 5, 6 and 7.
+// ShardCanonJSONL splits a canonical JSONL stream into sequential shards using
+// the default S78+ policy of DefaultCanonShardMaxLines lines per file.
 func ShardCanonJSONL(r io.Reader) (map[string][]string, ShardCanonReport, error) {
+	return ShardCanonJSONLWithMaxLines(r, DefaultCanonShardMaxLines)
+}
+
+// ShardCanonJSONLWithMaxLines splits a canonical JSONL stream into sequential
+// tiddlers_<n>.jsonl shards with at most maxLines non-empty lines per shard.
+func ShardCanonJSONLWithMaxLines(r io.Reader, maxLines int) (map[string][]string, ShardCanonReport, error) {
 	report := ShardCanonReport{
-		ShardLineCounts:  make(map[string]int, 7),
-		AuxShardMaxLines: auxShardMaxLines,
-		ShardOrder: []string{
-			"tiddlers_1.jsonl",
-			"tiddlers_2.jsonl",
-			"tiddlers_3.jsonl",
-			"tiddlers_4.jsonl",
-			"tiddlers_5.jsonl",
-			"tiddlers_6.jsonl",
-			"tiddlers_7.jsonl",
-		},
+		ShardLineCounts: make(map[string]int),
+		ShardMaxLines:   maxLines,
+		PolicyID:        "sequential-max-lines-v0",
 	}
-	shards := map[string][]string{
-		"tiddlers_1.jsonl": {},
-		"tiddlers_2.jsonl": {},
-		"tiddlers_3.jsonl": {},
-		"tiddlers_4.jsonl": {},
-		"tiddlers_5.jsonl": {},
-		"tiddlers_6.jsonl": {},
-		"tiddlers_7.jsonl": {},
+	shards := make(map[string][]string)
+	if maxLines <= 0 {
+		return nil, report, fmt.Errorf("shard max lines must be positive, got %d", maxLines)
 	}
 
-	var shard3Pinned []string
-	var shard3Hypotheses []string
-	var shard4Provenance []string
-	var shard4Pinned []string
-	var remaining []string
+	var currentShard string
 	scanner := bufio.NewScanner(r)
 	buf := make([]byte, 0, 1024*1024)
 	scanner.Buffer(buf, 64*1024*1024)
 
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
+		rawLine := scanner.Text()
+		if strings.TrimSpace(rawLine) == "" {
 			continue
 		}
 		report.LinesRead++
 
 		var parsed shardCanonLine
-		if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+		if err := json.Unmarshal([]byte(rawLine), &parsed); err != nil {
 			return nil, report, fmt.Errorf("line %d: parse title: %w", report.LinesRead, err)
 		}
 		if strings.TrimSpace(parsed.Title) == "" {
 			return nil, report, fmt.Errorf("line %d: title is empty", report.LinesRead)
 		}
 
-		switch {
-		case strings.HasPrefix(parsed.Title, SessionTitlePrefix):
-			shards["tiddlers_2.jsonl"] = append(shards["tiddlers_2.jsonl"], line)
-			report.SessionCount++
-		case belongsInShard3(parsed.Title):
-			shard3Pinned = append(shard3Pinned, line)
-			report.HypothesisCount++
-		case strings.HasPrefix(parsed.Title, HypothesisTitlePrefix):
-			shard3Hypotheses = append(shard3Hypotheses, line)
-			report.HypothesisCount++
-		case belongsInShard4(parsed.Title):
-			shard4Pinned = append(shard4Pinned, line)
-			report.ProvenanceCount++
-		case strings.HasPrefix(parsed.Title, ProvenanceTitlePrefix):
-			shard4Provenance = append(shard4Provenance, line)
-			report.ProvenanceCount++
-		default:
-			remaining = append(remaining, line)
-			report.RemainingCount++
+		shardIndex := ((report.LinesRead - 1) / maxLines) + 1
+		shardName := fmt.Sprintf("tiddlers_%d.jsonl", shardIndex)
+		if shardName != currentShard {
+			currentShard = shardName
+			report.ShardOrder = append(report.ShardOrder, shardName)
 		}
+		shards[shardName] = append(shards[shardName], rawLine)
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, report, fmt.Errorf("scan canon jsonl: %w", err)
-	}
-
-	maxRemaining := auxShardMaxLines * len(auxShardOrder)
-	if len(remaining) > maxRemaining {
-		return nil, report, fmt.Errorf(
-			"remaining corpus has %d lines, exceeds S44 auxiliary shard capacity of %d",
-			len(remaining),
-			maxRemaining,
-		)
-	}
-
-	shards["tiddlers_3.jsonl"] = append(shards["tiddlers_3.jsonl"], shard3Pinned...)
-	shards["tiddlers_3.jsonl"] = append(shards["tiddlers_3.jsonl"], shard3Hypotheses...)
-	shards["tiddlers_4.jsonl"] = append(shards["tiddlers_4.jsonl"], shard4Provenance...)
-	shards["tiddlers_4.jsonl"] = append(shards["tiddlers_4.jsonl"], shard4Pinned...)
-
-	cursor := 0
-	for idx, shardNumber := range auxShardOrder {
-		filename := fmt.Sprintf("tiddlers_%d.jsonl", shardNumber)
-		count := auxShardMaxLines
-		if idx == 0 && len(remaining)%auxShardMaxLines != 0 {
-			count = len(remaining) % auxShardMaxLines
-		}
-		if len(remaining) == 0 {
-			count = 0
-		}
-		if idx > 0 && cursor >= len(remaining) {
-			count = 0
-		}
-		if count > len(remaining)-cursor {
-			count = len(remaining) - cursor
-		}
-		if count < 0 {
-			count = 0
-		}
-		if count > 0 {
-			shards[filename] = append(shards[filename], remaining[cursor:cursor+count]...)
-			cursor += count
-		}
 	}
 
 	for shardName, lines := range shards {
@@ -173,20 +88,13 @@ func ShardCanonJSONL(r io.Reader) (map[string][]string, ShardCanonReport, error)
 	return shards, report, nil
 }
 
-func belongsInShard3(title string) bool {
-	_, ok := shard3PinnedTitles[title]
-	return ok
-}
-
-func belongsInShard4(title string) bool {
-	if _, ok := shard4PinnedTitles[title]; ok {
-		return true
-	}
-	return shard4ReferenceTitlePattern.MatchString(title)
-}
-
-// WriteShardSet writes the seven S44 canon shard files to outDir.
+// WriteShardSet writes the S78+ sequential canon shard set to outDir.
 func WriteShardSet(inputPath, outDir string) (ShardCanonReport, error) {
+	return WriteShardSetWithMaxLines(inputPath, outDir, DefaultCanonShardMaxLines)
+}
+
+// WriteShardSetWithMaxLines writes the sequential canon shard set to outDir.
+func WriteShardSetWithMaxLines(inputPath, outDir string, maxLines int) (ShardCanonReport, error) {
 	report := ShardCanonReport{}
 
 	inFile, err := os.Open(inputPath)
@@ -195,7 +103,7 @@ func WriteShardSet(inputPath, outDir string) (ShardCanonReport, error) {
 	}
 	defer inFile.Close()
 
-	shards, shardReport, err := ShardCanonJSONL(inFile)
+	shards, shardReport, err := ShardCanonJSONLWithMaxLines(inFile, maxLines)
 	if err != nil {
 		return report, err
 	}
@@ -203,6 +111,9 @@ func WriteShardSet(inputPath, outDir string) (ShardCanonReport, error) {
 
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return report, fmt.Errorf("create output dir %s: %w", outDir, err)
+	}
+	if err := removeExistingCanonShards(outDir); err != nil {
+		return report, err
 	}
 
 	for _, shardName := range report.ShardOrder {
@@ -218,4 +129,24 @@ func WriteShardSet(inputPath, outDir string) (ShardCanonReport, error) {
 	}
 
 	return report, nil
+}
+
+func removeExistingCanonShards(outDir string) error {
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		return fmt.Errorf("read output dir %s: %w", outDir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if _, ok := parseCanonShardFilename(entry.Name()); !ok {
+			continue
+		}
+		target := filepath.Join(outDir, entry.Name())
+		if err := os.Remove(target); err != nil {
+			return fmt.Errorf("remove stale shard %s: %w", target, err)
+		}
+	}
+	return nil
 }

--- a/go/canon/shard_canon_test.go
+++ b/go/canon/shard_canon_test.go
@@ -2,77 +2,70 @@ package canon
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestShardCanonJSONL_ClassifiesSessionFamilies(t *testing.T) {
-	input := strings.Join([]string{
-		`{"title":"_README.md"}`,
-		`{"title":"#### 🌀📦 Política de dependencias"}`,
-		`{"title":"#### 🌀 Sesión 44 = canon-sharded-homogeneous-records-and-robust-reverse-v0"}`,
-		`{"title":"#### 🌀🧪 Hipótesis de sesión 44 = canon-sharded-homogeneous-records-and-robust-reverse-v0"}`,
-		`{"title":"#### 🌀🧾 Procedencia de sesión 44"}`,
-		`{"title":"#### referencias especificas 🌀"}`,
-		`{"title":"01. Reference title"}`,
-		`{"title":"go/canon/example.go"}`,
-	}, "\n") + "\n"
+func TestShardCanonJSONL_SequentialDefaultMaxLines(t *testing.T) {
+	input := shardTestInput(205)
 
 	shards, report, err := ShardCanonJSONL(strings.NewReader(input))
 	if err != nil {
 		t.Fatalf("ShardCanonJSONL() error = %v", err)
 	}
 
-	if report.SessionCount != 1 || len(shards["tiddlers_2.jsonl"]) != 1 {
-		t.Fatalf("session shard mismatch: report=%d shard=%d", report.SessionCount, len(shards["tiddlers_2.jsonl"]))
+	if report.PolicyID != "sequential-max-lines-v0" {
+		t.Fatalf("policy_id = %q, want sequential-max-lines-v0", report.PolicyID)
 	}
-	if report.HypothesisCount != 2 || len(shards["tiddlers_3.jsonl"]) != 2 {
-		t.Fatalf("hypothesis shard mismatch: report=%d shard=%d", report.HypothesisCount, len(shards["tiddlers_3.jsonl"]))
+	if report.ShardMaxLines != DefaultCanonShardMaxLines {
+		t.Fatalf("shard max lines = %d, want %d", report.ShardMaxLines, DefaultCanonShardMaxLines)
 	}
-	if report.ProvenanceCount != 3 || len(shards["tiddlers_4.jsonl"]) != 3 {
-		t.Fatalf("provenance shard mismatch: report=%d shard=%d", report.ProvenanceCount, len(shards["tiddlers_4.jsonl"]))
+	wantOrder := []string{"tiddlers_1.jsonl", "tiddlers_2.jsonl", "tiddlers_3.jsonl"}
+	if !stringSliceEqual(report.ShardOrder, wantOrder) {
+		t.Fatalf("shard order = %v, want %v", report.ShardOrder, wantOrder)
 	}
-	if got := len(shards["tiddlers_1.jsonl"]); got != 2 {
-		t.Fatalf("tiddlers_1.jsonl count = %d, want 2", got)
+	if report.ShardLineCounts["tiddlers_1.jsonl"] != 100 {
+		t.Fatalf("tiddlers_1.jsonl count = %d, want 100", report.ShardLineCounts["tiddlers_1.jsonl"])
 	}
-	if !strings.Contains(shards["tiddlers_3.jsonl"][0], `"title":"#### 🌀📦 Política de dependencias"`) {
-		t.Fatalf("shard 3 pinned block order mismatch: %q", shards["tiddlers_3.jsonl"][0])
+	if report.ShardLineCounts["tiddlers_2.jsonl"] != 100 {
+		t.Fatalf("tiddlers_2.jsonl count = %d, want 100", report.ShardLineCounts["tiddlers_2.jsonl"])
 	}
-	if !strings.Contains(shards["tiddlers_4.jsonl"][0], `"title":"#### 🌀🧾 Procedencia de sesión 44"`) {
-		t.Fatalf("shard 4 provenance-first order mismatch: %q", shards["tiddlers_4.jsonl"][0])
+	if report.ShardLineCounts["tiddlers_3.jsonl"] != 5 {
+		t.Fatalf("tiddlers_3.jsonl count = %d, want 5", report.ShardLineCounts["tiddlers_3.jsonl"])
+	}
+	if _, exists := shards["tiddlers_4.jsonl"]; exists {
+		t.Fatal("unexpected empty tiddlers_4.jsonl shard")
+	}
+	if !strings.Contains(shards["tiddlers_1.jsonl"][0], `"title":"node-000"`) {
+		t.Fatalf("first line not preserved: %q", shards["tiddlers_1.jsonl"][0])
+	}
+	if !strings.Contains(shards["tiddlers_3.jsonl"][4], `"title":"node-204"`) {
+		t.Fatalf("last line not preserved: %q", shards["tiddlers_3.jsonl"][4])
 	}
 }
 
-func TestShardCanonJSONL_PreservesRemainingOrderAcrossAuxShards(t *testing.T) {
-	var lines []string
-	for i := 0; i < 290; i++ {
-		lines = append(lines, fmt.Sprintf(`{"title":"node-%03d"}`, i))
-	}
-	input := strings.Join(lines, "\n") + "\n"
+func TestShardCanonJSONLWithMaxLines_PreservesOrder(t *testing.T) {
+	input := shardTestInput(5)
 
-	shards, report, err := ShardCanonJSONL(strings.NewReader(input))
+	shards, report, err := ShardCanonJSONLWithMaxLines(strings.NewReader(input), 3)
 	if err != nil {
-		t.Fatalf("ShardCanonJSONL() error = %v", err)
+		t.Fatalf("ShardCanonJSONLWithMaxLines() error = %v", err)
 	}
 
-	if report.ShardLineCounts["tiddlers_1.jsonl"] != 2 {
-		t.Fatalf("tiddlers_1.jsonl count = %d, want 2", report.ShardLineCounts["tiddlers_1.jsonl"])
+	wantOrder := []string{"tiddlers_1.jsonl", "tiddlers_2.jsonl"}
+	if !stringSliceEqual(report.ShardOrder, wantOrder) {
+		t.Fatalf("shard order = %v, want %v", report.ShardOrder, wantOrder)
 	}
-	if report.ShardLineCounts["tiddlers_5.jsonl"] != 144 {
-		t.Fatalf("tiddlers_5.jsonl count = %d, want 144", report.ShardLineCounts["tiddlers_5.jsonl"])
+	if report.ShardLineCounts["tiddlers_1.jsonl"] != 3 {
+		t.Fatalf("tiddlers_1.jsonl count = %d, want 3", report.ShardLineCounts["tiddlers_1.jsonl"])
 	}
-	if report.ShardLineCounts["tiddlers_6.jsonl"] != 144 {
-		t.Fatalf("tiddlers_6.jsonl count = %d, want 144", report.ShardLineCounts["tiddlers_6.jsonl"])
+	if report.ShardLineCounts["tiddlers_2.jsonl"] != 2 {
+		t.Fatalf("tiddlers_2.jsonl count = %d, want 2", report.ShardLineCounts["tiddlers_2.jsonl"])
 	}
-	if report.ShardLineCounts["tiddlers_7.jsonl"] != 0 {
-		t.Fatalf("tiddlers_7.jsonl count = %d, want 0", report.ShardLineCounts["tiddlers_7.jsonl"])
-	}
-
-	if !strings.Contains(shards["tiddlers_1.jsonl"][0], `"title":"node-000"`) {
-		t.Fatalf("first auxiliary line not preserved: %q", shards["tiddlers_1.jsonl"][0])
-	}
-	if !strings.Contains(shards["tiddlers_6.jsonl"][143], `"title":"node-289"`) {
-		t.Fatalf("last filled auxiliary line not preserved: %q", shards["tiddlers_6.jsonl"][143])
+	if !strings.Contains(shards["tiddlers_2.jsonl"][0], `"title":"node-003"`) {
+		t.Fatalf("first second-shard line not preserved: %q", shards["tiddlers_2.jsonl"][0])
 	}
 }
 
@@ -83,14 +76,65 @@ func TestShardCanonJSONL_FailsOnInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestShardCanonJSONL_FailsWhenAuxCapacityExceeded(t *testing.T) {
-	var builder strings.Builder
-	for i := 0; i < (auxShardMaxLines*len(auxShardOrder))+1; i++ {
-		builder.WriteString(`{"title":"node-overflow"}` + "\n")
+func TestShardCanonJSONLWithMaxLines_FailsOnInvalidLimit(t *testing.T) {
+	_, _, err := ShardCanonJSONLWithMaxLines(strings.NewReader(shardTestInput(1)), 0)
+	if err == nil {
+		t.Fatal("expected invalid limit error")
+	}
+}
+
+func TestWriteShardSetWithMaxLines_ReplacesOnlyCanonShards(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputPath := filepath.Join(tmpDir, "tiddlers.export.jsonl")
+	outDir := filepath.Join(tmpDir, "canon")
+	if err := os.WriteFile(inputPath, []byte(shardTestInput(3)), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("mkdir out: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "tiddlers_99.jsonl"), []byte(`{"title":"stale"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write stale shard: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "notes.txt"), []byte("keep me\n"), 0o644); err != nil {
+		t.Fatalf("write non-shard file: %v", err)
 	}
 
-	_, _, err := ShardCanonJSONL(strings.NewReader(builder.String()))
-	if err == nil {
-		t.Fatal("expected overflow error")
+	report, err := WriteShardSetWithMaxLines(inputPath, outDir, 2)
+	if err != nil {
+		t.Fatalf("WriteShardSetWithMaxLines() error = %v", err)
 	}
+
+	if _, err := os.Stat(filepath.Join(outDir, "tiddlers_99.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("stale shard should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "notes.txt")); err != nil {
+		t.Fatalf("non-shard file should remain: %v", err)
+	}
+	if report.ShardLineCounts["tiddlers_1.jsonl"] != 2 || report.ShardLineCounts["tiddlers_2.jsonl"] != 1 {
+		t.Fatalf("unexpected shard line counts: %v", report.ShardLineCounts)
+	}
+	if got := countShardTestLines(t, filepath.Join(outDir, "tiddlers_1.jsonl")); got != 2 {
+		t.Fatalf("tiddlers_1.jsonl lines = %d, want 2", got)
+	}
+	if got := countShardTestLines(t, filepath.Join(outDir, "tiddlers_2.jsonl")); got != 1 {
+		t.Fatalf("tiddlers_2.jsonl lines = %d, want 1", got)
+	}
+}
+
+func shardTestInput(count int) string {
+	var lines []string
+	for i := 0; i < count; i++ {
+		lines = append(lines, fmt.Sprintf(`{"title":"node-%03d"}`, i))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func countShardTestLines(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return len(strings.Split(strings.TrimSpace(string(data)), "\n"))
 }

--- a/go/canon/validator.go
+++ b/go/canon/validator.go
@@ -257,6 +257,123 @@ func validateLine(lineNum int, data []byte, policy CanonPolicy) []ValidationIssu
 			Severity: "error",
 		})
 	}
+	if entry.Content != nil && entry.Content.Asset != nil {
+		expected := DeriveAssetProjection(entry)
+		if !reflect.DeepEqual(entry.Content.Asset, expected) {
+			issues = append(issues, ValidationIssue{
+				Line:     lineNum,
+				Field:    "content",
+				RuleID:   "inconsistent-derived-content-asset",
+				Message:  "content.asset does not match deterministic asset projection",
+				Severity: "error",
+			})
+		}
+	}
+	if entry.Content != nil && len(entry.Content.CodeBlocks) > 0 {
+		if entry.Text == nil {
+			issues = append(issues, ValidationIssue{
+				Line:     lineNum,
+				Field:    "content",
+				RuleID:   "inconsistent-derived-content-code-blocks",
+				Message:  "content.code_blocks requires source text",
+				Severity: "error",
+			})
+		} else {
+			expected := ExtractCodeBlocks(*entry.Text)
+			if !reflect.DeepEqual(entry.Content.CodeBlocks, expected) {
+				issues = append(issues, ValidationIssue{
+					Line:     lineNum,
+					Field:    "content",
+					RuleID:   "inconsistent-derived-content-code-blocks",
+					Message:  "content.code_blocks does not match deterministic code block projection",
+					Severity: "error",
+				})
+			}
+		}
+	}
+	if entry.Content != nil && len(entry.Content.Equations) > 0 {
+		if entry.Text == nil {
+			issues = append(issues, ValidationIssue{
+				Line:     lineNum,
+				Field:    "content",
+				RuleID:   "inconsistent-derived-content-equations",
+				Message:  "content.equations requires source text",
+				Severity: "error",
+			})
+		} else {
+			expected := ExtractEquations(*entry.Text)
+			if !reflect.DeepEqual(entry.Content.Equations, expected) {
+				issues = append(issues, ValidationIssue{
+					Line:     lineNum,
+					Field:    "content",
+					RuleID:   "inconsistent-derived-content-equations",
+					Message:  "content.equations does not match deterministic equation projection",
+					Severity: "error",
+				})
+			}
+		}
+	}
+	if entry.Content != nil && len(entry.Content.References) > 0 {
+		if entry.Text == nil {
+			issues = append(issues, ValidationIssue{
+				Line:     lineNum,
+				Field:    "content",
+				RuleID:   "inconsistent-derived-content-references",
+				Message:  "content.references requires source text",
+				Severity: "error",
+			})
+		} else {
+			expected := ExtractReferences(*entry.Text)
+			if !reflect.DeepEqual(entry.Content.References, expected) {
+				issues = append(issues, ValidationIssue{
+					Line:     lineNum,
+					Field:    "content",
+					RuleID:   "inconsistent-derived-content-references",
+					Message:  "content.references does not match deterministic reference projection",
+					Severity: "error",
+				})
+			}
+		}
+	}
+	if entry.Content != nil && entry.Content.StructuredPayload != nil {
+		expected := DeriveStructuredPayload(entry)
+		if !reflect.DeepEqual(entry.Content.StructuredPayload, expected) {
+			issues = append(issues, ValidationIssue{
+				Line:     lineNum,
+				Field:    "content",
+				RuleID:   "inconsistent-derived-content-structured-payload",
+				Message:  "content.structured_payload does not match deterministic structured payload projection",
+				Severity: "error",
+			})
+		}
+	}
+	if entry.Content != nil && (entry.Content.ProjectionKind != "" || len(entry.Content.Modalities) > 0) {
+		expected := DeriveContentProjection(entry)
+		expectedProjectionKind := ""
+		var expectedModalities []string
+		if expected != nil {
+			expectedProjectionKind = expected.ProjectionKind
+			expectedModalities = expected.Modalities
+		}
+		if entry.Content.ProjectionKind != "" && entry.Content.ProjectionKind != expectedProjectionKind {
+			issues = append(issues, ValidationIssue{
+				Line:     lineNum,
+				Field:    "content",
+				RuleID:   "inconsistent-derived-content-projection-kind",
+				Message:  fmt.Sprintf("content.projection_kind %q does not match deterministic recomputation %q", entry.Content.ProjectionKind, expectedProjectionKind),
+				Severity: "error",
+			})
+		}
+		if len(entry.Content.Modalities) > 0 && !reflect.DeepEqual(entry.Content.Modalities, expectedModalities) {
+			issues = append(issues, ValidationIssue{
+				Line:     lineNum,
+				Field:    "content",
+				RuleID:   "inconsistent-derived-content-modalities",
+				Message:  fmt.Sprintf("content.modalities do not match deterministic recomputation (got %v, expected %v)", entry.Content.Modalities, expectedModalities),
+				Severity: "error",
+			})
+		}
+	}
 
 	expectedNormalizedTags := DeriveNormalizedTags(entry)
 	if len(entry.NormalizedTags) > 0 && !reflect.DeepEqual(entry.NormalizedTags, expectedNormalizedTags) {

--- a/python_scripts/admit_session_candidates.py
+++ b/python_scripts/admit_session_candidates.py
@@ -23,6 +23,7 @@ from path_governance import (
     REPO_ROOT,
     as_display_path,
     resolve_repo_path,
+    sorted_canon_shards,
 )
 
 
@@ -236,7 +237,7 @@ def _read_jsonl(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]
 
 def _canon_hash(canon_dir: Path) -> str:
     digest = hashlib.sha256()
-    shard_paths = sorted(canon_dir.glob("tiddlers_*.jsonl"))
+    shard_paths = sorted_canon_shards(canon_dir)
     for shard in shard_paths:
         digest.update(shard.name.encode("utf-8"))
         digest.update(b"\0")
@@ -556,7 +557,7 @@ def _load_canon_index(canon_dir: Path) -> CanonIndex:
     by_hash: dict[str, list[CanonRecord]] = {}
     by_title: dict[str, list[CanonRecord]] = {}
 
-    for shard_path in sorted(canon_dir.glob("tiddlers_*.jsonl")):
+    for shard_path in sorted_canon_shards(canon_dir):
         with shard_path.open("r", encoding="utf-8") as handle:
             for line_no, raw in enumerate(handle, start=1):
                 line = raw.strip()
@@ -1008,7 +1009,7 @@ def _prepare_admitted_lines(entries: list[CandidateEntry], work_dir: Path) -> tu
 
 
 def _copy_canon_shards(canon_dir: Path, target_dir: Path) -> list[Path]:
-    shard_paths = sorted(canon_dir.glob("tiddlers_*.jsonl"))
+    shard_paths = sorted_canon_shards(canon_dir)
     if not shard_paths:
         raise RuntimeError(f"no canon shard files found under {as_display_path(canon_dir)}")
 
@@ -1179,7 +1180,7 @@ def _run_canon_proposal_validate(candidate_file: Path, canon_dir: Path) -> Comma
 
 
 def _replace_canon_from_tmp(canon_dir: Path, tmp_canon_dir: Path) -> None:
-    target_shards = sorted(tmp_canon_dir.glob("tiddlers_*.jsonl"))
+    target_shards = sorted_canon_shards(tmp_canon_dir)
     if not target_shards:
         raise RuntimeError("temporary canon has no shard files")
 
@@ -1508,7 +1509,7 @@ def _run_dry_pipeline(args: argparse.Namespace, mode: str) -> tuple[int, dict[st
     if mode == "apply":
         backup_dir = report_dir / "backups" / run_id
         backup_dir.mkdir(parents=True, exist_ok=True)
-        for shard in sorted(canon_dir.glob("tiddlers_*.jsonl")):
+        for shard in sorted_canon_shards(canon_dir):
             shutil.copy2(shard, backup_dir / shard.name)
 
         if normalized_lines:
@@ -1575,7 +1576,7 @@ def _handle_apply(args: argparse.Namespace) -> int:
 
 def _remove_ids_from_canon(canon_dir: Path, ids_to_remove: set[str]) -> tuple[int, list[str]]:
     removed_ids: list[str] = []
-    for shard_path in sorted(canon_dir.glob("tiddlers_*.jsonl")):
+    for shard_path in sorted_canon_shards(canon_dir):
         kept_lines: list[str] = []
         with shard_path.open("r", encoding="utf-8") as handle:
             for raw in handle:
@@ -1742,7 +1743,7 @@ def _handle_rollback(args: argparse.Namespace) -> int:
         report["removed_count"] = removed_count
         report["removed_ids"] = removed_ids
     if replacement_records and not backup_shards_available:
-        target_shards = sorted(tmp_canon_dir.glob("tiddlers_*.jsonl"))
+        target_shards = sorted_canon_shards(tmp_canon_dir)
         if not target_shards:
             report["warnings"].append("temporary canon has no shard files for replacement restore")
             report["canon_after_hash"] = report["canon_before_hash"]
@@ -1833,7 +1834,7 @@ def _handle_rollback(args: argparse.Namespace) -> int:
     if not args.dry_run:
         backup_dir = report_dir / "backups" / f"{run_id}-pre"
         backup_dir.mkdir(parents=True, exist_ok=True)
-        for shard in sorted(canon_dir.glob("tiddlers_*.jsonl")):
+        for shard in sorted_canon_shards(canon_dir):
             shutil.copy2(shard, backup_dir / shard.name)
         _replace_canon_from_tmp(canon_dir, tmp_canon_dir)
         report["backup_dir"] = as_display_path(backup_dir)

--- a/python_scripts/audit_normative_projection.py
+++ b/python_scripts/audit_normative_projection.py
@@ -53,6 +53,7 @@ from path_governance import (
     DEFAULT_CANON_DIR,
     DEFAULT_ENRICHED_DIR,
     resolve_repo_path,
+    sorted_canon_shards,
 )
 
 # ── Session metadata ──────────────────────────────────────────────────────────
@@ -97,7 +98,7 @@ RECOGNIZED_CONTENT_TYPES = {
 
 def load_canon_shards(input_root: Path) -> list[dict]:
     """Load all canon shard records preserving shard order."""
-    shards = sorted(input_root.glob("tiddlers_*.jsonl"))
+    shards = sorted_canon_shards(input_root)
     records = []
     for shard in shards:
         for lineno, line in enumerate(shard.read_text(encoding="utf-8").splitlines(), 1):
@@ -974,9 +975,11 @@ def main():
     ai_role_map = {r.get("id"): r.get("role_primary") for r in ai_records if r.get("id")}
     chunk_source_ids = {c.get("source_id") or c.get("tiddler_id") for c in chunks if c.get("source_id") or c.get("tiddler_id")}
 
-    inputs_read = [
-        str(input_root / f"tiddlers_{i}.jsonl") for i in range(1, 8) if (input_root / f"tiddlers_{i}.jsonl").exists()
-    ] + [str(enriched_dir), str(ai_dir), str(reports_dir)]
+    inputs_read = [str(path) for path in sorted_canon_shards(input_root)] + [
+        str(enriched_dir),
+        str(ai_dir),
+        str(reports_dir),
+    ]
 
     # ── Step 3: Evaluate rules ────────────────────────────────────────────────
     print("[audit] Evaluating normative rules…")

--- a/python_scripts/canon_proposal.py
+++ b/python_scripts/canon_proposal.py
@@ -18,6 +18,7 @@ from path_governance import (
     ensure_runtime_directories,
     proposals_path,
     resolve_repo_path,
+    sorted_canon_shards,
 )
 
 
@@ -149,7 +150,7 @@ def _load_canon_index(canon_dir: Path) -> tuple[set[str], set[str], set[str]]:
     ids: set[str] = set()
     keys: set[str] = set()
     titles: set[str] = set()
-    for shard_path in sorted(canon_dir.glob("tiddlers_*.jsonl")):
+    for shard_path in sorted_canon_shards(canon_dir):
         for raw_line in shard_path.read_text(encoding="utf-8").splitlines():
             line = raw_line.strip()
             if not line:

--- a/python_scripts/corpus_governance.py
+++ b/python_scripts/corpus_governance.py
@@ -20,6 +20,7 @@ from path_governance import (
     DEFAULT_REMOTE_OUT_DIR,
     DEFAULT_REVERSE_HTML_DIR,
     as_display_path,
+    sorted_canon_shards,
 )
 
 
@@ -142,7 +143,7 @@ def _iter_jsonl(path: Path) -> list[dict]:
 
 def _load_canon_records(canon_dir: Path) -> list[dict]:
     records: list[dict] = []
-    for shard_path in sorted(canon_dir.glob("tiddlers_*.jsonl")):
+    for shard_path in sorted_canon_shards(canon_dir):
         records.extend(_iter_jsonl(shard_path))
     return records
 

--- a/python_scripts/derive_layers.py
+++ b/python_scripts/derive_layers.py
@@ -72,6 +72,7 @@ from path_governance import (
     DEFAULT_MICROSOFT_COPILOT_DIR,
     as_display_path,
     resolve_repo_path,
+    sorted_canon_shards,
 )
 
 # ── Derivation session identifier ────────────────────────────────────────────
@@ -1367,7 +1368,7 @@ def validate_relations(relations: list, known_ids: set) -> tuple:
 
 def discover_shards(input_dir: Path) -> list:
     """Discover all canon shards matching tiddlers_*.jsonl pattern."""
-    shards = sorted(input_dir.glob("tiddlers_*.jsonl"))
+    shards = sorted_canon_shards(input_dir)
     if not shards:
         print(f"ERROR: No tiddlers_*.jsonl shards found in {input_dir}", file=sys.stderr)
         sys.exit(1)

--- a/python_scripts/operator_menu.py
+++ b/python_scripts/operator_menu.py
@@ -30,6 +30,7 @@ from path_governance import (  # noqa: E402
     DEFAULT_REVERSE_REPORT,
     REPO_ROOT,
     as_display_path,
+    sorted_canon_shards,
 )
 from session_sync import DEFAULT_SESSION_SYNC_DIR, scan_session_sync  # noqa: E402
 
@@ -40,8 +41,10 @@ DEFAULT_ADMISSION_TMP_DIR = DEFAULT_TMP_DIR / "session_admission"
 DEFAULT_ADMISSION_REPORT_DIR = DEFAULT_TMP_DIR / "admissions"
 HTML_EXPORT_DIR = DEFAULT_TMP_DIR / "html_export"
 RECONSTRUCTION_DIR = DEFAULT_TMP_DIR / "reconstruction"
+QUALITY_REPORT_DIR = DEFAULT_TMP_DIR / "canonical_quality"
 MAIN_SEED_HTML = REPO_ROOT / "data" / "in" / "objeto_de_estudio_trazabilidad_y_desarrollo.html"
 BOOTSTRAP_AUX_HTML = REPO_ROOT / "data" / "in" / "empty-store.html"
+CANON_SHARD_MAX_LINES = 100
 
 
 @dataclass
@@ -58,6 +61,7 @@ class MenuState:
     selected_html: Path | None = None
     last_export_jsonl: Path | None = None
     last_reconstruction_report: Path | None = None
+    last_reverse_report: Path | None = None
     last_sync_inventory: dict[str, Any] | None = None
     last_sync_candidate_file: Path | None = None
     last_validate_report: Path | None = None
@@ -181,20 +185,55 @@ def canonical_file_hash(path: Path) -> str:
     return f"sha256:{digest.hexdigest()}"
 
 
-def canon_tree_hash(canon_dir: Path = DEFAULT_CANON_DIR) -> str:
+def file_content_hash(path: Path) -> str:
     digest = hashlib.sha256()
-    for shard in canon_shards(canon_dir):
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def canon_tree_manifest(canon_dir: Path = DEFAULT_CANON_DIR) -> dict[str, Any]:
+    digest = hashlib.sha256()
+    shards = canon_shards(canon_dir)
+    shard_entries: list[dict[str, Any]] = []
+    for shard in shards:
+        data_hash = hashlib.sha256()
+        byte_count = 0
         digest.update(shard.name.encode("utf-8"))
         digest.update(b"\0")
         with shard.open("rb") as handle:
             for chunk in iter(lambda: handle.read(1024 * 1024), b""):
                 digest.update(chunk)
+                data_hash.update(chunk)
+                byte_count += len(chunk)
         digest.update(b"\0")
-    return f"sha256:{digest.hexdigest()}"
+        shard_entries.append(
+            {
+                "path": as_display_path(shard),
+                "name": shard.name,
+                "line_count": count_jsonl_lines(shard),
+                "byte_count": byte_count,
+                "sha256": f"sha256:{data_hash.hexdigest()}",
+            }
+        )
+    return {
+        "root": as_display_path(canon_dir),
+        "hash": f"sha256:{digest.hexdigest()}",
+        "shard_count": len(shards),
+        "line_count": sum(item["line_count"] for item in shard_entries),
+        "byte_count": sum(item["byte_count"] for item in shard_entries),
+        "shards": shard_entries,
+        "has_real_content": bool(shards) and any(item["byte_count"] > 0 for item in shard_entries),
+    }
+
+
+def canon_tree_hash(canon_dir: Path = DEFAULT_CANON_DIR) -> str:
+    return str(canon_tree_manifest(canon_dir)["hash"])
 
 
 def canon_shards(canon_dir: Path = DEFAULT_CANON_DIR) -> list[Path]:
-    return sorted(canon_dir.glob("tiddlers_*.jsonl"))
+    return sorted_canon_shards(canon_dir)
 
 
 def canon_summary(canon_dir: Path = DEFAULT_CANON_DIR) -> dict[str, Any]:
@@ -269,6 +308,9 @@ def run_reconstruction_gate(
     *,
     requires_backup: bool,
     requires_hash_report: bool,
+    input_jsonl: Path | None = None,
+    reconstruction_run_dir: Path | None = None,
+    report_dir: Path | None = None,
     show_result: bool = True,
 ) -> tuple[bool, dict[str, Any] | None, CommandResult | None]:
     if not shutil.which("cargo"):
@@ -276,32 +318,56 @@ def run_reconstruction_gate(
         return False, None, None
 
     role = source_role_for_html(source_html)
-    result = run_command(
+    args = [
+        "cargo",
+        "run",
+        "--quiet",
+        "--bin",
+        "audit",
+        "--",
+        "reconstruction-plan",
+        str(REPO_ROOT),
+        "--source-html",
+        str(source_html),
+        "--source-role",
+        role,
+        "--mode",
+        mode,
+        "--output-target",
+        str(output_target),
+    ]
+    if input_jsonl is not None:
+        args.extend(["--input-jsonl", str(input_jsonl)])
+    if reconstruction_run_dir is not None:
+        args.extend(["--reconstruction-run-dir", str(reconstruction_run_dir)])
+    args.extend(
         [
-            "cargo",
-            "run",
-            "--quiet",
-            "--bin",
-            "audit",
-            "--",
-            "reconstruction-plan",
-            str(REPO_ROOT),
-            "--source-html",
-            str(source_html),
-            "--source-role",
-            role,
-            "--mode",
-            mode,
-            "--output-target",
-            str(output_target),
             "--requires-backup",
             "true" if requires_backup else "false",
             "--requires-hash-report",
             "true" if requires_hash_report else "false",
-        ],
-        cwd=REPO_ROOT / "rust" / "doctor",
+        ]
     )
+    result = run_command(args, cwd=REPO_ROOT / "rust" / "doctor")
     payload = parse_stdout_json_payload(result.stdout)
+    if payload is not None and report_dir is not None:
+        report_dir.mkdir(parents=True, exist_ok=True)
+        gate_report = {
+            "run_id": report_dir.name,
+            "timestamp": stamp_now(),
+            "report_kind": "rust_reconstruction_gate",
+            "source_html": as_display_path(source_html),
+            "source_role": role,
+            "mode": mode,
+            "output_target": as_display_path(output_target),
+            "input_jsonl": as_display_path(input_jsonl) if input_jsonl else None,
+            "backup_required": requires_backup,
+            "hash_report_required": requires_hash_report,
+            "gate_verdict": payload.get("verdict"),
+            "gate_exit_code": result.returncode,
+            "gate_report": payload,
+        }
+        write_json(report_dir / "gate-report.json", gate_report)
     if show_result:
         verdict = payload.get("verdict") if payload else "sin_json"
         errors = payload.get("errors") if payload else "-"
@@ -309,6 +375,10 @@ def run_reconstruction_gate(
         print(f"- fuente: {display(source_html)} ({describe_source_role(role)})")
         print(f"- modo: {mode}")
         print(f"- destino: {display(output_target)}")
+        if input_jsonl is not None:
+            print(f"- JSONL temporal: {display(input_jsonl)}")
+        if report_dir is not None:
+            print(f"- reporte gate: {display(report_dir / 'gate-report.json')}")
         print(f"- veredicto: {verdict}")
         print(f"- errores: {errors}")
         if result.returncode != 0:
@@ -322,12 +392,66 @@ def write_reconstruction_report(run_dir: Path, payload: dict[str, Any]) -> Path:
     return report_path
 
 
+def copy_canon_shards(run_dir: Path, name: str, canon_dir: Path = DEFAULT_CANON_DIR) -> Path:
+    snapshot_dir = run_dir / name
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    for existing in snapshot_dir.glob("tiddlers_*.jsonl"):
+        existing.unlink()
+    for shard in canon_shards(canon_dir):
+        shutil.copy2(shard, snapshot_dir / shard.name)
+    return snapshot_dir
+
+
 def backup_canon_shards(run_dir: Path) -> Path:
-    backup_dir = run_dir / "canon_before"
-    backup_dir.mkdir(parents=True, exist_ok=True)
-    for shard in canon_shards(DEFAULT_CANON_DIR):
-        shutil.copy2(shard, backup_dir / shard.name)
-    return backup_dir
+    return copy_canon_shards(run_dir, "canon_before", DEFAULT_CANON_DIR)
+
+
+def latest_reconstruction_reports(rollback_only: bool = False) -> list[Path]:
+    reports = recent_files([RECONSTRUCTION_DIR], "reconstruction-report.json", limit=80)
+    selected: list[Path] = []
+    for path in reports:
+        try:
+            payload = load_json(path)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if rollback_only and not payload.get("rollback_ready"):
+            continue
+        selected.append(path)
+    return selected[:12]
+
+
+def reverse_rejected_count(report_path: Path) -> int | None:
+    try:
+        payload = load_json(report_path)
+    except (OSError, json.JSONDecodeError):
+        return None
+    value = payload.get("rejected_count", payload.get("rejected"))
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def reverse_evidence_report(state: MenuState | None = None) -> Path | None:
+    candidates: list[Path] = []
+    if state and state.last_reverse_report and state.last_reverse_report.exists():
+        candidates.append(state.last_reverse_report)
+    if DEFAULT_REVERSE_REPORT.exists():
+        candidates.append(DEFAULT_REVERSE_REPORT)
+    candidates.extend(recent_files([DEFAULT_CANON_DIR / "reverse_html", RECONSTRUCTION_DIR], "reverse-report.json", limit=8))
+    for path in candidates:
+        if path.exists() and reverse_rejected_count(path) == 0:
+            return path
+    return None
+
+
+def derivative_continuity_ok(state: MenuState | None = None) -> tuple[bool, str, Path | None]:
+    report = reverse_evidence_report(state)
+    if not report:
+        return False, "no hay reporte reverse reciente con Rejected: 0", None
+    return True, "ok", report
 
 
 def choose_html(state: MenuState) -> Path | None:
@@ -399,7 +523,26 @@ def summarize_report(path: Path) -> str:
             f"run_id={payload.get('run_id')}, "
             f"gate={payload.get('gate_verdict')}, "
             f"shard_exit={payload.get('shard_exit_code')}, "
+            f"post_validation={payload.get('post_shard_validation_ok')}, "
+            f"rollback_ready={payload.get('rollback_ready')}, "
             f"canon_modified={payload.get('canon_modified')}"
+        )
+
+    if payload.get("report_kind") == "rust_reconstruction_gate":
+        return (
+            f"run_id={payload.get('run_id')}, "
+            f"mode={payload.get('mode')}, "
+            f"gate={payload.get('gate_verdict')}, "
+            f"exit={payload.get('gate_exit_code')}"
+        )
+
+    if payload.get("mode") == "reverse_projection":
+        return (
+            f"run_id={payload.get('run_id')}, "
+            f"gate={payload.get('gate_verdict')}, "
+            f"reverse_exit={payload.get('reverse_exit_code')}, "
+            f"reverse_rejected={payload.get('reverse_rejected')}, "
+            f"derivatives_ready={payload.get('derivatives_ready')}"
         )
 
     parts = []
@@ -484,12 +627,14 @@ def option_build_from_html(state: MenuState) -> None:
     print("Flujo: HTML vivo -> JSONL temporal -> shards canonicos locales -> validacion")
     selected = choose_html(state)
     if selected:
+        run_dir = RECONSTRUCTION_DIR / f"diagnostic-{stamp_now()}"
         run_reconstruction_gate(
             selected,
             "diagnostic",
             DEFAULT_TMP_DIR / "reconstruction_plan",
             requires_backup=False,
             requires_hash_report=False,
+            report_dir=run_dir,
         )
         print(f"HTML seleccionado: {display(selected)}")
         print("Siguiente paso recomendado: opcion 4 para extraer a JSONL temporal.")
@@ -504,12 +649,14 @@ def option_extract_html(state: MenuState) -> None:
     out_jsonl = out_dir / "tiddlers.export.jsonl"
     out_log = out_dir / "tiddlers.export.log"
     manifest = out_dir / "tiddlers.export.manifest.json"
+    gate_report_dir = RECONSTRUCTION_DIR / run_id
     gate_ok, _, _ = run_reconstruction_gate(
         html,
         "staging",
         out_dir,
         requires_backup=False,
         requires_hash_report=True,
+        report_dir=gate_report_dir,
     )
     if not gate_ok:
         print("Extraccion bloqueada por la compuerta Rust. No se escribio salida temporal.")
@@ -537,10 +684,29 @@ def option_extract_html(state: MenuState) -> None:
     print_command_result(result)
     if result.returncode == 0:
         state.last_export_jsonl = out_jsonl
+        write_reconstruction_report(
+            gate_report_dir,
+            {
+                "run_id": run_id,
+                "timestamp": stamp_now(),
+                "mode": "staging",
+                "source_html": as_display_path(html),
+                "source_role": source_role_for_html(html),
+                "source_html_hash": file_content_hash(html),
+                "input_jsonl": as_display_path(out_jsonl),
+                "input_jsonl_hash": file_content_hash(out_jsonl),
+                "output_target": as_display_path(out_dir),
+                "export_manifest": as_display_path(manifest),
+                "gate_report": as_display_path(gate_report_dir / "gate-report.json"),
+                "export_exit_code": result.returncode,
+                "rollback_ready": False,
+            },
+        )
         print("\nSalidas temporales:")
         print(f"- JSONL: {display(out_jsonl)} ({count_jsonl_lines(out_jsonl)} lineas)")
         print(f"- log: {display(out_log)}")
         print(f"- manifest: {display(manifest)}")
+        print(f"- reporte reconstruccion: {display(gate_report_dir / 'reconstruction-report.json')}")
         print("Siguiente paso recomendado: opcion 5 para shardizar si quieres reconstruir el canon local.")
     else:
         print("Extraccion fallida. No se escribio el canon.")
@@ -571,6 +737,9 @@ def option_shard_jsonl(state: MenuState) -> None:
         DEFAULT_CANON_DIR,
         requires_backup=True,
         requires_hash_report=True,
+        input_jsonl=selected,
+        reconstruction_run_dir=run_dir,
+        report_dir=run_dir,
     )
     if not gate_ok:
         print("Shardizacion bloqueada por la compuerta Rust. No se modifico el canon.")
@@ -578,6 +747,7 @@ def option_shard_jsonl(state: MenuState) -> None:
 
     print("\nAdvertencia: esta opcion escribe shards en data/out/local.")
     print("JSONL temporal != canon; los shards en data/out/local son el canon local oficial.")
+    print(f"Politica de shardizacion: maximo {CANON_SHARD_MAX_LINES} lineas por archivo.")
     print(f"Fuente HTML declarada: {display(html)}")
     print(f"JSONL temporal: {display(selected)}")
     print(f"Destino de salida: {display(DEFAULT_CANON_DIR)}")
@@ -588,9 +758,51 @@ def option_shard_jsonl(state: MenuState) -> None:
         return
 
     run_dir.mkdir(parents=True, exist_ok=True)
-    before_hash = canon_tree_hash(DEFAULT_CANON_DIR)
+    before_manifest = canon_tree_manifest(DEFAULT_CANON_DIR)
+    before_hash = str(before_manifest["hash"])
     backup_dir = backup_canon_shards(run_dir)
+    backup_manifest = canon_tree_manifest(backup_dir)
+    backup_matches_before = backup_manifest["hash"] == before_hash
+    before_had_canon = before_manifest["shard_count"] > 0 and before_manifest["has_real_content"]
+    empty_before_authorized = backup_matches_before and before_manifest["shard_count"] == 0
+    backup_usable = (
+        backup_matches_before
+        and before_had_canon
+        and backup_manifest["has_real_content"]
+    )
+    if not backup_usable and not empty_before_authorized:
+        report_path = write_reconstruction_report(
+            run_dir,
+            {
+                "run_id": run_id,
+                "timestamp": stamp_now(),
+                "mode": "write_local_canon",
+                "source_html": as_display_path(html),
+                "source_role": source_role_for_html(html),
+                "input_jsonl": as_display_path(selected),
+                "output_target": as_display_path(DEFAULT_CANON_DIR),
+                "backup_dir": as_display_path(backup_dir),
+                "canon_before": before_manifest,
+                "canon_before_hash": before_hash,
+                "backup_manifest": backup_manifest,
+                "backup_matches_before": backup_matches_before,
+                "empty_before_authorized": empty_before_authorized,
+                "gate_verdict": gate_payload.get("verdict") if gate_payload else None,
+                "gate_report": gate_payload,
+                "gate_exit_code": gate_result.returncode if gate_result else None,
+                "shard_exit_code": None,
+                "status": "blocked_backup_unusable",
+                "rollback_ready": False,
+            },
+        )
+        state.last_reconstruction_report = report_path
+        print("Shardizacion bloqueada: el backup no representa un canon previo real y verificable.")
+        print(f"Reporte de reconstruccion: {display(report_path)}")
+        return
+    if empty_before_authorized:
+        print("Canon previo vacio detectado: se conservara evidencia before/after, sin rollback a canon previo real.")
     input_hash = canonical_file_hash(selected)
+    input_content_hash = file_content_hash(selected)
 
     result = run_command(
         [
@@ -601,39 +813,91 @@ def option_shard_jsonl(state: MenuState) -> None:
             str(selected),
             "--out-dir",
             str(DEFAULT_CANON_DIR),
+            "--max-lines",
+            str(CANON_SHARD_MAX_LINES),
         ],
         cwd=REPO_ROOT / "go" / "canon",
     )
     print_command_result(result)
-    after_hash = canon_tree_hash(DEFAULT_CANON_DIR)
+    after_manifest = canon_tree_manifest(DEFAULT_CANON_DIR)
+    after_hash = str(after_manifest["hash"])
+    after_dir = copy_canon_shards(run_dir, "canon_after", DEFAULT_CANON_DIR)
+    after_snapshot_manifest = canon_tree_manifest(after_dir)
+    strict_result: CommandResult | None = None
+    strict_payload: dict[str, Any] | None = None
+    reverse_preflight_result: CommandResult | None = None
+    reverse_preflight_payload: dict[str, Any] | None = None
+    if result.returncode == 0:
+        print("\nValidacion post-shardizacion: strict")
+        strict_result = run_preflight("strict")
+        print_command_result(strict_result)
+        strict_payload = parse_stdout_json_payload(strict_result.stdout)
+
+        print("\nValidacion post-shardizacion: reverse-preflight")
+        reverse_preflight_result = run_preflight("reverse-preflight")
+        print_command_result(reverse_preflight_result)
+        reverse_preflight_payload = parse_stdout_json_payload(reverse_preflight_result.stdout)
+
+    validation_ok = (
+        result.returncode == 0
+        and strict_result is not None
+        and strict_result.returncode == 0
+        and reverse_preflight_result is not None
+        and reverse_preflight_result.returncode == 0
+    )
     report_path = write_reconstruction_report(
         run_dir,
         {
             "run_id": run_id,
             "timestamp": stamp_now(),
+            "mode": "write_local_canon",
             "source_html": as_display_path(html),
             "source_role": source_role_for_html(html),
+            "source_html_hash": file_content_hash(html),
             "input_jsonl": as_display_path(selected),
             "input_jsonl_hash": input_hash,
+            "input_jsonl_content_hash": input_content_hash,
             "output_target": as_display_path(DEFAULT_CANON_DIR),
             "backup_dir": as_display_path(backup_dir),
+            "canon_after_dir": as_display_path(after_dir),
+            "canon_before": before_manifest,
+            "canon_after": after_manifest,
+            "backup_manifest": backup_manifest,
+            "canon_after_snapshot": after_snapshot_manifest,
             "canon_before_hash": before_hash,
             "canon_after_hash": after_hash,
+            "shard_max_lines": CANON_SHARD_MAX_LINES,
+            "backup_matches_before": backup_matches_before,
+            "empty_before_authorized": empty_before_authorized,
             "gate_verdict": gate_payload.get("verdict") if gate_payload else None,
             "gate_report": gate_payload,
             "gate_exit_code": gate_result.returncode if gate_result else None,
             "shard_exit_code": result.returncode,
+            "shard_report": parse_stdout_json_payload(result.stdout),
+            "strict_exit_code": strict_result.returncode if strict_result else None,
+            "strict_report": strict_payload,
+            "reverse_preflight_exit_code": reverse_preflight_result.returncode if reverse_preflight_result else None,
+            "reverse_preflight_report": reverse_preflight_payload,
+            "post_shard_validation_ok": validation_ok,
+            "reverse_required_for_derivatives": True,
+            "derivatives_ready": False,
+            "rollback_ready": backup_usable,
             "canon_modified": before_hash != after_hash,
         },
     )
     state.last_reconstruction_report = report_path
     print(f"\nReporte de reconstruccion: {display(report_path)}")
     print(f"- backup: {display(backup_dir)}")
+    print(f"- canon_after: {display(after_dir)}")
     print(f"- hash before: {before_hash}")
     print(f"- hash after:  {after_hash}")
     if result.returncode == 0:
         option_canon_status()
-        print("Siguiente paso recomendado: opcion 6 para validar el canon.")
+        if validation_ok:
+            print("Cadena post-shardizacion OK: strict + reverse-preflight.")
+            print("Siguiente paso recomendado: opcion 9 para ejecutar reverse. Derivados siguen bloqueados hasta Rejected: 0.")
+        else:
+            print("Continuidad bloqueada: strict y reverse-preflight deben pasar antes de reverse o derivados.")
 
 
 def run_preflight(mode: str) -> CommandResult:
@@ -660,6 +924,158 @@ def option_validate_canon() -> bool:
 
     print("\nEstado final: OK. Condicion critica esperada: not_ready=0 y Rejected=0 en reverse.")
     return True
+
+
+def run_doctor_quality_report(kind: str, input_path: Path, report_path: Path) -> tuple[CommandResult | None, dict[str, Any] | None]:
+    if not shutil.which("cargo"):
+        print("Compuerta Rust bloqueada: cargo no esta disponible.")
+        return None, None
+    result = run_command(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "--bin",
+            "audit",
+            "--",
+            kind,
+            str(REPO_ROOT),
+            "--input",
+            str(input_path),
+            "--report",
+            str(report_path),
+        ],
+        cwd=REPO_ROOT / "rust" / "doctor",
+    )
+    payload = parse_stdout_json_payload(result.stdout)
+    if payload is None and report_path.exists():
+        try:
+            payload = load_json(report_path)
+        except (OSError, json.JSONDecodeError):
+            payload = None
+    return result, payload
+
+
+def option_canon_quality() -> None:
+    run_dir = QUALITY_REPORT_DIR / f"quality-{stamp_now()}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    line_report = run_dir / "canonical-line-gate.json"
+    deep_report = run_dir / "deep-node-inspect.json"
+
+    print("\nAuditoria Rust de calidad canonica")
+    print("No escribe data/out/local; solo emite reportes bajo data/tmp/canonical_quality.")
+
+    line_result, line_payload = run_doctor_quality_report(
+        "canonical-line-gate",
+        DEFAULT_CANON_DIR,
+        line_report,
+    )
+    if line_payload:
+        counts = line_payload.get("counts") or {}
+        print("\nCanonical-line gate:")
+        print(f"- reporte: {display(line_report)}")
+        print(f"- veredicto: {line_payload.get('verdict')}")
+        print(f"- lineas leidas: {line_payload.get('lines_read')}")
+        print(f"- ok: {counts.get('canon_line_ok', 0)}")
+        print(f"- warning: {counts.get('canon_line_warning', 0)}")
+        print(f"- incomplete: {counts.get('canon_line_incomplete', 0)}")
+        print(f"- inconsistent: {counts.get('canon_line_inconsistent', 0)}")
+        print(f"- rejected: {counts.get('canon_line_rejected', 0)}")
+        print(f"- familias con deriva: {len(line_payload.get('template_families_with_drift') or [])}")
+        print(f"- perfiles de familia: {len(line_payload.get('family_profiles') or [])}")
+        modal = line_payload.get("modal_projection_audit") or {}
+        if modal:
+            print("- auditoria modal:")
+            print(f"  - lineas relevantes: {modal.get('relevant_lines', 0)}")
+            print(f"  - proyectadas: {modal.get('projected_lines', 0)}")
+            print(f"  - sin proyeccion: {modal.get('missing_projection_lines', 0)}")
+            projection_counts = modal.get("projection_counts") or {}
+            if projection_counts:
+                summary = ", ".join(f"{key}={value}" for key, value in sorted(projection_counts.items()))
+                print(f"  - proyecciones: {summary}")
+        debt = line_payload.get("debt_summary") or {}
+        if debt:
+            print("- separacion de deuda:")
+            print(f"  - deuda modal: {debt.get('modal_debt_lines', 0)} lineas")
+            print(f"  - deuda modal de assets: {debt.get('asset_modal_debt_lines', 0)} lineas")
+            print(f"  - deriva historica de plantillas: {debt.get('template_drift_families_historical', 0)} familias")
+            print(f"  - warnings de riqueza: {debt.get('richness_warning_lines', 0)} lineas")
+        triage = line_payload.get("incomplete_line_triage") or []
+        print(f"- triage de incompletas: {len(triage)} grupos")
+        for item in triage[:5]:
+            print(
+                f"  - {item.get('family')}: {item.get('line_count')} "
+                f"lineas, prioridad={item.get('priority')}, razon={item.get('reason')}"
+            )
+    else:
+        print("Canonical-line gate no produjo JSON parseable.")
+        if line_result:
+            print_command_result(line_result, max_chars=1600)
+
+    deep_result, deep_payload = run_doctor_quality_report(
+        "deep-node-inspect",
+        DEFAULT_CANON_DIR,
+        deep_report,
+    )
+    if deep_payload:
+        counts = deep_payload.get("counts") or {}
+        print("\nDeep-node inspector:")
+        print(f"- reporte: {display(deep_report)}")
+        print(f"- veredicto: {deep_payload.get('verdict')}")
+        print(f"- nodos leidos: {deep_payload.get('nodes_read')}")
+        print(f"- campos inspeccionados: {deep_payload.get('inspected_text_fields')}")
+        print(f"- hallazgos: {deep_payload.get('findings_count')}")
+        print(f"- JSON estructural: {counts.get('structural_json', 0)}")
+        print(f"- JSON valido: {counts.get('valid_json', 0)}")
+        print(f"- JSON recuperable: {counts.get('recoverable_json', 0)}")
+        print(f"- fragmentos JSON: {counts.get('json_fragment', 0)}")
+        print(f"- JSON pedagogico/fixture: {counts.get('pedagogical_json', 0)}")
+        print(f"- JSON invalido/reportable: {counts.get('invalid_json', 0)}")
+        print(f"- tablas markdown: {counts.get('markdown_table', 0)}")
+    else:
+        print("Deep-node inspector no produjo JSON parseable.")
+        if deep_result:
+            print_command_result(deep_result, max_chars=1600)
+
+    print("\nSiguiente paso recomendado: revisar reportes y decidir si alguna familia requiere hardening posterior.")
+
+
+def option_modal_delta_staging() -> None:
+    run_id = f"s77-modal-assets-{stamp_now()}"
+    normalized_jsonl = DEFAULT_TMP_DIR / "s76-modal-export" / "local-normalized-modal.jsonl"
+    print("\nStaging de delta modal controlado")
+    print("Compara canon vivo contra la copia normalizada S76 y no modifica data/out/local.")
+    if not normalized_jsonl.exists():
+        print(f"No existe la copia normalizada esperada: {display(normalized_jsonl)}")
+        return
+
+    result = run_command(
+        [
+            sys.executable,
+            "python_scripts/stage_modal_delta.py",
+            "--run-id",
+            run_id,
+            "--run-gates",
+        ],
+        cwd=REPO_ROOT,
+    )
+    print_command_result(result)
+    payload = parse_stdout_json(result.stdout)
+    if not payload:
+        print("El staging no produjo resumen JSON parseable.")
+        return
+
+    print("\nResultado:")
+    print(f"- reporte: {payload.get('report')}")
+    print(f"- patch JSONL: {payload.get('patch_jsonl')}")
+    print(f"- staged canon: {payload.get('staged_canon_dir')}")
+    print(f"- lineas cambiadas en comparacion S76: {payload.get('changed_line_count')}")
+    print(f"- delta seleccionado: {payload.get('selected_count')}")
+    gates = payload.get("gates") or {}
+    print(f"- strict: {gates.get('strict')}")
+    print(f"- reverse-preflight: {gates.get('reverse_preflight')}")
+    print(f"- reverse: {gates.get('reverse_authoritative')} (Rejected: {gates.get('reverse_rejected')})")
+    print("- canon modificado: no")
 
 
 def print_inventory_summary(inventory: dict[str, Any]) -> None:
@@ -866,9 +1282,14 @@ def option_session_sync(state: MenuState) -> None:
             print("Opcion invalida.")
 
 
-def option_derivatives() -> None:
+def option_derivatives(state: MenuState) -> None:
     print("\nDerivados: canon local -> derivados")
     print("Los derivados no son fuente de verdad y no escriben al canon.")
+    continuity_ok, reason, reverse_report = derivative_continuity_ok(state)
+    if continuity_ok and reverse_report:
+        print(f"- evidencia reverse: OK ({display(reverse_report)}, Rejected: 0)")
+    else:
+        print(f"- evidencia reverse: BLOQUEADA - {reason}")
     for path in (DEFAULT_ENRICHED_DIR, DEFAULT_AI_DIR, DEFAULT_MICROSOFT_COPILOT_DIR, DEFAULT_AUDIT_DIR, DEFAULT_EXPORT_DIR):
         print(f"- {display(path)}: {'OK' if path.exists() else 'no existe'}")
 
@@ -878,6 +1299,9 @@ def option_derivatives() -> None:
     print("0) Volver")
     choice = prompt("> ").strip()
     if choice == "1":
+        if not continuity_ok:
+            print("Generacion bloqueada: ejecuta reverse y exige Rejected: 0 antes de derivados.")
+            return
         confirmation = prompt("Escribe DERIVE para generar derivados locales: ").strip()
         if confirmation != "DERIVE":
             print("Generacion cancelada.")
@@ -942,12 +1366,14 @@ def option_reverse(state: MenuState) -> None:
     html = choose_html(state)
     if not html:
         return
-    gate_ok, _, _ = run_reconstruction_gate(
+    run_dir = RECONSTRUCTION_DIR / f"reverse-{stamp_now()}"
+    gate_ok, gate_payload, gate_result = run_reconstruction_gate(
         html,
         "reverse_projection",
         DEFAULT_REVERSE_HTML,
         requires_backup=False,
         requires_hash_report=True,
+        report_dir=run_dir,
     )
     if not gate_ok:
         print("Reverse bloqueado por la compuerta Rust.")
@@ -984,14 +1410,51 @@ def option_reverse(state: MenuState) -> None:
         cwd=REPO_ROOT / "go" / "bridge",
     )
     print_command_result(result)
+    reverse_payload: dict[str, Any] | None = None
     if DEFAULT_REVERSE_REPORT.exists():
         print(f"\nReporte: {display(DEFAULT_REVERSE_REPORT)}")
         print(summarize_report(DEFAULT_REVERSE_REPORT))
         try:
-            payload = load_json(DEFAULT_REVERSE_REPORT)
-            print(f"Rejected: {payload.get('rejected_count', payload.get('rejected', '-'))}")
+            reverse_payload = load_json(DEFAULT_REVERSE_REPORT)
+            rejected = reverse_payload.get("rejected_count", reverse_payload.get("rejected", "-"))
+            print(f"Rejected: {rejected}")
         except (OSError, json.JSONDecodeError):
             pass
+    reverse_rejected = None
+    if reverse_payload:
+        try:
+            reverse_rejected = int(reverse_payload.get("rejected_count", reverse_payload.get("rejected")))
+        except (TypeError, ValueError):
+            reverse_rejected = None
+    reverse_ok = result.returncode == 0 and reverse_rejected == 0
+    report_path = write_reconstruction_report(
+        run_dir,
+        {
+            "run_id": run_dir.name,
+            "timestamp": stamp_now(),
+            "mode": "reverse_projection",
+            "source_html": as_display_path(html),
+            "source_role": source_role_for_html(html),
+            "source_html_hash": file_content_hash(html),
+            "output_target": as_display_path(DEFAULT_REVERSE_HTML),
+            "gate_verdict": gate_payload.get("verdict") if gate_payload else None,
+            "gate_report": gate_payload,
+            "gate_exit_code": gate_result.returncode if gate_result else None,
+            "reverse_preflight_exit_code": preflight.returncode,
+            "reverse_preflight_report": parse_stdout_json_payload(preflight.stdout),
+            "reverse_exit_code": result.returncode,
+            "reverse_report_path": as_display_path(DEFAULT_REVERSE_REPORT),
+            "reverse_result": reverse_payload,
+            "reverse_rejected": reverse_rejected,
+            "derivatives_ready": reverse_ok,
+            "rollback_ready": False,
+        },
+    )
+    state.last_reverse_report = DEFAULT_REVERSE_REPORT if reverse_ok else report_path
+    if reverse_ok:
+        print("Reverse OK con Rejected: 0. Continuidad hacia derivados habilitada.")
+    else:
+        print("Continuidad hacia derivados bloqueada: reverse debe terminar con Rejected: 0.")
 
 
 def option_reports() -> None:
@@ -1000,6 +1463,7 @@ def option_reports() -> None:
         DEFAULT_ADMISSION_REPORT_DIR,
         DEFAULT_SESSION_SYNC_DIR,
         RECONSTRUCTION_DIR,
+        QUALITY_REPORT_DIR,
         DEFAULT_CANON_DIR / "reverse_html",
     ]
     reports = recent_files(roots, "*.json", limit=16)
@@ -1044,6 +1508,120 @@ def option_rollback() -> None:
     print_command_result(result)
 
 
+def run_reconstruction_rollback_gate(report_path: Path) -> tuple[bool, dict[str, Any] | None, CommandResult | None]:
+    if not shutil.which("cargo"):
+        print("Compuerta Rust bloqueada: cargo no esta disponible.")
+        return False, None, None
+    result = run_command(
+        [
+            "cargo",
+            "run",
+            "--quiet",
+            "--bin",
+            "audit",
+            "--",
+            "reconstruction-rollback",
+            str(REPO_ROOT),
+            "--report",
+            str(report_path),
+        ],
+        cwd=REPO_ROOT / "rust" / "doctor",
+    )
+    payload = parse_stdout_json_payload(result.stdout)
+    print("\nCompuerta Rust de rollback de reconstruccion:")
+    print(f"- reporte: {display(report_path)}")
+    print(f"- veredicto: {payload.get('verdict') if payload else 'sin_json'}")
+    print(f"- errores: {payload.get('errors') if payload else '-'}")
+    if result.returncode != 0:
+        print_command_result(result, max_chars=1600)
+    return result.returncode == 0, payload, result
+
+
+def option_reconstruction_rollback() -> None:
+    reports = latest_reconstruction_reports(rollback_only=True)
+    selected = select_path(reports, "reporte de reconstruccion con rollback disponible")
+    if not selected:
+        return
+    try:
+        payload = load_json(selected)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"No se pudo leer reporte: {exc}")
+        return
+
+    print(f"Reporte seleccionado: {display(selected)}")
+    print(summarize_report(selected))
+    gate_ok, gate_payload, gate_result = run_reconstruction_rollback_gate(selected)
+    if not gate_ok:
+        print("Rollback bloqueado por la compuerta Rust. No se modifico el canon.")
+        return
+
+    backup_value = payload.get("backup_dir")
+    if not backup_value:
+        print("Rollback bloqueado: el reporte no declara backup_dir.")
+        return
+    backup_dir = (REPO_ROOT / backup_value).resolve() if not Path(backup_value).is_absolute() else Path(backup_value)
+    if not backup_dir.exists():
+        print(f"Rollback bloqueado: no existe backup {display(backup_dir)}.")
+        return
+
+    print("\nAdvertencia: rollback de reconstruccion reemplazara tiddlers_*.jsonl en data/out/local.")
+    print(f"- backup fuente: {display(backup_dir)}")
+    print(f"- hash esperado: {payload.get('canon_before_hash')}")
+    confirmation = prompt("Escribe ROLLBACK RECONSTRUCTION para restaurar el canon local: ").strip()
+    if confirmation != "ROLLBACK RECONSTRUCTION":
+        print("Rollback cancelado.")
+        return
+
+    run_dir = selected.parent
+    rollback_stamp = stamp_now()
+    rollback_before_dir = copy_canon_shards(run_dir, f"rollback_before_{rollback_stamp}", DEFAULT_CANON_DIR)
+    rollback_before_manifest = canon_tree_manifest(rollback_before_dir)
+
+    for shard in canon_shards(DEFAULT_CANON_DIR):
+        shard.unlink()
+    for shard in canon_shards(backup_dir):
+        shutil.copy2(shard, DEFAULT_CANON_DIR / shard.name)
+
+    restored_manifest = canon_tree_manifest(DEFAULT_CANON_DIR)
+    print("\nValidacion post-rollback: strict")
+    strict = run_preflight("strict")
+    print_command_result(strict)
+    print("\nValidacion post-rollback: reverse-preflight")
+    reverse_preflight = run_preflight("reverse-preflight")
+    print_command_result(reverse_preflight)
+    validation_ok = strict.returncode == 0 and reverse_preflight.returncode == 0
+
+    rollback_report = run_dir / f"rollback-report-{rollback_stamp}.json"
+    write_json(
+        rollback_report,
+        {
+            "run_id": run_dir.name,
+            "timestamp": rollback_stamp,
+            "mode": "rollback_reconstruction",
+            "source_report": as_display_path(selected),
+            "backup_dir": as_display_path(backup_dir),
+            "rollback_before_dir": as_display_path(rollback_before_dir),
+            "rollback_before": rollback_before_manifest,
+            "restored_canon": restored_manifest,
+            "expected_restored_hash": payload.get("canon_before_hash"),
+            "restored_hash": restored_manifest["hash"],
+            "gate_verdict": gate_payload.get("verdict") if gate_payload else None,
+            "gate_report": gate_payload,
+            "gate_exit_code": gate_result.returncode if gate_result else None,
+            "strict_exit_code": strict.returncode,
+            "strict_report": parse_stdout_json_payload(strict.stdout),
+            "reverse_preflight_exit_code": reverse_preflight.returncode,
+            "reverse_preflight_report": parse_stdout_json_payload(reverse_preflight.stdout),
+            "post_rollback_validation_ok": validation_ok,
+        },
+    )
+    print(f"\nReporte de rollback: {display(rollback_report)}")
+    if validation_ok and restored_manifest["hash"] == payload.get("canon_before_hash"):
+        print("Rollback completado y validado.")
+    else:
+        print("Rollback aplicado, pero la validacion minima no quedo OK. Revisar reporte antes de continuar.")
+
+
 def main_menu() -> None:
     state = MenuState()
     while True:
@@ -1060,6 +1638,8 @@ def main_menu() -> None:
             "9) Ejecutar reverse\n"
             "10) Ver reportes / metricas\n"
             "11) Rollback de admision\n"
+            "12) Rollback de reconstruccion\n"
+            "13) Auditar calidad canonica / nodos\n"
             "0) Salir"
         )
         choice = prompt("> ").strip()
@@ -1083,13 +1663,17 @@ def main_menu() -> None:
         elif choice == "7":
             option_session_sync(state)
         elif choice == "8":
-            option_derivatives()
+            option_derivatives(state)
         elif choice == "9":
             option_reverse(state)
         elif choice == "10":
             option_reports()
         elif choice == "11":
             option_rollback()
+        elif choice == "12":
+            option_reconstruction_rollback()
+        elif choice == "13":
+            option_canon_quality()
         else:
             print("Opcion invalida.")
         pause()

--- a/python_scripts/path_governance.py
+++ b/python_scripts/path_governance.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 
@@ -30,6 +31,7 @@ DEFAULT_EXPORT_DIR = DEFAULT_LOCAL_OUT_DIR / "export"
 DEFAULT_MICROSOFT_COPILOT_DIR = DEFAULT_LOCAL_OUT_DIR / "microsoft_copilot"
 DEFAULT_COPILOT_AGENT_DIR = DEFAULT_MICROSOFT_COPILOT_DIR / "copilot_agent"
 DEFAULT_PROPOSALS_FILE = DEFAULT_LOCAL_OUT_DIR / "proposals.jsonl"
+CANON_SHARD_FILENAME_RE = re.compile(r"^tiddlers_(\d+)\.jsonl$")
 
 
 def resolve_repo_path(path_value: str | None, default_path: Path) -> Path:
@@ -46,6 +48,17 @@ def as_display_path(path: Path) -> str:
         return str(path.relative_to(REPO_ROOT))
     except ValueError:
         return str(path)
+
+
+def canon_shard_sort_key(path: Path) -> tuple[int, int, str]:
+    match = CANON_SHARD_FILENAME_RE.match(path.name)
+    if match:
+        return (0, int(match.group(1)), path.name)
+    return (1, 0, path.name)
+
+
+def sorted_canon_shards(canon_dir: Path) -> list[Path]:
+    return sorted(canon_dir.glob("tiddlers_*.jsonl"), key=canon_shard_sort_key)
 
 
 def proposals_path() -> Path:

--- a/python_scripts/stage_modal_delta.py
+++ b/python_scripts/stage_modal_delta.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Stage a controlled modal delta between live canon and a normalized copy."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from path_governance import (
+    DEFAULT_CANON_DIR,
+    DEFAULT_INPUT_HTML,
+    REPO_ROOT,
+    as_display_path,
+    resolve_repo_path,
+    sorted_canon_shards,
+)
+
+
+SESSION_ID = "m04-s77-canonical-staging-and-controlled-modal-admission-v0"
+DEFAULT_NORMALIZED_JSONL = REPO_ROOT / "data" / "tmp" / "s76-modal-export" / "local-normalized-modal.jsonl"
+DEFAULT_REPORT_ROOT = REPO_ROOT / "data" / "tmp" / "s77-modal-admission"
+
+
+@dataclass
+class JsonlRecord:
+    source_path: Path
+    shard: str
+    line_no: int
+    record: dict[str, Any]
+
+
+@dataclass
+class CommandResult:
+    args: list[str]
+    cwd: Path
+    returncode: int
+    stdout: str
+    stderr: str
+
+    def to_report(self) -> dict[str, Any]:
+        return {
+            "command": " ".join(self.args),
+            "cwd": as_display_path(self.cwd),
+            "exit_code": self.returncode,
+            "stdout_tail": self.stdout[-4000:],
+            "stderr_tail": self.stderr[-4000:],
+        }
+
+
+def stamp_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+
+
+def iso_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def canonical_json(record: dict[str, Any]) -> str:
+    return json.dumps(record, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
+            handle.write("\n")
+
+
+def file_hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def canon_tree_manifest(canon_dir: Path) -> dict[str, Any]:
+    digest = hashlib.sha256()
+    shards = sorted_canon_shards(canon_dir)
+    shard_reports: list[dict[str, Any]] = []
+    for shard in shards:
+        data = shard.read_bytes()
+        digest.update(shard.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(data)
+        digest.update(b"\0")
+        line_count = sum(1 for line in data.decode("utf-8").splitlines() if line.strip())
+        shard_reports.append(
+            {
+                "path": as_display_path(shard),
+                "name": shard.name,
+                "line_count": line_count,
+                "byte_count": len(data),
+                "sha256": f"sha256:{hashlib.sha256(data).hexdigest()}",
+            }
+        )
+    return {
+        "root": as_display_path(canon_dir),
+        "hash": f"sha256:{digest.hexdigest()}",
+        "shard_count": len(shards),
+        "line_count": sum(item["line_count"] for item in shard_reports),
+        "byte_count": sum(item["byte_count"] for item in shard_reports),
+        "shards": shard_reports,
+    }
+
+
+def read_jsonl_file(path: Path, shard_name: str | None = None) -> list[JsonlRecord]:
+    records: list[JsonlRecord] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, raw in enumerate(handle, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError(f"{as_display_path(path)}:{line_no} is not a JSON object")
+            records.append(JsonlRecord(path, shard_name or path.name, line_no, payload))
+    return records
+
+
+def read_canon_dir(canon_dir: Path) -> list[JsonlRecord]:
+    shards = sorted_canon_shards(canon_dir)
+    if not shards:
+        raise ValueError(f"no tiddlers_*.jsonl files under {as_display_path(canon_dir)}")
+    records: list[JsonlRecord] = []
+    for shard in shards:
+        records.extend(read_jsonl_file(shard, shard.name))
+    return records
+
+
+def index_by_id(records: list[JsonlRecord], label: str) -> dict[str, JsonlRecord]:
+    indexed: dict[str, JsonlRecord] = {}
+    for item in records:
+        record_id = str(item.record.get("id") or "")
+        if not record_id:
+            raise ValueError(f"{label} has a record without id at {as_display_path(item.source_path)}:{item.line_no}")
+        if record_id in indexed:
+            first = indexed[record_id]
+            raise ValueError(
+                f"{label} repeats id {record_id} at "
+                f"{as_display_path(first.source_path)}:{first.line_no} and "
+                f"{as_display_path(item.source_path)}:{item.line_no}"
+            )
+        indexed[record_id] = item
+    return indexed
+
+
+def content_asset_present(record: dict[str, Any]) -> bool:
+    content = record.get("content")
+    return isinstance(content, dict) and isinstance(content.get("asset"), dict)
+
+
+def select_asset_content_delta(live: dict[str, Any], normalized: dict[str, Any]) -> bool:
+    if live.get("role_primary") != "asset":
+        return False
+    if content_asset_present(live):
+        return False
+    if not content_asset_present(normalized):
+        return False
+    return live.get("content") != normalized.get("content")
+
+
+def compare_and_stage(
+    canon_dir: Path,
+    normalized_jsonl: Path,
+    out_dir: Path,
+    *,
+    scope: str,
+) -> dict[str, Any]:
+    live_records = read_canon_dir(canon_dir)
+    normalized_records = read_jsonl_file(normalized_jsonl)
+    live_by_id = index_by_id(live_records, "canon")
+    normalized_by_id = index_by_id(normalized_records, "normalized")
+
+    missing_in_normalized = sorted(set(live_by_id) - set(normalized_by_id))
+    extra_in_normalized = sorted(set(normalized_by_id) - set(live_by_id))
+    if missing_in_normalized or extra_in_normalized:
+        raise ValueError(
+            "canon and normalized copy do not have the same id set "
+            f"(missing={len(missing_in_normalized)}, extra={len(extra_in_normalized)})"
+        )
+
+    field_change_counts: Counter[str] = Counter()
+    role_change_counts: Counter[str] = Counter()
+    diffset_counts: Counter[tuple[str, ...]] = Counter()
+    normalized_tags_changes = 0
+    changed_line_count = 0
+    selected_by_id: dict[str, dict[str, Any]] = {}
+    patch_records: list[dict[str, Any]] = []
+
+    for live_item in live_records:
+        record_id = str(live_item.record["id"])
+        normalized_item = normalized_by_id[record_id]
+        live = live_item.record
+        normalized = normalized_item.record
+        changed_fields = tuple(sorted(field for field in set(live) | set(normalized) if live.get(field) != normalized.get(field)))
+        if not changed_fields:
+            continue
+        changed_line_count += 1
+        field_change_counts.update(changed_fields)
+        role_change_counts.update([str(live.get("role_primary") or "")])
+        diffset_counts.update([changed_fields])
+        if "normalized_tags" in changed_fields:
+            normalized_tags_changes += 1
+
+        if scope == "asset-content" and select_asset_content_delta(live, normalized):
+            staged = copy.deepcopy(live)
+            staged["content"] = copy.deepcopy(normalized.get("content"))
+            selected_by_id[record_id] = staged
+            patch_records.append(
+                {
+                    "op": "replace_content",
+                    "scope": scope,
+                    "id": record_id,
+                    "title": live.get("title"),
+                    "role_primary": live.get("role_primary"),
+                    "shard": live_item.shard,
+                    "line": live_item.line_no,
+                    "changed_fields": ["content"],
+                    "before": {"content": live.get("content")},
+                    "after": {"content": staged.get("content")},
+                    "source_normalized": {
+                        "path": as_display_path(normalized_jsonl),
+                        "line": normalized_item.line_no,
+                    },
+                }
+            )
+
+    staged_canon_dir = out_dir / "staged-canon"
+    if staged_canon_dir.exists():
+        shutil.rmtree(staged_canon_dir)
+    staged_canon_dir.mkdir(parents=True, exist_ok=True)
+
+    for shard in sorted_canon_shards(canon_dir):
+        staged_lines: list[str] = []
+        for item in read_jsonl_file(shard, shard.name):
+            record_id = str(item.record["id"])
+            staged = selected_by_id.get(record_id, item.record)
+            staged_lines.append(json.dumps(staged, ensure_ascii=False, separators=(",", ":")))
+        (staged_canon_dir / shard.name).write_text("\n".join(staged_lines) + "\n", encoding="utf-8")
+
+    patch_path = out_dir / "modal-assets.patch.jsonl"
+    write_jsonl(patch_path, patch_records)
+
+    comparison = {
+        "canon_line_count": len(live_records),
+        "normalized_line_count": len(normalized_records),
+        "matched_line_count": len(live_records),
+        "changed_line_count": changed_line_count,
+        "field_change_counts": dict(sorted(field_change_counts.items())),
+        "role_change_counts": dict(sorted(role_change_counts.items())),
+        "diffset_counts": [
+            {"fields": list(fields), "count": count}
+            for fields, count in sorted(diffset_counts.items(), key=lambda item: (-item[1], item[0]))
+        ],
+        "normalized_tags_changed_lines": normalized_tags_changes,
+    }
+
+    return {
+        "report_kind": "canonical_modal_delta_staging",
+        "session_id": SESSION_ID,
+        "timestamp": iso_now(),
+        "scope": scope,
+        "canon_modified": False,
+        "selection_criteria": [
+            "role_primary == asset",
+            "live content.asset absent",
+            "normalized content.asset present",
+            "only the top-level content field is staged",
+        ],
+        "inputs": {
+            "canon_dir": as_display_path(canon_dir),
+            "normalized_jsonl": as_display_path(normalized_jsonl),
+            "normalized_jsonl_sha256": file_hash(normalized_jsonl),
+        },
+        "outputs": {
+            "out_dir": as_display_path(out_dir),
+            "staged_canon_dir": as_display_path(staged_canon_dir),
+            "patch_jsonl": as_display_path(patch_path),
+            "comparison_report": as_display_path(out_dir / "comparison-report.json"),
+        },
+        "before": canon_tree_manifest(canon_dir),
+        "after": canon_tree_manifest(staged_canon_dir),
+        "comparison": comparison,
+        "delta": {
+            "selected_count": len(patch_records),
+            "updated_fields": ["content"] if patch_records else [],
+            "ignored_changed_lines": changed_line_count - len(patch_records),
+            "candidate_apply_status": "staging_only_not_applied",
+            "examples": [
+                {
+                    "id": item["id"],
+                    "title": item["title"],
+                    "shard": item["shard"],
+                    "line": item["line"],
+                    "after_content_keys": sorted((item["after"]["content"] or {}).keys()),
+                }
+                for item in patch_records[:8]
+            ],
+        },
+        "gates": {
+            "strict": "not_run",
+            "reverse_preflight": "not_run",
+            "reverse_authoritative": "not_run",
+        },
+        "commands_run": [],
+    }
+
+
+def command_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.setdefault("GOCACHE", "/tmp/tdc-go-build")
+    return env
+
+
+def run_command(args: list[str], cwd: Path) -> CommandResult:
+    completed = subprocess.run(args, cwd=cwd, env=command_env(), check=False, capture_output=True, text=True)
+    return CommandResult(args=args, cwd=cwd, returncode=completed.returncode, stdout=completed.stdout, stderr=completed.stderr)
+
+
+def parse_stdout_json(stdout: str) -> Any:
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def run_gates(report: dict[str, Any], html_path: Path) -> None:
+    staged_canon_dir = REPO_ROOT / report["outputs"]["staged_canon_dir"]
+    reverse_html = Path("/tmp") / f"{Path(report['outputs']['out_dir']).name}.reverse.html"
+    reverse_report = Path("/tmp") / f"{Path(report['outputs']['out_dir']).name}.reverse-report.json"
+
+    strict = run_command(
+        ["go", "run", "./cmd/canon_preflight", "--mode", "strict", "--input", str(staged_canon_dir)],
+        cwd=REPO_ROOT / "go" / "canon",
+    )
+    reverse_preflight = run_command(
+        ["go", "run", "./cmd/canon_preflight", "--mode", "reverse-preflight", "--input", str(staged_canon_dir)],
+        cwd=REPO_ROOT / "go" / "canon",
+    )
+    reverse = run_command(
+        [
+            "go",
+            "run",
+            "./cmd/reverse_tiddlers",
+            "--html",
+            str(html_path),
+            "--canon",
+            str(staged_canon_dir),
+            "--out-html",
+            str(reverse_html),
+            "--report",
+            str(reverse_report),
+            "--mode",
+            "authoritative-upsert",
+        ],
+        cwd=REPO_ROOT / "go" / "bridge",
+    )
+
+    reverse_payload: dict[str, Any] | None = None
+    if reverse_report.exists():
+        with reverse_report.open("r", encoding="utf-8") as handle:
+            reverse_payload = json.load(handle)
+    reverse_rejected = None
+    if isinstance(reverse_payload, dict):
+        raw_rejected = reverse_payload.get("rejected_count", reverse_payload.get("rejected"))
+        try:
+            reverse_rejected = int(raw_rejected)
+        except (TypeError, ValueError):
+            reverse_rejected = None
+
+    report["gates"] = {
+        "strict": "passed" if strict.returncode == 0 else "failed",
+        "reverse_preflight": "passed" if reverse_preflight.returncode == 0 else "failed",
+        "reverse_authoritative": "passed" if reverse.returncode == 0 and reverse_rejected == 0 else "failed",
+        "reverse_rejected": reverse_rejected,
+        "reverse_report": str(reverse_report),
+        "reverse_html": str(reverse_html),
+    }
+    report["commands_run"].extend([strict.to_report(), reverse_preflight.to_report(), reverse.to_report()])
+    report["gate_reports"] = {
+        "strict": parse_stdout_json(strict.stdout),
+        "reverse_preflight": parse_stdout_json(reverse_preflight.stdout),
+        "reverse_authoritative": reverse_payload,
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--canon-dir", default=str(DEFAULT_CANON_DIR), help="live canon shard directory")
+    parser.add_argument("--normalized-jsonl", default=str(DEFAULT_NORMALIZED_JSONL), help="normalized JSONL copy to compare")
+    parser.add_argument("--out-dir", default="", help="output run directory; defaults under data/tmp/s77-modal-admission")
+    parser.add_argument("--run-id", default="", help="run id when --out-dir is not provided")
+    parser.add_argument("--scope", choices=["asset-content"], default="asset-content")
+    parser.add_argument("--run-gates", action="store_true", help="run strict, reverse-preflight and reverse against staged canon")
+    parser.add_argument("--html", default=str(DEFAULT_INPUT_HTML), help="HTML source for reverse gate")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    canon_dir = resolve_repo_path(args.canon_dir, DEFAULT_CANON_DIR)
+    normalized_jsonl = resolve_repo_path(args.normalized_jsonl, DEFAULT_NORMALIZED_JSONL)
+    html_path = resolve_repo_path(args.html, DEFAULT_INPUT_HTML)
+    run_id = args.run_id or f"s77-modal-assets-{stamp_now()}"
+    out_dir = resolve_repo_path(args.out_dir, DEFAULT_REPORT_ROOT / run_id) if args.out_dir else DEFAULT_REPORT_ROOT / run_id
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    report = compare_and_stage(canon_dir, normalized_jsonl, out_dir, scope=args.scope)
+    if args.run_gates:
+        run_gates(report, html_path)
+    report_path = out_dir / "comparison-report.json"
+    write_json(report_path, report)
+    summary = {
+        "status": "ok",
+        "report": as_display_path(report_path),
+        "patch_jsonl": report["outputs"]["patch_jsonl"],
+        "staged_canon_dir": report["outputs"]["staged_canon_dir"],
+        "changed_line_count": report["comparison"]["changed_line_count"],
+        "selected_count": report["delta"]["selected_count"],
+        "canon_modified": False,
+        "gates": report["gates"],
+    }
+    print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+    if args.run_gates and any(report["gates"].get(name) != "passed" for name in ("strict", "reverse_preflight", "reverse_authoritative")):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rust/doctor/src/bin/audit.rs
+++ b/rust/doctor/src/bin/audit.rs
@@ -3,7 +3,10 @@
 //! Uso:
 //!   audit <raw_path>
 //!   audit perimeter <repo_root>
-//!   audit reconstruction-plan <repo_root> --source-html <path> --source-role <role> --mode <mode> --output-target <path> --requires-backup <true|false> --requires-hash-report <true|false>
+//!   audit reconstruction-plan <repo_root> --source-html <path> --source-role <role> --mode <mode> --output-target <path> [--input-jsonl <path>] [--reconstruction-run-dir <path>] --requires-backup <true|false> --requires-hash-report <true|false>
+//!   audit reconstruction-rollback <repo_root> --report <path>
+//!   audit canonical-line-gate <repo_root> --input <path> [--report <path>]
+//!   audit deep-node-inspect <repo_root> --input <path> [--report <path>]
 //!
 //! Audita la integridad estructural mínima del artefacto raw producido por
 //! el Extractor, o el perímetro reusable del repositorio. Emite el reporte
@@ -23,7 +26,7 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         eprintln!(
-            "[doctor] uso: audit <raw_path> | audit perimeter <repo_root> | audit reconstruction-plan <repo_root> --source-html <path> --source-role <role> --mode <mode> --output-target <path> --requires-backup <true|false> --requires-hash-report <true|false>"
+            "[doctor] uso: audit <raw_path> | audit perimeter <repo_root> | audit reconstruction-plan <repo_root> --source-html <path> --source-role <role> --mode <mode> --output-target <path> [--input-jsonl <path>] [--reconstruction-run-dir <path>] --requires-backup <true|false> --requires-hash-report <true|false> | audit reconstruction-rollback <repo_root> --report <path> | audit canonical-line-gate <repo_root> --input <path> [--report <path>] | audit deep-node-inspect <repo_root> --input <path> [--report <path>]"
         );
         process::exit(1);
     }
@@ -56,6 +59,8 @@ fn main() {
         let source_role = required_flag(&flags, "source-role");
         let mode = required_flag(&flags, "mode");
         let output_target = required_flag(&flags, "output-target");
+        let input_jsonl = flags.get("input-jsonl");
+        let reconstruction_run_dir = flags.get("reconstruction-run-dir");
         let requires_backup = parse_bool_flag(required_flag(&flags, "requires-backup"));
         let requires_hash_report = parse_bool_flag(required_flag(&flags, "requires-hash-report"));
 
@@ -75,12 +80,14 @@ fn main() {
             process::exit(1);
         });
 
-        let report = tdc_doctor::audit_reconstruction_plan(
+        let report = tdc_doctor::audit_reconstruction_plan_with_artifacts(
             Path::new(repo_root),
             Path::new(source_html),
             source_role,
             mode,
             Path::new(output_target),
+            input_jsonl.map(|path| Path::new(path.as_str())),
+            reconstruction_run_dir.map(|path| Path::new(path.as_str())),
             requires_backup,
             requires_hash_report,
         );
@@ -96,6 +103,92 @@ fn main() {
         if report.verdict == tdc_doctor::ReconstructionPlanVerdict::Rejected {
             process::exit(10);
         }
+        return;
+    }
+
+    if args[1] == "reconstruction-rollback" {
+        let repo_root = args.get(2).map(String::as_str).unwrap_or(".");
+        let flags = parse_flags(&args[3..]).unwrap_or_else(|message| {
+            eprintln!("[doctor] ERROR: {}", message);
+            process::exit(1);
+        });
+        let report_path = required_flag(&flags, "report");
+        let report =
+            tdc_doctor::audit_reconstruction_rollback(Path::new(repo_root), Path::new(report_path));
+        let json = serde_json::to_string_pretty(&report).unwrap_or_else(|e| {
+            eprintln!("[doctor] ERROR al serializar reporte de rollback: {}", e);
+            process::exit(2);
+        });
+        println!("{}", json);
+        eprintln!(
+            "[doctor] reconstruction-rollback verdict={:?} checks={} errors={}",
+            report.verdict, report.checks_run, report.errors
+        );
+        if report.verdict == tdc_doctor::ReconstructionRollbackVerdict::Rejected {
+            process::exit(10);
+        }
+        return;
+    }
+
+    if args[1] == "canonical-line-gate" {
+        let repo_root = args.get(2).map(String::as_str).unwrap_or(".");
+        let flags = parse_flags(&args[3..]).unwrap_or_else(|message| {
+            eprintln!("[doctor] ERROR: {}", message);
+            process::exit(1);
+        });
+        let input_path = required_flag(&flags, "input");
+        let report = tdc_doctor::audit_canonical_lines(Path::new(repo_root), Path::new(input_path));
+        let json = serde_json::to_string_pretty(&report).unwrap_or_else(|e| {
+            eprintln!("[doctor] ERROR al serializar canonical-line gate: {}", e);
+            process::exit(2);
+        });
+        if let Some(report_path) = flags.get("report") {
+            write_report_file(Path::new(report_path), &json);
+        }
+        println!("{}", json);
+        eprintln!(
+            "[doctor] canonical-line-gate verdict={:?} lines={} parsed={} rejected={} inconsistent={}",
+            report.verdict,
+            report.lines_read,
+            report.parsed_lines,
+            report.counts.canon_line_rejected,
+            report.counts.canon_line_inconsistent
+        );
+        if matches!(
+            report.verdict,
+            tdc_doctor::CanonicalLineVerdict::CanonLineRejected
+                | tdc_doctor::CanonicalLineVerdict::CanonLineInconsistent
+        ) {
+            process::exit(10);
+        }
+        return;
+    }
+
+    if args[1] == "deep-node-inspect" {
+        let repo_root = args.get(2).map(String::as_str).unwrap_or(".");
+        let flags = parse_flags(&args[3..]).unwrap_or_else(|message| {
+            eprintln!("[doctor] ERROR: {}", message);
+            process::exit(1);
+        });
+        let input_path = required_flag(&flags, "input");
+        let report = tdc_doctor::inspect_deep_nodes(Path::new(repo_root), Path::new(input_path));
+        let json = serde_json::to_string_pretty(&report).unwrap_or_else(|e| {
+            eprintln!("[doctor] ERROR al serializar deep-node inspector: {}", e);
+            process::exit(2);
+        });
+        if let Some(report_path) = flags.get("report") {
+            write_report_file(Path::new(report_path), &json);
+        }
+        println!("{}", json);
+        eprintln!(
+            "[doctor] deep-node-inspect verdict={:?} nodes={} findings={} structural_json={} pedagogical_json={} invalid_json={}",
+            report.verdict,
+            report.nodes_read,
+            report.findings_count,
+            report.counts.structural_json,
+            report.counts.pedagogical_json,
+            report.counts.invalid_json
+        );
         return;
     }
 
@@ -172,5 +265,26 @@ fn parse_bool_flag(value: &str) -> bool {
             );
             process::exit(1);
         }
+    }
+}
+
+fn write_report_file(path: &Path, json: &str) {
+    if let Some(parent) = path.parent() {
+        if let Err(err) = std::fs::create_dir_all(parent) {
+            eprintln!(
+                "[doctor] ERROR al crear directorio de reporte '{}': {}",
+                parent.display(),
+                err
+            );
+            process::exit(2);
+        }
+    }
+    if let Err(err) = std::fs::write(path, json) {
+        eprintln!(
+            "[doctor] ERROR al escribir reporte '{}': {}",
+            path.display(),
+            err
+        );
+        process::exit(2);
     }
 }

--- a/rust/doctor/src/canon_quality.rs
+++ b/rust/doctor/src/canon_quality.rs
@@ -1,0 +1,2460 @@
+use crate::report::{
+    CanonQualityDebtSummary, CanonicalLineCounts, CanonicalLineGateReport, CanonicalLineIssue,
+    CanonicalLineItemReport, CanonicalLineVerdict, DeepNodeFinding, DeepNodeFindingCounts,
+    DeepNodeInspectionReport, DeepNodeInspectorVerdict, FamilyProfileIssueSummary,
+    FamilyProfileReport, IncompleteLineTriageReport, ModalProjectionAuditReport,
+    ModalProjectionIssueReport, TemplateFamilyReport, TemplateVariantReport,
+};
+use serde_json::Value;
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    path::{Path, PathBuf},
+};
+
+const ALLOWED_TOP_LEVEL_FIELDS: &[&str] = &[
+    "schema_version",
+    "id",
+    "key",
+    "title",
+    "canonical_slug",
+    "version_id",
+    "content_type",
+    "modality",
+    "encoding",
+    "is_binary",
+    "is_reference_only",
+    "role_primary",
+    "roles_secondary",
+    "tags",
+    "taxonomy_path",
+    "semantic_text",
+    "content",
+    "normalized_tags",
+    "raw_payload_ref",
+    "asset_id",
+    "mime_type",
+    "document_id",
+    "section_path",
+    "order_in_document",
+    "relations",
+    "source_tags",
+    "source_fields",
+    "source_type",
+    "source_position",
+    "source_role",
+    "text",
+    "created",
+    "modified",
+];
+
+const CORE_EXPECTED_FIELDS: &[&str] = &[
+    "schema_version",
+    "id",
+    "key",
+    "title",
+    "canonical_slug",
+    "version_id",
+    "content_type",
+    "modality",
+    "encoding",
+    "is_binary",
+    "is_reference_only",
+    "role_primary",
+    "semantic_text",
+    "content",
+    "mime_type",
+    "document_id",
+    "section_path",
+    "order_in_document",
+    "relations",
+    "text",
+    "source_type",
+    "source_position",
+    "created",
+    "modified",
+];
+
+const RICHNESS_EXPECTED_FIELDS: &[&str] = &[
+    "tags",
+    "taxonomy_path",
+    "normalized_tags",
+    "source_tags",
+    "source_fields",
+    "raw_payload_ref",
+];
+
+const FAMILY_PROFILE_RULE_PREFIX: &str = "family-profile-";
+
+const SESSION_PROFILE_TOP_LEVEL_FIELDS: &[&str] = &[
+    "schema_version",
+    "id",
+    "key",
+    "title",
+    "canonical_slug",
+    "version_id",
+    "content_type",
+    "modality",
+    "encoding",
+    "is_binary",
+    "is_reference_only",
+    "role_primary",
+    "tags",
+    "taxonomy_path",
+    "semantic_text",
+    "content",
+    "normalized_tags",
+    "raw_payload_ref",
+    "mime_type",
+    "document_id",
+    "section_path",
+    "order_in_document",
+    "relations",
+    "source_tags",
+    "source_fields",
+    "source_type",
+    "source_position",
+    "source_role",
+    "text",
+    "created",
+    "modified",
+];
+
+const SESSION_PROFILE_SOURCE_FIELDS: &[&str] = &[
+    "session_origin",
+    "artifact_family",
+    "source_path",
+    "canonical_status",
+    "document_key",
+    "provenance_ref",
+];
+
+const SESSION_PROFILE_TAG_PREFIXES: &[&str] = &["session:", "milestone:", "status:"];
+
+const ASSET_PROFILE_TOP_LEVEL_FIELDS: &[&str] = &[
+    "schema_version",
+    "id",
+    "key",
+    "title",
+    "canonical_slug",
+    "version_id",
+    "content_type",
+    "modality",
+    "encoding",
+    "is_binary",
+    "is_reference_only",
+    "role_primary",
+    "tags",
+    "taxonomy_path",
+    "normalized_tags",
+    "raw_payload_ref",
+    "asset_id",
+    "mime_type",
+    "document_id",
+    "section_path",
+    "order_in_document",
+    "relations",
+    "source_tags",
+    "source_fields",
+    "source_type",
+    "source_position",
+    "text",
+    "created",
+    "modified",
+];
+
+const CONTROLLED_ROLES: &[&str] = &[
+    "concept",
+    "procedure",
+    "evidence",
+    "definition",
+    "glossary",
+    "policy",
+    "log",
+    "asset",
+    "config",
+    "code",
+    "narrative",
+    "note",
+    "warning",
+    "unclassified",
+    "concepto",
+    "dato",
+    "hipótesis",
+    "hipotesis",
+    "modelo",
+    "reporte",
+    "evento",
+    "proceso",
+    "procedimiento",
+    "ecuacion",
+    "ecuación",
+    "definición",
+    "definicion",
+    "evidencia",
+];
+
+const CONTROLLED_MODALITIES: &[&str] = &[
+    "text",
+    "metadata",
+    "image",
+    "audio",
+    "video",
+    "binary",
+    "mixed",
+    "equation",
+    "table",
+    "reference",
+    "code",
+    "unknown",
+];
+
+/// Clasifica lineas canonicas o candidatas sin modificar el canon.
+pub fn audit_canonical_lines(repo_root: &Path, input_path: &Path) -> CanonicalLineGateReport {
+    let root = repo_root;
+    let input = resolve_quality_path(root, input_path);
+    let mut source_files = collect_canonical_input_files(&input);
+    source_files.sort();
+
+    let mut report = CanonicalLineGateReport {
+        verdict: CanonicalLineVerdict::CanonLineOk,
+        repo_root: root.to_string_lossy().to_string(),
+        input_path: display_quality_path(root, &input),
+        source_files: source_files
+            .iter()
+            .map(|path| display_quality_path(root, path))
+            .collect(),
+        lines_read: 0,
+        parsed_lines: 0,
+        counts: CanonicalLineCounts::default(),
+        template_families_with_drift: Vec::new(),
+        family_profiles: Vec::new(),
+        incomplete_line_triage: Vec::new(),
+        modal_projection_audit: empty_modal_projection_audit(),
+        debt_summary: CanonQualityDebtSummary::default(),
+        lines: Vec::new(),
+    };
+
+    if source_files.is_empty() {
+        report.verdict = CanonicalLineVerdict::CanonLineRejected;
+        report.counts.canon_line_rejected = 1;
+        return report;
+    }
+
+    let mut template_observations: HashMap<String, Vec<TemplateObservation>> = HashMap::new();
+
+    for source_file in &source_files {
+        let content = match std::fs::read_to_string(source_file) {
+            Ok(content) => content,
+            Err(err) => {
+                let item = rejected_line_item(
+                    root,
+                    source_file,
+                    0,
+                    "file-not-readable",
+                    &format!("no se pudo leer el archivo: {}", err),
+                );
+                push_line_item(&mut report, item);
+                continue;
+            }
+        };
+
+        for (index, raw_line) in content.lines().enumerate() {
+            let line_number = index + 1;
+            let line = raw_line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            report.lines_read += 1;
+
+            let value: Value = match serde_json::from_str(line) {
+                Ok(value) => value,
+                Err(err) => {
+                    let item = rejected_line_item(
+                        root,
+                        source_file,
+                        line_number,
+                        "invalid-json-line",
+                        &format!("linea JSONL invalida: {}", err),
+                    );
+                    push_line_item(&mut report, item);
+                    continue;
+                }
+            };
+            report.parsed_lines += 1;
+
+            let item = classify_canonical_value(root, source_file, line_number, &value);
+            if let Value::Object(map) = &value {
+                template_observations
+                    .entry(item.family.clone())
+                    .or_default()
+                    .push(TemplateObservation {
+                        signature: sorted_object_keys(map),
+                        title: item
+                            .title
+                            .clone()
+                            .unwrap_or_else(|| format!("line:{}", line_number)),
+                    });
+            }
+            push_line_item(&mut report, item);
+        }
+    }
+
+    report.template_families_with_drift = build_template_family_reports(template_observations);
+    for family in &report.template_families_with_drift {
+        report.verdict = worst_verdict(report.verdict, family.verdict);
+    }
+    report.family_profiles = build_family_profile_reports(&report.lines);
+    for profile in &report.family_profiles {
+        report.verdict = worst_verdict(report.verdict, profile.verdict);
+    }
+    report.incomplete_line_triage = build_incomplete_line_triage(&report.lines);
+    report.modal_projection_audit = build_modal_projection_audit(&report.lines);
+    report.debt_summary = build_debt_summary(&report);
+    report
+}
+
+/// Detecta estructura interna aprovechable dentro de nodos sin reescribirlos.
+pub fn inspect_deep_nodes(repo_root: &Path, input_path: &Path) -> DeepNodeInspectionReport {
+    let root = repo_root;
+    let input = resolve_quality_path(root, input_path);
+    let mut source_files = collect_deep_node_input_files(&input);
+    source_files.sort();
+
+    let mut report = DeepNodeInspectionReport {
+        verdict: DeepNodeInspectorVerdict::NoStructureFound,
+        repo_root: root.to_string_lossy().to_string(),
+        input_path: display_quality_path(root, &input),
+        source_files: source_files
+            .iter()
+            .map(|path| display_quality_path(root, path))
+            .collect(),
+        nodes_read: 0,
+        inspected_text_fields: 0,
+        findings_count: 0,
+        counts: DeepNodeFindingCounts::default(),
+        findings: Vec::new(),
+    };
+
+    for source_file in &source_files {
+        let records = read_node_records(source_file);
+        for record in records {
+            let Value::Object(map) = record.value else {
+                continue;
+            };
+            report.nodes_read += 1;
+            let title = map.get("title").and_then(Value::as_str).map(str::to_string);
+            let fields = text_fields_from_object(&map);
+            report.inspected_text_fields += fields.len();
+            for (field_name, text) in fields {
+                inspect_text_field(
+                    root,
+                    source_file,
+                    record.line,
+                    title.clone(),
+                    &field_name,
+                    &text,
+                    &mut report,
+                );
+            }
+        }
+    }
+
+    report.findings_count = report.findings.len();
+    report.verdict = if report.counts.invalid_json > 0 {
+        DeepNodeInspectorVerdict::StructureFoundWithWarnings
+    } else if report.findings_count > 0 {
+        DeepNodeInspectorVerdict::StructureFound
+    } else {
+        DeepNodeInspectorVerdict::NoStructureFound
+    };
+    report
+}
+
+fn classify_canonical_value(
+    root: &Path,
+    source_file: &Path,
+    line_number: usize,
+    value: &Value,
+) -> CanonicalLineItemReport {
+    let Some(map) = value.as_object() else {
+        return rejected_line_item(
+            root,
+            source_file,
+            line_number,
+            "line-not-object",
+            "la linea canonica debe ser un objeto JSON",
+        );
+    };
+
+    let title = map.get("title").and_then(Value::as_str).map(str::to_string);
+    let role_primary = map
+        .get("role_primary")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let modality = map
+        .get("modality")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let family = artifact_family(map, title.as_deref());
+    let mut issues = Vec::new();
+
+    for field in map.keys() {
+        if !ALLOWED_TOP_LEVEL_FIELDS.contains(&field.as_str()) {
+            issues.push(issue(
+                "unknown-top-level-field",
+                CanonicalLineVerdict::CanonLineInconsistent,
+                &format!(
+                    "campo top-level no permitido por la politica canonica: {}",
+                    field
+                ),
+            ));
+        }
+    }
+
+    check_required_string(
+        map,
+        "schema_version",
+        CanonicalLineVerdict::CanonLineIncomplete,
+        &mut issues,
+    );
+    if let Some(schema) = map.get("schema_version").and_then(Value::as_str) {
+        if schema != "v0" {
+            issues.push(issue(
+                "wrong-schema-version",
+                CanonicalLineVerdict::CanonLineRejected,
+                &format!("schema_version debe ser v0, encontrado {}", schema),
+            ));
+        }
+    }
+    check_required_string(
+        map,
+        "key",
+        CanonicalLineVerdict::CanonLineIncomplete,
+        &mut issues,
+    );
+    check_required_string(
+        map,
+        "title",
+        CanonicalLineVerdict::CanonLineIncomplete,
+        &mut issues,
+    );
+
+    if let (Some(key), Some(title)) = (
+        map.get("key").and_then(Value::as_str),
+        map.get("title").and_then(Value::as_str),
+    ) {
+        if key != title {
+            issues.push(issue(
+                "key-title-mismatch",
+                CanonicalLineVerdict::CanonLineInconsistent,
+                "key debe conservar el mismo anclaje que title",
+            ));
+        }
+    }
+
+    for field in CORE_EXPECTED_FIELDS {
+        if !map.contains_key(*field) {
+            issues.push(issue(
+                "missing-core-canon-field",
+                CanonicalLineVerdict::CanonLineIncomplete,
+                &format!("falta campo canonico esperado: {}", field),
+            ));
+        }
+    }
+    for field in RICHNESS_EXPECTED_FIELDS {
+        if !map.contains_key(*field) {
+            issues.push(issue(
+                "missing-richness-field",
+                CanonicalLineVerdict::CanonLineWarning,
+                &format!("falta campo de riqueza/procedencia recomendado: {}", field),
+            ));
+        }
+    }
+
+    check_optional_string(map, "id", &mut issues);
+    check_optional_string(map, "canonical_slug", &mut issues);
+    check_optional_string(map, "version_id", &mut issues);
+    check_optional_string(map, "content_type", &mut issues);
+    check_optional_string(map, "modality", &mut issues);
+    check_optional_string(map, "encoding", &mut issues);
+    check_optional_string(map, "role_primary", &mut issues);
+    check_optional_string(map, "raw_payload_ref", &mut issues);
+    check_optional_string(map, "mime_type", &mut issues);
+    check_optional_string(map, "document_id", &mut issues);
+    check_optional_string(map, "source_type", &mut issues);
+    check_optional_string(map, "source_position", &mut issues);
+    check_optional_string(map, "source_role", &mut issues);
+    check_optional_string(map, "created", &mut issues);
+    check_optional_string(map, "modified", &mut issues);
+    check_optional_bool(map, "is_binary", &mut issues);
+    check_optional_bool(map, "is_reference_only", &mut issues);
+    check_optional_integer(map, "order_in_document", &mut issues);
+    check_optional_array_or_null(map, "tags", &mut issues);
+    check_optional_array_or_null(map, "roles_secondary", &mut issues);
+    check_optional_array_or_null(map, "taxonomy_path", &mut issues);
+    check_optional_array_or_null(map, "normalized_tags", &mut issues);
+    check_optional_array_or_null(map, "source_tags", &mut issues);
+    check_optional_array_or_null(map, "section_path", &mut issues);
+    check_optional_array_or_null(map, "relations", &mut issues);
+    check_optional_object(map, "content", &mut issues);
+    check_optional_object(map, "source_fields", &mut issues);
+
+    if let Some(id) = map.get("id").and_then(Value::as_str) {
+        if !is_uuid_like(id) {
+            issues.push(issue(
+                "id-not-uuid-like",
+                CanonicalLineVerdict::CanonLineInconsistent,
+                "id debe tener forma UUID estable",
+            ));
+        }
+    }
+    if let Some(version_id) = map.get("version_id").and_then(Value::as_str) {
+        if !is_sha256_label(version_id) {
+            issues.push(issue(
+                "version-id-not-sha256",
+                CanonicalLineVerdict::CanonLineInconsistent,
+                "version_id debe tener forma sha256:<64 hex>",
+            ));
+        }
+    }
+    for field in ["created", "modified"] {
+        if let Some(timestamp) = map.get(field).and_then(Value::as_str) {
+            if !is_tiddlywiki_timestamp(timestamp) {
+                issues.push(issue(
+                    "timestamp-shape-warning",
+                    CanonicalLineVerdict::CanonLineWarning,
+                    &format!("{} no parece timestamp TW5 YYYYMMDDHHmmssSSS", field),
+                ));
+            }
+        }
+    }
+    if let Some(role) = map.get("role_primary").and_then(Value::as_str) {
+        if !CONTROLLED_ROLES.contains(&role) {
+            issues.push(issue(
+                "role-primary-outside-known-vocabulary",
+                CanonicalLineVerdict::CanonLineWarning,
+                &format!("role_primary fuera del vocabulario observado: {}", role),
+            ));
+        }
+    }
+    if let Some(modality) = map.get("modality").and_then(Value::as_str) {
+        if !CONTROLLED_MODALITIES.contains(&modality) {
+            issues.push(issue(
+                "modality-outside-known-vocabulary",
+                CanonicalLineVerdict::CanonLineWarning,
+                &format!("modality fuera del vocabulario observado: {}", modality),
+            ));
+        }
+    }
+
+    for field in [
+        "id",
+        "key",
+        "title",
+        "canonical_slug",
+        "version_id",
+        "content_type",
+        "role_primary",
+        "document_id",
+        "source_position",
+    ] {
+        if let Some(value) = map.get(field).and_then(Value::as_str) {
+            if contains_placeholder(value) {
+                issues.push(issue(
+                    "placeholder-in-structural-field",
+                    CanonicalLineVerdict::CanonLineRejected,
+                    &format!("{} contiene marcador pendiente o placeholder", field),
+                ));
+            }
+        }
+    }
+
+    if !has_source_anchor(map) {
+        issues.push(issue(
+            "weak-source-anchor",
+            CanonicalLineVerdict::CanonLineWarning,
+            "la linea no declara source_position, raw_payload_ref ni source_fields.source_path",
+        ));
+    }
+
+    if title
+        .as_deref()
+        .map(is_session_artifact_title)
+        .unwrap_or(false)
+    {
+        if !has_session_origin(map) {
+            issues.push(issue(
+                "session-artifact-without-session-origin",
+                CanonicalLineVerdict::CanonLineWarning,
+                "artefacto de sesion sin session_origin/source tag session:* verificable",
+            ));
+        }
+        if !source_fields_string(map, "artifact_family").is_some() {
+            issues.push(issue(
+                "session-artifact-without-artifact-family",
+                CanonicalLineVerdict::CanonLineWarning,
+                "artefacto de sesion sin source_fields.artifact_family",
+            ));
+        }
+        if !source_fields_string(map, "source_path").is_some() {
+            issues.push(issue(
+                "session-artifact-without-source-path",
+                CanonicalLineVerdict::CanonLineWarning,
+                "artefacto de sesion sin source_fields.source_path bajo data/sessions",
+            ));
+        }
+    }
+
+    let modal_projections = content_projection_kinds(map);
+    apply_modal_projection_profile(map, &modal_projections, &mut issues);
+    apply_family_profile(&family, map, title.as_deref(), &mut issues);
+
+    let verdict = issues
+        .iter()
+        .fold(CanonicalLineVerdict::CanonLineOk, |current, item| {
+            worst_verdict(current, item.impact)
+        });
+
+    CanonicalLineItemReport {
+        source_path: display_quality_path(root, source_file),
+        line: line_number,
+        title,
+        role_primary,
+        modality,
+        family,
+        verdict,
+        field_count: map.len(),
+        modal_projections,
+        issues,
+    }
+}
+
+fn push_line_item(report: &mut CanonicalLineGateReport, item: CanonicalLineItemReport) {
+    report.verdict = worst_verdict(report.verdict, item.verdict);
+    match item.verdict {
+        CanonicalLineVerdict::CanonLineOk => report.counts.canon_line_ok += 1,
+        CanonicalLineVerdict::CanonLineWarning => report.counts.canon_line_warning += 1,
+        CanonicalLineVerdict::CanonLineIncomplete => report.counts.canon_line_incomplete += 1,
+        CanonicalLineVerdict::CanonLineInconsistent => report.counts.canon_line_inconsistent += 1,
+        CanonicalLineVerdict::CanonLineRejected => report.counts.canon_line_rejected += 1,
+    }
+    report.lines.push(item);
+}
+
+fn rejected_line_item(
+    root: &Path,
+    source_file: &Path,
+    line: usize,
+    rule_id: &str,
+    message: &str,
+) -> CanonicalLineItemReport {
+    CanonicalLineItemReport {
+        source_path: display_quality_path(root, source_file),
+        line,
+        title: None,
+        role_primary: None,
+        modality: None,
+        family: "unparseable".to_string(),
+        verdict: CanonicalLineVerdict::CanonLineRejected,
+        field_count: 0,
+        modal_projections: Vec::new(),
+        issues: vec![issue(
+            rule_id,
+            CanonicalLineVerdict::CanonLineRejected,
+            message,
+        )],
+    }
+}
+
+fn issue(rule_id: &str, impact: CanonicalLineVerdict, message: &str) -> CanonicalLineIssue {
+    let severity = match impact {
+        CanonicalLineVerdict::CanonLineOk => "info",
+        CanonicalLineVerdict::CanonLineWarning | CanonicalLineVerdict::CanonLineIncomplete => {
+            "warning"
+        }
+        CanonicalLineVerdict::CanonLineInconsistent | CanonicalLineVerdict::CanonLineRejected => {
+            "error"
+        }
+    };
+    CanonicalLineIssue {
+        rule_id: rule_id.to_string(),
+        severity: severity.to_string(),
+        impact,
+        message: message.to_string(),
+    }
+}
+
+fn check_required_string(
+    map: &serde_json::Map<String, Value>,
+    field: &str,
+    impact: CanonicalLineVerdict,
+    issues: &mut Vec<CanonicalLineIssue>,
+) {
+    match map.get(field) {
+        Some(Value::String(value)) if !value.trim().is_empty() => {}
+        Some(Value::String(_)) => issues.push(issue(
+            "empty-required-string",
+            impact,
+            &format!("{} esta vacio", field),
+        )),
+        Some(_) => issues.push(issue(
+            "required-field-wrong-type",
+            CanonicalLineVerdict::CanonLineInconsistent,
+            &format!("{} debe ser string no vacio", field),
+        )),
+        None => issues.push(issue(
+            "missing-required-field",
+            impact,
+            &format!("falta campo requerido: {}", field),
+        )),
+    }
+}
+
+fn check_optional_string(
+    map: &serde_json::Map<String, Value>,
+    field: &str,
+    issues: &mut Vec<CanonicalLineIssue>,
+) {
+    if let Some(value) = map.get(field) {
+        if !value.is_string() && !value.is_null() {
+            issues.push(issue(
+                "field-wrong-type",
+                CanonicalLineVerdict::CanonLineInconsistent,
+                &format!("{} debe ser string o null", field),
+            ));
+        }
+    }
+}
+
+fn check_optional_bool(
+    map: &serde_json::Map<String, Value>,
+    field: &str,
+    issues: &mut Vec<CanonicalLineIssue>,
+) {
+    if let Some(value) = map.get(field) {
+        if !value.is_boolean() {
+            issues.push(issue(
+                "field-wrong-type",
+                CanonicalLineVerdict::CanonLineInconsistent,
+                &format!("{} debe ser boolean", field),
+            ));
+        }
+    }
+}
+
+fn check_optional_integer(
+    map: &serde_json::Map<String, Value>,
+    field: &str,
+    issues: &mut Vec<CanonicalLineIssue>,
+) {
+    if let Some(value) = map.get(field) {
+        if value.as_i64().is_none() {
+            issues.push(issue(
+                "field-wrong-type",
+                CanonicalLineVerdict::CanonLineInconsistent,
+                &format!("{} debe ser entero", field),
+            ));
+        }
+    }
+}
+
+fn check_optional_array_or_null(
+    map: &serde_json::Map<String, Value>,
+    field: &str,
+    issues: &mut Vec<CanonicalLineIssue>,
+) {
+    if let Some(value) = map.get(field) {
+        if !value.is_array() && !value.is_null() {
+            issues.push(issue(
+                "field-wrong-type",
+                CanonicalLineVerdict::CanonLineInconsistent,
+                &format!("{} debe ser array o null", field),
+            ));
+        }
+    }
+}
+
+fn check_optional_object(
+    map: &serde_json::Map<String, Value>,
+    field: &str,
+    issues: &mut Vec<CanonicalLineIssue>,
+) {
+    if let Some(value) = map.get(field) {
+        if !value.is_object() && !value.is_null() {
+            issues.push(issue(
+                "field-wrong-type",
+                CanonicalLineVerdict::CanonLineInconsistent,
+                &format!("{} debe ser objeto o null", field),
+            ));
+        }
+    }
+}
+
+fn content_projection_kinds(map: &serde_json::Map<String, Value>) -> Vec<String> {
+    let Some(Value::Object(content)) = map.get("content") else {
+        return Vec::new();
+    };
+
+    let mut kinds = BTreeSet::new();
+    if content
+        .get("plain")
+        .and_then(Value::as_str)
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+    {
+        kinds.insert("text".to_string());
+    }
+    if content.get("asset").and_then(Value::as_object).is_some() {
+        kinds.insert("asset".to_string());
+    }
+    for (field, kind) in [
+        ("code_blocks", "code"),
+        ("equations", "equation"),
+        ("references", "reference"),
+    ] {
+        if content
+            .get(field)
+            .and_then(Value::as_array)
+            .map(|items| !items.is_empty())
+            .unwrap_or(false)
+        {
+            kinds.insert(kind.to_string());
+        }
+    }
+    if content
+        .get("structured_payload")
+        .and_then(Value::as_object)
+        .is_some()
+    {
+        kinds.insert("structured_payload".to_string());
+    }
+    if let Some(Value::Array(modalities)) = content.get("modalities") {
+        for modality in modalities.iter().filter_map(Value::as_str) {
+            if !modality.trim().is_empty() {
+                kinds.insert(modality.trim().to_string());
+            }
+        }
+    }
+    if let Some(kind) = content.get("projection_kind").and_then(Value::as_str) {
+        if !kind.trim().is_empty() && kind != "mixed" {
+            kinds.insert(kind.trim().to_string());
+        }
+    }
+    kinds.into_iter().collect()
+}
+
+fn apply_modal_projection_profile(
+    map: &serde_json::Map<String, Value>,
+    modal_projections: &[String],
+    issues: &mut Vec<CanonicalLineIssue>,
+) {
+    let role = map
+        .get("role_primary")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let modality = map.get("modality").and_then(Value::as_str).unwrap_or("");
+    let is_binary = map
+        .get("is_binary")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let is_reference_only = map
+        .get("is_reference_only")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let content = map.get("content").and_then(Value::as_object);
+
+    if content.is_some() && modal_projections.is_empty() {
+        issues.push(issue(
+            "modal-projection-empty-content",
+            CanonicalLineVerdict::CanonLineWarning,
+            "content existe pero no expone plain, asset, code_blocks, equations, references ni structured_payload",
+        ));
+    }
+
+    let asset_like = role == "asset"
+        || modality == "image"
+        || modality == "binary"
+        || is_binary
+        || is_reference_only;
+    if asset_like {
+        match content {
+            Some(content) if content.get("asset").and_then(Value::as_object).is_some() => {
+                check_asset_projection_shape(content, issues);
+            }
+            Some(_) => issues.push(issue(
+                "modal-projection-asset-subprojection-missing",
+                CanonicalLineVerdict::CanonLineIncomplete,
+                "activo o binario tiene content pero no content.asset",
+            )),
+            None => issues.push(issue(
+                "modal-projection-missing",
+                CanonicalLineVerdict::CanonLineWarning,
+                "linea asset/binaria sin proyeccion modal content",
+            )),
+        }
+    }
+
+    if modality == "code" && !modal_projections.iter().any(|item| item == "code") {
+        issues.push(issue(
+            "modal-projection-code-missing",
+            CanonicalLineVerdict::CanonLineIncomplete,
+            "nodo con modality=code sin content.code_blocks",
+        ));
+    }
+    if modality == "equation" && !modal_projections.iter().any(|item| item == "equation") {
+        issues.push(issue(
+            "modal-projection-equation-missing",
+            CanonicalLineVerdict::CanonLineIncomplete,
+            "nodo con modality=equation sin content.equations",
+        ));
+    }
+    if modality == "mixed" {
+        let declared_count = content
+            .and_then(|content| content.get("modalities"))
+            .and_then(Value::as_array)
+            .map(|items| items.len())
+            .unwrap_or(0);
+        if declared_count < 2 || modal_projections.len() < 2 {
+            issues.push(issue(
+                "modal-projection-mixed-underdeclared",
+                CanonicalLineVerdict::CanonLineWarning,
+                "nodo mixto debe declarar al menos dos modalidades proyectadas",
+            ));
+        }
+    }
+}
+
+fn check_asset_projection_shape(
+    content: &serde_json::Map<String, Value>,
+    issues: &mut Vec<CanonicalLineIssue>,
+) {
+    let Some(Value::Object(asset)) = content.get("asset") else {
+        return;
+    };
+    for field in ["asset_id", "mime_type", "encoding", "payload_ref"] {
+        if !asset
+            .get(field)
+            .and_then(Value::as_str)
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+        {
+            issues.push(issue(
+                "modal-projection-asset-anchor-missing",
+                CanonicalLineVerdict::CanonLineWarning,
+                &format!("content.asset no declara {}", field),
+            ));
+        }
+    }
+    if asset.get("payload_present").and_then(Value::as_bool) == Some(true)
+        && !asset
+            .get("payload_sha256")
+            .and_then(Value::as_str)
+            .map(is_sha256_label)
+            .unwrap_or(false)
+    {
+        issues.push(issue(
+            "modal-projection-asset-payload-hash-missing",
+            CanonicalLineVerdict::CanonLineWarning,
+            "content.asset declara payload presente sin payload_sha256 valido",
+        ));
+    }
+}
+
+fn apply_family_profile(
+    family: &str,
+    map: &serde_json::Map<String, Value>,
+    title: Option<&str>,
+    issues: &mut Vec<CanonicalLineIssue>,
+) {
+    if let Some(profile) = session_family_profile(family) {
+        if let Some(title) = title {
+            if !title.starts_with(profile.title_prefix) {
+                issues.push(issue(
+                    "family-profile-title-prefix-mismatch",
+                    CanonicalLineVerdict::CanonLineInconsistent,
+                    &format!(
+                        "familia {} espera titulos con prefijo '{}'",
+                        family, profile.title_prefix
+                    ),
+                ));
+            }
+        }
+
+        if let Some(declared) = source_fields_string_from_map(map, "artifact_family") {
+            if declared != family {
+                issues.push(issue(
+                    "family-profile-artifact-family-mismatch",
+                    CanonicalLineVerdict::CanonLineInconsistent,
+                    &format!(
+                        "source_fields.artifact_family declara {} pero la familia detectada es {}",
+                        declared, family
+                    ),
+                ));
+            }
+        }
+
+        for field in SESSION_PROFILE_SOURCE_FIELDS {
+            if source_fields_string_from_map(map, field).is_none() {
+                issues.push(issue(
+                    "family-profile-missing-source-field",
+                    CanonicalLineVerdict::CanonLineWarning,
+                    &format!(
+                        "perfil {} recomienda source_fields.{} para trazabilidad estable",
+                        family, field
+                    ),
+                ));
+            }
+        }
+
+        if let Some(source_path) = source_fields_string_from_map(map, "source_path") {
+            if !source_path.starts_with(profile.source_path_prefix) {
+                issues.push(issue(
+                    "family-profile-source-path-outside-family",
+                    CanonicalLineVerdict::CanonLineInconsistent,
+                    &format!(
+                        "source_fields.source_path debe vivir bajo {}",
+                        profile.source_path_prefix
+                    ),
+                ));
+            }
+        }
+
+        for prefix in SESSION_PROFILE_TAG_PREFIXES {
+            if !has_tag_with_prefix(map, prefix) {
+                issues.push(issue(
+                    "family-profile-missing-tag-prefix",
+                    CanonicalLineVerdict::CanonLineWarning,
+                    &format!("perfil {} recomienda tag con prefijo {}", family, prefix),
+                ));
+            }
+        }
+        let artifact_tag = format!("artifact:{}", family);
+        if !has_exact_tag(map, &artifact_tag) {
+            issues.push(issue(
+                "family-profile-missing-artifact-tag",
+                CanonicalLineVerdict::CanonLineWarning,
+                &format!("perfil {} recomienda tag {}", family, artifact_tag),
+            ));
+        }
+
+        if !map.contains_key("source_role") {
+            issues.push(issue(
+                "family-profile-missing-source-role",
+                CanonicalLineVerdict::CanonLineWarning,
+                &format!(
+                    "perfil {} recomienda source_role para estabilizar la plantilla moderna",
+                    family
+                ),
+            ));
+        }
+        return;
+    }
+
+    if family == "role:asset" {
+        for field in [
+            "asset_id",
+            "raw_payload_ref",
+            "mime_type",
+            "source_type",
+            "source_position",
+            "text",
+        ] {
+            if !map.contains_key(field) {
+                issues.push(issue(
+                    "family-profile-asset-missing-anchor",
+                    CanonicalLineVerdict::CanonLineIncomplete,
+                    &format!("activo canonico sin anclaje esperado: {}", field),
+                ));
+            }
+        }
+
+        if map.get("content").is_none() {
+            let impact = if map
+                .get("is_binary")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                CanonicalLineVerdict::CanonLineWarning
+            } else {
+                CanonicalLineVerdict::CanonLineIncomplete
+            };
+            issues.push(issue(
+                "family-profile-asset-content-projection-missing",
+                impact,
+                "activo sin campo content; en binarios puede ser excepcion documentable, no admision automatica",
+            ));
+        } else if !modal_projections_include_asset(map) {
+            issues.push(issue(
+                "family-profile-asset-modal-projection-missing",
+                CanonicalLineVerdict::CanonLineIncomplete,
+                "activo con content pero sin subproyeccion asset verificable",
+            ));
+        }
+    }
+}
+
+fn modal_projections_include_asset(map: &serde_json::Map<String, Value>) -> bool {
+    map.get("content")
+        .and_then(Value::as_object)
+        .and_then(|content| content.get("asset"))
+        .and_then(Value::as_object)
+        .is_some()
+}
+
+fn profile_baseline_signature(family: &str) -> Option<Vec<String>> {
+    if session_family_profile(family).is_some() {
+        return Some(sorted_field_slice(SESSION_PROFILE_TOP_LEVEL_FIELDS));
+    }
+    if family == "role:asset" {
+        return Some(sorted_field_slice(ASSET_PROFILE_TOP_LEVEL_FIELDS));
+    }
+    None
+}
+
+fn core_or_profile_required_field(family: &str, field: &str) -> bool {
+    if session_family_profile(family).is_some() {
+        return SESSION_PROFILE_TOP_LEVEL_FIELDS.contains(&field);
+    }
+    if family == "role:asset" {
+        return ASSET_PROFILE_TOP_LEVEL_FIELDS.contains(&field);
+    }
+    CORE_EXPECTED_FIELDS.contains(&field)
+}
+
+fn build_template_family_reports(
+    observations: HashMap<String, Vec<TemplateObservation>>,
+) -> Vec<TemplateFamilyReport> {
+    let mut reports = Vec::new();
+    for (family, items) in observations {
+        if items.len() < 2 {
+            continue;
+        }
+
+        let mut variants: BTreeMap<Vec<String>, Vec<String>> = BTreeMap::new();
+        for item in items {
+            variants.entry(item.signature).or_default().push(item.title);
+        }
+        if variants.len() < 2 {
+            continue;
+        }
+
+        let (baseline, baseline_source) =
+            if let Some(profile_baseline) = profile_baseline_signature(&family) {
+                (profile_baseline, "family_profile".to_string())
+            } else {
+                (
+                    variants
+                        .iter()
+                        .max_by(|(left_sig, left_examples), (right_sig, right_examples)| {
+                            left_examples
+                                .len()
+                                .cmp(&right_examples.len())
+                                .then_with(|| right_sig.len().cmp(&left_sig.len()))
+                        })
+                        .map(|(signature, _)| signature.clone())
+                        .unwrap_or_default(),
+                    "observed_majority".to_string(),
+                )
+            };
+
+        let mut verdict = CanonicalLineVerdict::CanonLineWarning;
+        let mut variant_reports = Vec::new();
+        for (signature, examples) in variants {
+            let missing = diff_fields(&baseline, &signature);
+            let extra = diff_fields(&signature, &baseline);
+            if missing
+                .iter()
+                .any(|field| core_or_profile_required_field(&family, field))
+            {
+                verdict = worst_verdict(verdict, CanonicalLineVerdict::CanonLineIncomplete);
+            }
+            variant_reports.push(TemplateVariantReport {
+                count: examples.len(),
+                signature,
+                missing_from_baseline: missing,
+                extra_vs_baseline: extra,
+                examples: examples.into_iter().take(5).collect(),
+            });
+        }
+        variant_reports.sort_by(|a, b| b.count.cmp(&a.count));
+        reports.push(TemplateFamilyReport {
+            family,
+            verdict,
+            line_count: variant_reports.iter().map(|variant| variant.count).sum(),
+            variant_count: variant_reports.len(),
+            baseline_source,
+            baseline_signature: baseline,
+            variants: variant_reports,
+        });
+    }
+    reports.sort_by(|a, b| {
+        b.variant_count
+            .cmp(&a.variant_count)
+            .then_with(|| b.line_count.cmp(&a.line_count))
+            .then_with(|| a.family.cmp(&b.family))
+    });
+    reports
+}
+
+fn build_family_profile_reports(lines: &[CanonicalLineItemReport]) -> Vec<FamilyProfileReport> {
+    let mut by_family: BTreeMap<String, Vec<&CanonicalLineItemReport>> = BTreeMap::new();
+    for line in lines {
+        if is_profiled_family(&line.family) {
+            by_family.entry(line.family.clone()).or_default().push(line);
+        }
+    }
+
+    let mut reports = Vec::new();
+    for (family, items) in by_family {
+        let mut issue_groups: BTreeMap<(String, CanonicalLineVerdict), BTreeSet<String>> =
+            BTreeMap::new();
+        let mut verdict = CanonicalLineVerdict::CanonLineOk;
+        let mut issue_count = 0;
+        for item in &items {
+            for issue in item
+                .issues
+                .iter()
+                .filter(|issue| issue.rule_id.starts_with(FAMILY_PROFILE_RULE_PREFIX))
+            {
+                issue_count += 1;
+                verdict = worst_verdict(verdict, issue.impact);
+                let example = item
+                    .title
+                    .clone()
+                    .unwrap_or_else(|| format!("{}:{}", item.source_path, item.line));
+                issue_groups
+                    .entry((issue.rule_id.clone(), issue.impact))
+                    .or_default()
+                    .insert(example);
+            }
+        }
+
+        let mut issues = Vec::new();
+        for ((rule_id, impact), examples) in issue_groups {
+            issues.push(FamilyProfileIssueSummary {
+                rule_id,
+                impact,
+                count: examples.len(),
+                examples: examples.into_iter().take(5).collect(),
+            });
+        }
+        issues.sort_by(|a, b| {
+            verdict_rank(b.impact)
+                .cmp(&verdict_rank(a.impact))
+                .then_with(|| b.count.cmp(&a.count))
+                .then_with(|| a.rule_id.cmp(&b.rule_id))
+        });
+
+        reports.push(FamilyProfileReport {
+            profile_id: profile_id_for_family(&family).to_string(),
+            priority: profile_priority_for_family(&family).to_string(),
+            family,
+            line_count: items.len(),
+            verdict,
+            issue_count,
+            issues,
+        });
+    }
+
+    reports.sort_by(|a, b| {
+        verdict_rank(b.verdict)
+            .cmp(&verdict_rank(a.verdict))
+            .then_with(|| b.issue_count.cmp(&a.issue_count))
+            .then_with(|| b.line_count.cmp(&a.line_count))
+            .then_with(|| a.family.cmp(&b.family))
+    });
+    reports
+}
+
+fn empty_modal_projection_audit() -> ModalProjectionAuditReport {
+    ModalProjectionAuditReport {
+        profile_id: "canonical-modal-projection-profile-v1".to_string(),
+        inspected_lines: 0,
+        relevant_lines: 0,
+        projected_lines: 0,
+        missing_projection_lines: 0,
+        modality_counts: BTreeMap::new(),
+        projection_counts: BTreeMap::new(),
+        issues: Vec::new(),
+    }
+}
+
+fn build_modal_projection_audit(lines: &[CanonicalLineItemReport]) -> ModalProjectionAuditReport {
+    let mut report = empty_modal_projection_audit();
+    report.inspected_lines = lines.len();
+
+    for line in lines {
+        if line.family == "unparseable" {
+            continue;
+        }
+        for projection in &line.modal_projections {
+            *report
+                .projection_counts
+                .entry(projection.clone())
+                .or_insert(0) += 1;
+        }
+        if !line.modal_projections.is_empty() {
+            report.projected_lines += 1;
+        }
+
+        let modality_value = line.modality.clone();
+        let role_value = line
+            .role_primary
+            .clone()
+            .or_else(|| role_from_family(&line.family));
+        if let Some(value) = modality_value.as_ref().filter(|value| !value.is_empty()) {
+            *report.modality_counts.entry(value.clone()).or_insert(0) += 1;
+        }
+
+        let relevant = is_modal_projection_relevant(line, modality_value.as_deref());
+        if relevant {
+            report.relevant_lines += 1;
+        }
+        if relevant && line.modal_projections.is_empty() {
+            report.missing_projection_lines += 1;
+        }
+
+        for issue in line.issues.iter().filter(|issue| {
+            issue.rule_id.starts_with("modal-projection-")
+                || issue.rule_id == "family-profile-asset-content-projection-missing"
+                || issue.rule_id == "family-profile-asset-modal-projection-missing"
+        }) {
+            report.issues.push(ModalProjectionIssueReport {
+                source_path: line.source_path.clone(),
+                line: line.line,
+                title: line.title.clone(),
+                role_primary: role_value.clone(),
+                modality: modality_value.clone(),
+                rule_id: issue.rule_id.clone(),
+                severity: issue.severity.clone(),
+                message: issue.message.clone(),
+            });
+        }
+    }
+
+    report
+}
+
+fn build_debt_summary(report: &CanonicalLineGateReport) -> CanonQualityDebtSummary {
+    let mut modal_debt_lines = BTreeSet::new();
+    let mut asset_modal_debt_lines = BTreeSet::new();
+    let mut modal_debt_issue_count = 0;
+    let mut modal_debt_families = BTreeSet::new();
+    let mut richness_warning_lines = BTreeSet::new();
+    let mut incomplete_line_count = 0;
+    let mut blocking_line_count = 0;
+
+    for line in &report.lines {
+        if line.verdict == CanonicalLineVerdict::CanonLineIncomplete {
+            incomplete_line_count += 1;
+        }
+        if matches!(
+            line.verdict,
+            CanonicalLineVerdict::CanonLineInconsistent | CanonicalLineVerdict::CanonLineRejected
+        ) {
+            blocking_line_count += 1;
+        }
+
+        let line_key = format!("{}:{}", line.source_path, line.line);
+        let mut line_has_modal_debt = false;
+        for issue in &line.issues {
+            if is_modal_debt_rule(&issue.rule_id) {
+                modal_debt_issue_count += 1;
+                line_has_modal_debt = true;
+            }
+            if issue.rule_id == "missing-richness-field" {
+                richness_warning_lines.insert(line_key.clone());
+            }
+        }
+        if line_has_modal_debt {
+            modal_debt_lines.insert(line_key);
+            modal_debt_families.insert(line.family.clone());
+            if line.family == "role:asset" || line.role_primary.as_deref() == Some("asset") {
+                asset_modal_debt_lines.insert(format!("{}:{}", line.source_path, line.line));
+            }
+        }
+    }
+
+    let template_drift_families_total = report.template_families_with_drift.len();
+    let mut template_drift_families_modal_related = 0;
+    let mut template_drift_lines_historical = 0;
+    for family in &report.template_families_with_drift {
+        if modal_debt_families.contains(&family.family) {
+            template_drift_families_modal_related += 1;
+        } else {
+            template_drift_lines_historical += family.line_count;
+        }
+    }
+    let template_drift_families_historical =
+        template_drift_families_total.saturating_sub(template_drift_families_modal_related);
+
+    CanonQualityDebtSummary {
+        profile_id: "canonical-quality-debt-separation-v1".to_string(),
+        modal_debt_lines: modal_debt_lines.len(),
+        modal_debt_issue_count,
+        asset_modal_debt_lines: asset_modal_debt_lines.len(),
+        template_drift_families_total,
+        template_drift_families_modal_related,
+        template_drift_families_historical,
+        template_drift_lines_historical,
+        richness_warning_lines: richness_warning_lines.len(),
+        incomplete_line_count,
+        blocking_line_count,
+    }
+}
+
+fn is_modal_debt_rule(rule_id: &str) -> bool {
+    rule_id.starts_with("modal-projection-")
+        || rule_id == "family-profile-asset-content-projection-missing"
+        || rule_id == "family-profile-asset-modal-projection-missing"
+}
+
+fn is_modal_projection_relevant(line: &CanonicalLineItemReport, modality: Option<&str>) -> bool {
+    if line.family == "role:asset" {
+        return true;
+    }
+    matches!(
+        modality,
+        Some("image")
+            | Some("binary")
+            | Some("code")
+            | Some("equation")
+            | Some("mixed")
+            | Some("metadata")
+    )
+}
+
+fn role_from_family(family: &str) -> Option<String> {
+    family
+        .strip_prefix("role:")
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn build_incomplete_line_triage(
+    lines: &[CanonicalLineItemReport],
+) -> Vec<IncompleteLineTriageReport> {
+    let mut groups: BTreeMap<(String, String), Vec<&CanonicalLineItemReport>> = BTreeMap::new();
+    for line in lines
+        .iter()
+        .filter(|line| line.verdict == CanonicalLineVerdict::CanonLineIncomplete)
+    {
+        let reason = primary_incomplete_reason(line);
+        groups
+            .entry((line.family.clone(), reason.to_string()))
+            .or_default()
+            .push(line);
+    }
+
+    let mut reports = Vec::new();
+    for ((family, reason), items) in groups {
+        let mut rule_ids = Vec::new();
+        for item in &items {
+            for issue in item
+                .issues
+                .iter()
+                .filter(|issue| issue.impact == CanonicalLineVerdict::CanonLineIncomplete)
+            {
+                if !rule_ids.contains(&issue.rule_id) {
+                    rule_ids.push(issue.rule_id.clone());
+                }
+            }
+        }
+        rule_ids.sort();
+
+        reports.push(IncompleteLineTriageReport {
+            priority: triage_priority(&family, &reason).to_string(),
+            family,
+            reason,
+            line_count: items.len(),
+            rule_ids,
+            examples: items
+                .into_iter()
+                .take(8)
+                .map(|item| {
+                    let title = item.title.as_deref().unwrap_or("<sin titulo>");
+                    format!("{}:{} {}", item.source_path, item.line, title)
+                })
+                .collect(),
+        });
+    }
+
+    reports.sort_by(|a, b| {
+        triage_rank(&a.priority)
+            .cmp(&triage_rank(&b.priority))
+            .then_with(|| b.line_count.cmp(&a.line_count))
+            .then_with(|| a.family.cmp(&b.family))
+    });
+    reports
+}
+
+fn primary_incomplete_reason(line: &CanonicalLineItemReport) -> &'static str {
+    if line.family == "role:asset"
+        && line.issues.iter().any(|issue| {
+            issue.rule_id == "missing-core-canon-field" && issue.message.ends_with("content")
+        })
+    {
+        return "asset_without_content_projection";
+    }
+    if line
+        .issues
+        .iter()
+        .any(|issue| issue.rule_id == "missing-core-canon-field")
+    {
+        return "missing_core_canon_field";
+    }
+    if line
+        .issues
+        .iter()
+        .any(|issue| issue.rule_id == "missing-required-field")
+    {
+        return "missing_identity_field";
+    }
+    "other_incomplete_profile_or_shape"
+}
+
+fn triage_priority(family: &str, reason: &str) -> &'static str {
+    match (family, reason) {
+        ("role:asset", "asset_without_content_projection") => "medium",
+        (_, "missing_identity_field") => "high",
+        (_, "missing_core_canon_field") => "high",
+        _ => "medium",
+    }
+}
+
+fn triage_rank(priority: &str) -> u8 {
+    match priority {
+        "high" => 0,
+        "medium" => 1,
+        "low" => 2,
+        _ => 3,
+    }
+}
+
+fn inspect_text_field(
+    root: &Path,
+    source_file: &Path,
+    line: usize,
+    title: Option<String>,
+    field: &str,
+    text: &str,
+    report: &mut DeepNodeInspectionReport,
+) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    let mut direct_json_found = false;
+    if looks_like_json(trimmed) {
+        direct_json_found = true;
+        push_json_finding(
+            root,
+            source_file,
+            line,
+            title.clone(),
+            field,
+            "embedded_json",
+            trimmed,
+            None,
+            report,
+        );
+    }
+
+    for block in json_fence_blocks(text) {
+        push_json_finding(
+            root,
+            source_file,
+            line,
+            title.clone(),
+            field,
+            "json_fence",
+            &block.content,
+            Some(&block.context),
+            report,
+        );
+        report.counts.json_fence += 1;
+    }
+
+    if has_yaml_front_matter(trimmed) {
+        report.counts.yaml_front_matter += 1;
+        report.findings.push(DeepNodeFinding {
+            source_path: display_quality_path(root, source_file),
+            line,
+            title: title.clone(),
+            field: field.to_string(),
+            kind: "yaml_front_matter".to_string(),
+            status: "detected".to_string(),
+            byte_count: trimmed.len(),
+            top_level_type: None,
+            top_level_keys: Vec::new(),
+            array_len: None,
+            recovery_actions: Vec::new(),
+            message: "front matter YAML detectable al inicio del texto".to_string(),
+        });
+    }
+
+    if !direct_json_found && has_markdown_table(trimmed) {
+        report.counts.markdown_table += 1;
+        report.findings.push(DeepNodeFinding {
+            source_path: display_quality_path(root, source_file),
+            line,
+            title: title.clone(),
+            field: field.to_string(),
+            kind: "markdown_table".to_string(),
+            status: "detected".to_string(),
+            byte_count: trimmed.len(),
+            top_level_type: None,
+            top_level_keys: Vec::new(),
+            array_len: None,
+            recovery_actions: Vec::new(),
+            message: "tabla markdown interna detectable".to_string(),
+        });
+    }
+
+    if !direct_json_found && has_key_value_block(trimmed) {
+        report.counts.key_value_block += 1;
+        report.findings.push(DeepNodeFinding {
+            source_path: display_quality_path(root, source_file),
+            line,
+            title,
+            field: field.to_string(),
+            kind: "key_value_block".to_string(),
+            status: "detected".to_string(),
+            byte_count: trimmed.len(),
+            top_level_type: None,
+            top_level_keys: Vec::new(),
+            array_len: None,
+            recovery_actions: Vec::new(),
+            message: "bloque key/value interno detectable".to_string(),
+        });
+    }
+}
+
+fn push_json_finding(
+    root: &Path,
+    source_file: &Path,
+    line: usize,
+    title: Option<String>,
+    field: &str,
+    kind: &str,
+    raw: &str,
+    context: Option<&str>,
+    report: &mut DeepNodeInspectionReport,
+) {
+    if is_pedagogical_json(kind, raw, context, title.as_deref()) {
+        report.counts.pedagogical_json += 1;
+        report.findings.push(DeepNodeFinding {
+            source_path: display_quality_path(root, source_file),
+            line,
+            title,
+            field: field.to_string(),
+            kind: kind.to_string(),
+            status: "pedagogical_json".to_string(),
+            byte_count: raw.len(),
+            top_level_type: None,
+            top_level_keys: Vec::new(),
+            array_len: None,
+            recovery_actions: Vec::new(),
+            message:
+                "bloque JSON ilustrativo o de fixture; no se interpreta como payload estructural"
+                    .to_string(),
+        });
+        return;
+    }
+
+    match serde_json::from_str::<Value>(raw) {
+        Ok(value) => {
+            report.counts.structural_json += 1;
+            report.counts.valid_json += 1;
+            let (top_level_type, top_level_keys, array_len) = summarize_json_value(&value);
+            report.findings.push(DeepNodeFinding {
+                source_path: display_quality_path(root, source_file),
+                line,
+                title,
+                field: field.to_string(),
+                kind: kind.to_string(),
+                status: "valid_json".to_string(),
+                byte_count: raw.len(),
+                top_level_type: Some(top_level_type),
+                top_level_keys,
+                array_len,
+                recovery_actions: Vec::new(),
+                message: "JSON incrustado valido; no se reescribio el nodo".to_string(),
+            });
+        }
+        Err(err) => {
+            let (fragment, fragment_actions) = repair_json_fragment(raw);
+            if let Ok(value) = serde_json::from_str::<Value>(&fragment) {
+                if !fragment_actions.is_empty() {
+                    report.counts.structural_json += 1;
+                    report.counts.recoverable_json += 1;
+                    report.counts.json_fragment += 1;
+                    let (top_level_type, top_level_keys, array_len) = summarize_json_value(&value);
+                    report.findings.push(DeepNodeFinding {
+                        source_path: display_quality_path(root, source_file),
+                        line,
+                        title,
+                        field: field.to_string(),
+                        kind: kind.to_string(),
+                        status: "recoverable_json_fragment".to_string(),
+                        byte_count: raw.len(),
+                        top_level_type: Some(top_level_type),
+                        top_level_keys,
+                        array_len,
+                        recovery_actions: fragment_actions,
+                        message: "fragmento JSON recuperable para auditoria; el texto original no fue modificado".to_string(),
+                    });
+                    return;
+                }
+            }
+
+            let (repaired, actions) = repair_json_like(raw);
+            match serde_json::from_str::<Value>(&repaired) {
+                Ok(value) if !actions.is_empty() => {
+                    report.counts.structural_json += 1;
+                    report.counts.recoverable_json += 1;
+                    let (top_level_type, top_level_keys, array_len) = summarize_json_value(&value);
+                    report.findings.push(DeepNodeFinding {
+                        source_path: display_quality_path(root, source_file),
+                        line,
+                        title,
+                        field: field.to_string(),
+                        kind: kind.to_string(),
+                        status: "recoverable_json".to_string(),
+                        byte_count: raw.len(),
+                        top_level_type: Some(top_level_type),
+                        top_level_keys,
+                        array_len,
+                        recovery_actions: actions,
+                        message: "JSON casi valido recuperable en reporte; el texto original no fue modificado".to_string(),
+                    });
+                }
+                _ => {
+                    report.counts.invalid_json += 1;
+                    report.findings.push(DeepNodeFinding {
+                        source_path: display_quality_path(root, source_file),
+                        line,
+                        title,
+                        field: field.to_string(),
+                        kind: kind.to_string(),
+                        status: "invalid_json".to_string(),
+                        byte_count: raw.len(),
+                        top_level_type: None,
+                        top_level_keys: Vec::new(),
+                        array_len: None,
+                        recovery_actions: actions,
+                        message: format!("parece JSON pero no pudo parsearse: {}", err),
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn read_node_records(source_file: &Path) -> Vec<NodeRecord> {
+    let content = match std::fs::read_to_string(source_file) {
+        Ok(content) => content,
+        Err(_) => return Vec::new(),
+    };
+
+    if source_file
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("json"))
+        .unwrap_or(false)
+    {
+        if let Ok(Value::Array(items)) = serde_json::from_str::<Value>(&content) {
+            return items
+                .into_iter()
+                .enumerate()
+                .map(|(index, value)| NodeRecord {
+                    line: index + 1,
+                    value,
+                })
+                .collect();
+        }
+    }
+
+    content
+        .lines()
+        .enumerate()
+        .filter_map(|(index, line)| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            serde_json::from_str::<Value>(trimmed)
+                .ok()
+                .map(|value| NodeRecord {
+                    line: index + 1,
+                    value,
+                })
+        })
+        .collect()
+}
+
+fn text_fields_from_object(map: &serde_json::Map<String, Value>) -> Vec<(String, String)> {
+    let mut fields = Vec::new();
+    let mut seen_values = Vec::new();
+    if let Some(text) = map.get("text").and_then(Value::as_str) {
+        fields.push(("text".to_string(), text.to_string()));
+        seen_values.push(text.to_string());
+    }
+    if let Some(Value::Object(content)) = map.get("content") {
+        for key in ["plain", "markdown"] {
+            if let Some(value) = content.get(key).and_then(Value::as_str) {
+                if !seen_values.iter().any(|seen| seen == value) {
+                    fields.push((format!("content.{}", key), value.to_string()));
+                    seen_values.push(value.to_string());
+                }
+            }
+        }
+    }
+    fields
+}
+
+fn collect_canonical_input_files(input: &Path) -> Vec<PathBuf> {
+    if input.is_file() {
+        return vec![input.to_path_buf()];
+    }
+    if !input.is_dir() {
+        return Vec::new();
+    }
+    let mut files = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(input) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() && is_jsonl_path(&path) {
+                files.push(path);
+            }
+        }
+    }
+    files
+}
+
+fn collect_deep_node_input_files(input: &Path) -> Vec<PathBuf> {
+    if input.is_file() {
+        return vec![input.to_path_buf()];
+    }
+    collect_canonical_input_files(input)
+}
+
+fn resolve_quality_path(root: &Path, value: &Path) -> PathBuf {
+    if value.is_absolute() {
+        value.to_path_buf()
+    } else {
+        root.join(value)
+    }
+}
+
+fn display_quality_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .to_string()
+}
+
+fn is_jsonl_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("jsonl"))
+        .unwrap_or(false)
+}
+
+fn sorted_object_keys(map: &serde_json::Map<String, Value>) -> Vec<String> {
+    let mut keys: Vec<String> = map.keys().cloned().collect();
+    keys.sort();
+    keys
+}
+
+fn sorted_field_slice(fields: &[&str]) -> Vec<String> {
+    let mut keys: Vec<String> = fields.iter().map(|field| field.to_string()).collect();
+    keys.sort();
+    keys
+}
+
+struct SessionFamilyProfile {
+    title_prefix: &'static str,
+    source_path_prefix: &'static str,
+}
+
+fn session_family_profile(family: &str) -> Option<SessionFamilyProfile> {
+    match family {
+        "contrato_de_sesion" => Some(SessionFamilyProfile {
+            title_prefix: "#### 🌀 Contrato de sesión",
+            source_path_prefix: "data/sessions/00_contratos/",
+        }),
+        "procedencia_de_sesion" => Some(SessionFamilyProfile {
+            title_prefix: "#### 🌀🧾 Procedencia de sesión",
+            source_path_prefix: "data/sessions/01_procedencia/",
+        }),
+        "detalles_de_sesion" => Some(SessionFamilyProfile {
+            title_prefix: "#### 🌀 Sesión",
+            source_path_prefix: "data/sessions/02_detalles_de_sesion/",
+        }),
+        "hipotesis_de_sesion" => Some(SessionFamilyProfile {
+            title_prefix: "#### 🌀🧪 Hipótesis de sesión",
+            source_path_prefix: "data/sessions/03_hipotesis/",
+        }),
+        "balance_de_sesion" => Some(SessionFamilyProfile {
+            title_prefix: "#### 🌀 Balance de sesión",
+            source_path_prefix: "data/sessions/04_balance_de_sesion/",
+        }),
+        "propuesta_de_sesion" => Some(SessionFamilyProfile {
+            title_prefix: "#### 🌀 Propuesta de sesión",
+            source_path_prefix: "data/sessions/05_propuesta_de_sesion/",
+        }),
+        "diagnostico_de_sesion" => Some(SessionFamilyProfile {
+            title_prefix: "#### 🌀 Diagnóstico de sesión",
+            source_path_prefix: "data/sessions/06_diagnoses/sesion/",
+        }),
+        _ => None,
+    }
+}
+
+fn is_profiled_family(family: &str) -> bool {
+    session_family_profile(family).is_some() || family == "role:asset"
+}
+
+fn profile_id_for_family(family: &str) -> &'static str {
+    if session_family_profile(family).is_some() {
+        "session-artifact-profile-v1"
+    } else if family == "role:asset" {
+        "asset-canonical-payload-profile-v1"
+    } else {
+        "unprofiled"
+    }
+}
+
+fn profile_priority_for_family(family: &str) -> &'static str {
+    if session_family_profile(family).is_some() {
+        "high"
+    } else if family == "role:asset" {
+        "medium"
+    } else {
+        "low"
+    }
+}
+
+fn artifact_family(map: &serde_json::Map<String, Value>, title: Option<&str>) -> String {
+    if let Some(family) = source_fields_string_from_map(map, "artifact_family") {
+        return family.to_string();
+    }
+    if let Some(title) = title {
+        if title.starts_with("#### 🌀 Contrato de sesión") {
+            return "contrato_de_sesion".to_string();
+        }
+        if title.starts_with("#### 🌀🧾 Procedencia de sesión") {
+            return "procedencia_de_sesion".to_string();
+        }
+        if title.starts_with("#### 🌀 Sesión") {
+            return "detalles_de_sesion".to_string();
+        }
+        if title.starts_with("#### 🌀🧪 Hipótesis de sesión") {
+            return "hipotesis_de_sesion".to_string();
+        }
+        if title.starts_with("#### 🌀 Balance de sesión") {
+            return "balance_de_sesion".to_string();
+        }
+        if title.starts_with("#### 🌀 Propuesta de sesión") {
+            return "propuesta_de_sesion".to_string();
+        }
+        if title.starts_with("#### 🌀 Diagnóstico de sesión") {
+            return "diagnostico_de_sesion".to_string();
+        }
+    }
+    if let Some(role) = map.get("role_primary").and_then(Value::as_str) {
+        return format!("role:{}", role);
+    }
+    if let Some(source_type) = map.get("source_type").and_then(Value::as_str) {
+        return format!("source_type:{}", source_type);
+    }
+    "unclassified".to_string()
+}
+
+fn source_fields_string(map: &serde_json::Map<String, Value>, key: &str) -> Option<String> {
+    source_fields_string_from_map(map, key).map(str::to_string)
+}
+
+fn source_fields_string_from_map<'a>(
+    map: &'a serde_json::Map<String, Value>,
+    key: &str,
+) -> Option<&'a str> {
+    map.get("source_fields")
+        .and_then(Value::as_object)
+        .and_then(|fields| fields.get(key))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn tag_values(map: &serde_json::Map<String, Value>) -> Vec<&str> {
+    let mut tags = Vec::new();
+    for key in ["tags", "source_tags", "normalized_tags"] {
+        if let Some(Value::Array(values)) = map.get(key) {
+            tags.extend(values.iter().filter_map(Value::as_str));
+        }
+    }
+    tags
+}
+
+fn has_tag_with_prefix(map: &serde_json::Map<String, Value>, prefix: &str) -> bool {
+    tag_values(map)
+        .iter()
+        .any(|tag| tag.trim().starts_with(prefix))
+}
+
+fn has_exact_tag(map: &serde_json::Map<String, Value>, expected: &str) -> bool {
+    tag_values(map).iter().any(|tag| tag.trim() == expected)
+}
+
+fn has_source_anchor(map: &serde_json::Map<String, Value>) -> bool {
+    for key in ["source_position", "raw_payload_ref"] {
+        if map
+            .get(key)
+            .and_then(Value::as_str)
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+        {
+            return true;
+        }
+    }
+    source_fields_string_from_map(map, "source_path").is_some()
+}
+
+fn has_session_origin(map: &serde_json::Map<String, Value>) -> bool {
+    if source_fields_string_from_map(map, "session_origin").is_some() {
+        return true;
+    }
+    for key in ["source_tags", "tags"] {
+        if let Some(Value::Array(tags)) = map.get(key) {
+            if tags
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|tag| tag.starts_with("session:"))
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn is_session_artifact_title(title: &str) -> bool {
+    title.starts_with("#### 🌀")
+}
+
+fn contains_placeholder(value: &str) -> bool {
+    let lower = value.to_lowercase();
+    lower.contains("pendiente")
+        || lower.contains("todo")
+        || lower.contains("resolver luego")
+        || lower.contains("fixme")
+}
+
+fn is_uuid_like(value: &str) -> bool {
+    let uuid = value.strip_prefix("urn:uuid:").unwrap_or(value);
+    if uuid.len() != 36 {
+        return false;
+    }
+    for (index, byte) in uuid.bytes().enumerate() {
+        match index {
+            8 | 13 | 18 | 23 => {
+                if byte != b'-' {
+                    return false;
+                }
+            }
+            _ => {
+                if !byte.is_ascii_hexdigit() {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+fn is_sha256_label(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return false;
+    };
+    hex.len() == 64 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_tiddlywiki_timestamp(value: &str) -> bool {
+    value.len() == 17 && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn diff_fields(left: &[String], right: &[String]) -> Vec<String> {
+    left.iter()
+        .filter(|field| !right.contains(field))
+        .cloned()
+        .collect()
+}
+
+fn worst_verdict(left: CanonicalLineVerdict, right: CanonicalLineVerdict) -> CanonicalLineVerdict {
+    if verdict_rank(right) > verdict_rank(left) {
+        right
+    } else {
+        left
+    }
+}
+
+fn verdict_rank(verdict: CanonicalLineVerdict) -> u8 {
+    match verdict {
+        CanonicalLineVerdict::CanonLineOk => 0,
+        CanonicalLineVerdict::CanonLineWarning => 1,
+        CanonicalLineVerdict::CanonLineIncomplete => 2,
+        CanonicalLineVerdict::CanonLineInconsistent => 3,
+        CanonicalLineVerdict::CanonLineRejected => 4,
+    }
+}
+
+fn looks_like_json(value: &str) -> bool {
+    value.starts_with('{') || value.starts_with('[')
+}
+
+fn summarize_json_value(value: &Value) -> (String, Vec<String>, Option<usize>) {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<String> = map.keys().take(20).cloned().collect();
+            keys.sort();
+            ("object".to_string(), keys, None)
+        }
+        Value::Array(items) => ("array".to_string(), Vec::new(), Some(items.len())),
+        Value::Null => ("null".to_string(), Vec::new(), None),
+        Value::Bool(_) => ("bool".to_string(), Vec::new(), None),
+        Value::Number(_) => ("number".to_string(), Vec::new(), None),
+        Value::String(_) => ("string".to_string(), Vec::new(), None),
+    }
+}
+
+fn json_fence_blocks(text: &str) -> Vec<JsonFenceBlock> {
+    let lower = text.to_ascii_lowercase();
+    let mut blocks = Vec::new();
+    let mut offset = 0;
+    while let Some(start_rel) = lower[offset..].find("```json") {
+        let fence_start = offset + start_rel;
+        let Some(line_end_rel) = text[fence_start..].find('\n') else {
+            break;
+        };
+        let content_start = fence_start + line_end_rel + 1;
+        let Some(end_rel) = text[content_start..].find("```") else {
+            break;
+        };
+        let content_end = content_start + end_rel;
+        blocks.push(JsonFenceBlock {
+            content: text[content_start..content_end].trim().to_string(),
+            context: fence_context(text, fence_start),
+        });
+        offset = content_end + 3;
+    }
+    blocks
+}
+
+fn fence_context(text: &str, fence_start: usize) -> String {
+    let prefix = &text[..fence_start.min(text.len())];
+    let mut context_lines: Vec<&str> = prefix
+        .lines()
+        .rev()
+        .filter(|line| !line.trim().is_empty())
+        .take(4)
+        .collect();
+    context_lines.reverse();
+    context_lines.join("\n")
+}
+
+fn has_yaml_front_matter(text: &str) -> bool {
+    if !text.starts_with("---\n") {
+        return false;
+    }
+    text[4..].contains("\n---")
+}
+
+fn has_markdown_table(text: &str) -> bool {
+    let mut has_row = false;
+    let mut has_separator = false;
+    for line in text.lines().take(80) {
+        let trimmed = line.trim();
+        if trimmed.starts_with('|') && trimmed.ends_with('|') {
+            has_row = true;
+            if trimmed.contains("---") {
+                has_separator = true;
+            }
+        }
+    }
+    has_row && has_separator
+}
+
+fn has_key_value_block(text: &str) -> bool {
+    let mut count = 0;
+    for line in text.lines().take(40) {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') || trimmed.starts_with('-') || trimmed.is_empty() {
+            continue;
+        }
+        let Some((key, value)) = trimmed.split_once(':') else {
+            continue;
+        };
+        if !key.is_empty()
+            && !value.trim().is_empty()
+            && key
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+        {
+            count += 1;
+        }
+    }
+    count >= 3
+}
+
+fn is_pedagogical_json(kind: &str, raw: &str, context: Option<&str>, title: Option<&str>) -> bool {
+    if kind != "json_fence" {
+        return false;
+    }
+
+    let trimmed = raw.trim();
+    let lower_raw = trimmed.to_ascii_lowercase();
+    let lower_context = context.unwrap_or("").to_ascii_lowercase();
+    let lower_title = title.unwrap_or("").to_ascii_lowercase();
+
+    if lower_raw.contains("json.dumps(")
+        || lower_raw.contains("esto no es json")
+        || lower_raw.contains("//")
+        || lower_raw.contains("/*")
+        || lower_raw.contains("...")
+        || lower_raw.contains("uuid-v5")
+        || lower_raw.contains("uuid-v5-del")
+        || lower_raw.contains("\"string\"")
+        || lower_raw.contains(": \"string")
+    {
+        return true;
+    }
+
+    if lower_context.contains("ejemplo")
+        || lower_context.contains("plantilla")
+        || lower_context.contains("schema")
+        || lower_context.contains("formato")
+        || lower_context.contains("fixture")
+        || lower_title.contains("readme")
+        || lower_title.contains("fixture")
+    {
+        return true;
+    }
+
+    if !looks_like_json(trimmed) && !looks_like_json_object_fragment(trimmed) {
+        return true;
+    }
+
+    false
+}
+
+fn looks_like_json_object_fragment(raw: &str) -> bool {
+    let trimmed = raw.trim_start();
+    trimmed.starts_with('"') && trimmed.contains("\":")
+}
+
+fn repair_json_fragment(raw: &str) -> (String, Vec<String>) {
+    let trimmed = raw.trim();
+    if looks_like_json_object_fragment(trimmed) {
+        return (
+            format!("{{{}}}", trimmed),
+            vec!["wrapped JSON object fragment with braces".to_string()],
+        );
+    }
+    (raw.to_string(), Vec::new())
+}
+
+fn repair_json_like(raw: &str) -> (String, Vec<String>) {
+    let mut working = raw.to_string();
+    let mut actions = Vec::new();
+    for _ in 0..3 {
+        if serde_json::from_str::<Value>(&working).is_ok() {
+            break;
+        }
+        let mut changed = false;
+        let escaped = repair_invalid_json_escapes(&working);
+        if escaped != working {
+            working = escaped;
+            changed = true;
+            if !actions
+                .iter()
+                .any(|item| item == "repaired invalid JSON escapes")
+            {
+                actions.push("repaired invalid JSON escapes".to_string());
+            }
+        }
+        if serde_json::from_str::<Value>(&working).is_ok() {
+            break;
+        }
+        let commas = repair_missing_json_array_commas(&working);
+        if commas != working {
+            working = commas;
+            changed = true;
+            if !actions
+                .iter()
+                .any(|item| item == "repaired missing JSON array commas")
+            {
+                actions.push("repaired missing JSON array commas".to_string());
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    (working, actions)
+}
+
+fn repair_invalid_json_escapes(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(raw.len() + 16);
+    let mut in_string = false;
+    let mut index = 0;
+    while index < bytes.len() {
+        let ch = bytes[index];
+        if !in_string {
+            out.push(ch);
+            if ch == b'"' {
+                in_string = true;
+            }
+            index += 1;
+            continue;
+        }
+        match ch {
+            b'"' => {
+                in_string = false;
+                out.push(b'"');
+                index += 1;
+            }
+            b'\\' => {
+                if index + 1 < bytes.len() {
+                    let next = bytes[index + 1];
+                    if next == b'u'
+                        && index + 5 < bytes.len()
+                        && is_hex_quartet(&raw[index + 2..index + 6])
+                    {
+                        out.extend_from_slice(&bytes[index..index + 6]);
+                        index += 6;
+                        continue;
+                    }
+                    if is_standard_json_escape(next) {
+                        out.push(b'\\');
+                        out.push(next);
+                        index += 2;
+                        continue;
+                    }
+                }
+                out.extend_from_slice(b"\\\\");
+                index += 1;
+            }
+            _ => {
+                out.push(ch);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| raw.to_string())
+}
+
+fn repair_missing_json_array_commas(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(raw.len() + 16);
+    let mut stack: Vec<u8> = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for index in 0..bytes.len() {
+        let ch = bytes[index];
+        out.push(ch);
+        if in_string {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            match ch {
+                b'\\' => escaped = true,
+                b'"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+        match ch {
+            b'"' => in_string = true,
+            b'{' | b'[' => stack.push(ch),
+            b'}' => {
+                if stack.last() == Some(&b'{') {
+                    stack.pop();
+                }
+                if inside_json_array(&stack) && next_json_array_value_needs_comma(bytes, index + 1)
+                {
+                    out.push(b',');
+                }
+            }
+            b']' => {
+                if stack.last() == Some(&b'[') {
+                    stack.pop();
+                }
+                if inside_json_array(&stack) && next_json_array_value_needs_comma(bytes, index + 1)
+                {
+                    out.push(b',');
+                }
+            }
+            _ => {}
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| raw.to_string())
+}
+
+fn inside_json_array(stack: &[u8]) -> bool {
+    stack.last() == Some(&b'[')
+}
+
+fn next_json_array_value_needs_comma(bytes: &[u8], start: usize) -> bool {
+    let mut index = start;
+    while index < bytes.len() && is_json_whitespace(bytes[index]) {
+        index += 1;
+    }
+    if index >= bytes.len() {
+        return false;
+    }
+    match bytes[index] {
+        b',' | b']' => false,
+        other => is_json_value_start(other),
+    }
+}
+
+fn is_json_whitespace(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\n' | b'\r' | b'\t')
+}
+
+fn is_json_value_start(byte: u8) -> bool {
+    matches!(byte, b'"' | b'{' | b'[' | b't' | b'f' | b'n') || is_json_number_start(byte)
+}
+
+fn is_json_number_start(byte: u8) -> bool {
+    byte.is_ascii_digit() || byte == b'-'
+}
+
+fn is_standard_json_escape(byte: u8) -> bool {
+    matches!(byte, b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't')
+}
+
+fn is_hex_quartet(value: &str) -> bool {
+    value.len() == 4 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[derive(Debug)]
+struct TemplateObservation {
+    signature: Vec<String>,
+    title: String,
+}
+
+struct NodeRecord {
+    line: usize,
+    value: Value,
+}
+
+struct JsonFenceBlock {
+    content: String,
+    context: String,
+}

--- a/rust/doctor/src/lib.rs
+++ b/rust/doctor/src/lib.rs
@@ -25,16 +25,24 @@
 //!
 //! Ref: contratos/m01-s04-doctor-contract.md
 
+pub mod canon_quality;
 pub mod error;
 pub mod report;
 
 use std::path::{Path, PathBuf};
 
+pub use canon_quality::{audit_canonical_lines, inspect_deep_nodes};
 pub use error::DoctorError;
 pub use report::{
-    DoctorReport, DoctorVerdict, PerimeterCheck, PerimeterReport, PerimeterVerdict,
-    ReconstructionMode, ReconstructionPlanInput, ReconstructionPlanReport,
-    ReconstructionPlanVerdict, ReconstructionSourceRole,
+    CanonQualityDebtSummary, CanonicalLineCounts, CanonicalLineGateReport, CanonicalLineIssue,
+    CanonicalLineItemReport, CanonicalLineVerdict, DeepNodeFinding, DeepNodeFindingCounts,
+    DeepNodeInspectionReport, DeepNodeInspectorVerdict, DoctorReport, DoctorVerdict,
+    FamilyProfileIssueSummary, FamilyProfileReport, IncompleteLineTriageReport,
+    ModalProjectionAuditReport, ModalProjectionIssueReport, PerimeterCheck, PerimeterReport,
+    PerimeterVerdict, ReconstructionMode, ReconstructionPlanInput, ReconstructionPlanReport,
+    ReconstructionPlanVerdict, ReconstructionRollbackInput, ReconstructionRollbackReport,
+    ReconstructionRollbackVerdict, ReconstructionSourceRole, TemplateFamilyReport,
+    TemplateVariantReport,
 };
 
 /// Audita la integridad estructural mínima del artefacto raw producido por el Extractor HTML.
@@ -315,12 +323,46 @@ pub fn audit_reconstruction_plan(
     requires_backup: bool,
     requires_hash_report: bool,
 ) -> ReconstructionPlanReport {
+    audit_reconstruction_plan_with_artifacts(
+        repo_root,
+        source_html_path,
+        source_role,
+        reconstruction_mode,
+        output_target,
+        None,
+        None,
+        requires_backup,
+        requires_hash_report,
+    )
+}
+
+/// Audita un plan de reconstrucción con artefactos operativos concretos.
+///
+/// Esta variante se usa cuando el menú ya seleccionó un JSONL temporal o un
+/// run directory de reconstrucción. Rust no ejecuta shardización ni reverse:
+/// valida que la procedencia HTML -> JSONL esté demostrada por manifiesto y
+/// que el espacio de evidencia viva bajo `data/tmp/reconstruction/`.
+pub fn audit_reconstruction_plan_with_artifacts(
+    repo_root: &Path,
+    source_html_path: &Path,
+    source_role: ReconstructionSourceRole,
+    reconstruction_mode: ReconstructionMode,
+    output_target: &Path,
+    input_jsonl_path: Option<&Path>,
+    reconstruction_run_dir: Option<&Path>,
+    requires_backup: bool,
+    requires_hash_report: bool,
+) -> ReconstructionPlanReport {
     let root = repo_root;
     let mut checks: Vec<PerimeterCheck> = Vec::new();
     let source = resolve_plan_path(root, source_html_path);
     let target = resolve_plan_path(root, output_target);
+    let input_jsonl = input_jsonl_path.map(|path| resolve_plan_path(root, path));
+    let run_dir = reconstruction_run_dir.map(|path| resolve_plan_path(root, path));
     let data_in = root.join("data/in");
     let data_tmp = root.join("data/tmp");
+    let html_export_dir = root.join("data/tmp/html_export");
+    let reconstruction_dir = root.join("data/tmp/reconstruction");
     let canon_dir = root.join("data/out/local");
     let reverse_html_dir = root.join("data/out/local/reverse_html");
 
@@ -330,6 +372,21 @@ pub fn audit_reconstruction_plan(
         &data_tmp,
         &canon_dir,
         &reverse_html_dir,
+        &reconstruction_mode,
+        &mut checks,
+    );
+    check_reconstruction_run_dir(
+        root,
+        run_dir.as_deref(),
+        &reconstruction_dir,
+        &reconstruction_mode,
+        &mut checks,
+    );
+    check_input_jsonl_origin(
+        root,
+        &source,
+        input_jsonl.as_deref(),
+        &html_export_dir,
         &reconstruction_mode,
         &mut checks,
     );
@@ -348,7 +405,15 @@ pub fn audit_reconstruction_plan(
         );
     }
 
-    if path_has_parent_component(source_html_path) || path_has_parent_component(output_target) {
+    if path_has_parent_component(source_html_path)
+        || path_has_parent_component(output_target)
+        || input_jsonl_path
+            .map(path_has_parent_component)
+            .unwrap_or(false)
+        || reconstruction_run_dir
+            .map(path_has_parent_component)
+            .unwrap_or(false)
+    {
         push_error(
             &mut checks,
             "plan-no-parent-path-components",
@@ -507,6 +572,10 @@ pub fn audit_reconstruction_plan(
             source_role,
             reconstruction_mode,
             output_target: display_plan_path(root, &target),
+            input_jsonl_path: input_jsonl
+                .as_deref()
+                .map(|path| display_plan_path(root, path)),
+            reconstruction_run_dir: run_dir.as_deref().map(|path| display_plan_path(root, path)),
             requires_backup,
             requires_hash_report,
         },
@@ -532,6 +601,456 @@ pub fn parse_reconstruction_mode(value: &str) -> Option<ReconstructionMode> {
         "write_local_canon" => Some(ReconstructionMode::WriteLocalCanon),
         "reverse_projection" => Some(ReconstructionMode::ReverseProjection),
         _ => None,
+    }
+}
+
+/// Audita un reporte de reconstrucción antes de que Python restaure su backup.
+///
+/// Rust no modifica `data/out/local`. Solo comprueba que el reporte pertenece
+/// a `data/tmp/reconstruction/`, que declara rollback habilitado, que el backup
+/// contiene shards reales y que el hash de ese backup coincide con el
+/// `canon_before_hash` registrado.
+pub fn audit_reconstruction_rollback(
+    repo_root: &Path,
+    report_path: &Path,
+) -> ReconstructionRollbackReport {
+    let root = repo_root;
+    let mut checks: Vec<PerimeterCheck> = Vec::new();
+    let report = resolve_plan_path(root, report_path);
+    let reconstruction_dir = root.join("data/tmp/reconstruction");
+    let canon_dir = root.join("data/out/local");
+
+    if path_has_parent_component(report_path) {
+        push_error(
+            &mut checks,
+            "rollback-report-no-parent-path-components",
+            "el reporte de rollback no acepta componentes '..'",
+        );
+    } else {
+        push_ok(
+            &mut checks,
+            "rollback-report-no-parent-path-components",
+            "el reporte de rollback no usa componentes '..'",
+        );
+    }
+
+    if path_under(&report, &reconstruction_dir) {
+        push_ok(
+            &mut checks,
+            "rollback-report-under-reconstruction",
+            "reporte de reconstruccion esta bajo data/tmp/reconstruction",
+        );
+    } else {
+        push_error(
+            &mut checks,
+            "rollback-report-under-reconstruction",
+            "reporte de reconstruccion debe estar bajo data/tmp/reconstruction",
+        );
+    }
+
+    let value = match read_json_object(&report) {
+        Ok(value) => {
+            push_ok(
+                &mut checks,
+                "rollback-report-readable",
+                "reporte de reconstruccion es JSON valido",
+            );
+            value
+        }
+        Err(message) => {
+            push_error(&mut checks, "rollback-report-readable", &message);
+            return finish_rollback_report(root, &report, None, None, None, None, checks);
+        }
+    };
+
+    if value.get("rollback_ready").and_then(|item| item.as_bool()) == Some(true) {
+        push_ok(
+            &mut checks,
+            "rollback-ready-flag",
+            "reporte declara rollback_ready=true",
+        );
+    } else {
+        push_error(
+            &mut checks,
+            "rollback-ready-flag",
+            "reporte debe declarar rollback_ready=true",
+        );
+    }
+
+    let backup_dir = value
+        .get("backup_dir")
+        .and_then(|item| item.as_str())
+        .map(|path| resolve_plan_path(root, Path::new(path)));
+    let output_target = value
+        .get("output_target")
+        .and_then(|item| item.as_str())
+        .map(|path| resolve_plan_path(root, Path::new(path)));
+    let expected_hash = value
+        .get("canon_before_hash")
+        .and_then(|item| item.as_str())
+        .map(|item| item.to_string());
+
+    match &output_target {
+        Some(target) if target == &canon_dir => {
+            push_ok(
+                &mut checks,
+                "rollback-output-target-local-canon",
+                "rollback apunta exactamente a data/out/local",
+            );
+        }
+        Some(target) => {
+            push_error(
+                &mut checks,
+                "rollback-output-target-local-canon",
+                &format!(
+                    "rollback debe apuntar a data/out/local, no a {}",
+                    display_plan_path(root, target)
+                ),
+            );
+        }
+        None => {
+            push_error(
+                &mut checks,
+                "rollback-output-target-local-canon",
+                "reporte no declara output_target",
+            );
+        }
+    }
+
+    let computed_hash = match &backup_dir {
+        Some(path) if path_under(path, &reconstruction_dir) && path.ends_with("canon_before") => {
+            push_ok(
+                &mut checks,
+                "rollback-backup-under-reconstruction",
+                "backup canon_before esta bajo data/tmp/reconstruction",
+            );
+            match canonical_canon_tree_hash(path) {
+                Ok(hash) => {
+                    push_ok(
+                        &mut checks,
+                        "rollback-backup-hash-computable",
+                        "hash del backup canon_before calculable sobre shards reales",
+                    );
+                    Some(hash)
+                }
+                Err(message) => {
+                    push_error(&mut checks, "rollback-backup-hash-computable", &message);
+                    None
+                }
+            }
+        }
+        Some(_) => {
+            push_error(
+                &mut checks,
+                "rollback-backup-under-reconstruction",
+                "backup debe ser canon_before bajo data/tmp/reconstruction",
+            );
+            None
+        }
+        None => {
+            push_error(
+                &mut checks,
+                "rollback-backup-under-reconstruction",
+                "reporte no declara backup_dir",
+            );
+            None
+        }
+    };
+
+    match (&expected_hash, &computed_hash) {
+        (Some(expected), Some(computed)) if is_sha256_label(expected) && expected == computed => {
+            push_ok(
+                &mut checks,
+                "rollback-backup-hash-matches-report",
+                "canon_before_hash coincide con el contenido real del backup",
+            );
+        }
+        (Some(expected), Some(computed)) if !is_sha256_label(expected) => {
+            push_error(
+                &mut checks,
+                "rollback-backup-hash-matches-report",
+                &format!("canon_before_hash invalido: {}", expected),
+            );
+        }
+        (Some(expected), Some(computed)) => {
+            push_error(
+                &mut checks,
+                "rollback-backup-hash-matches-report",
+                &format!(
+                    "canon_before_hash esperado {}, calculado {}",
+                    expected, computed
+                ),
+            );
+        }
+        (None, _) => {
+            push_error(
+                &mut checks,
+                "rollback-backup-hash-matches-report",
+                "reporte no declara canon_before_hash",
+            );
+        }
+        (_, None) => {
+            push_error(
+                &mut checks,
+                "rollback-backup-hash-matches-report",
+                "no se pudo calcular hash del backup",
+            );
+        }
+    }
+
+    finish_rollback_report(
+        root,
+        &report,
+        backup_dir.as_deref(),
+        output_target.as_deref(),
+        expected_hash.as_deref(),
+        computed_hash.as_deref(),
+        checks,
+    )
+}
+
+fn finish_rollback_report(
+    root: &Path,
+    report: &Path,
+    backup_dir: Option<&Path>,
+    output_target: Option<&Path>,
+    expected_hash: Option<&str>,
+    computed_hash: Option<&str>,
+    checks: Vec<PerimeterCheck>,
+) -> ReconstructionRollbackReport {
+    let errors = checks
+        .iter()
+        .filter(|check| check.status == "error")
+        .count();
+    let verdict = if errors == 0 {
+        ReconstructionRollbackVerdict::Ready
+    } else {
+        ReconstructionRollbackVerdict::Rejected
+    };
+
+    ReconstructionRollbackReport {
+        verdict,
+        repo_root: root.to_string_lossy().to_string(),
+        rollback: ReconstructionRollbackInput {
+            report_path: display_plan_path(root, report),
+            backup_dir: backup_dir.map(|path| display_plan_path(root, path)),
+            output_target: output_target.map(|path| display_plan_path(root, path)),
+            expected_canon_before_hash: expected_hash.map(str::to_string),
+            computed_backup_hash: computed_hash.map(str::to_string),
+        },
+        checks_run: checks.len(),
+        errors,
+        checks,
+    }
+}
+
+/// Calcula el hash de árbol usado por los reportes de reconstrucción:
+/// nombre de shard, byte NUL, contenido real, byte NUL, en orden de shard.
+pub fn canonical_canon_tree_hash(canon_dir: &Path) -> Result<String, String> {
+    let mut shards: Vec<PathBuf> = std::fs::read_dir(canon_dir)
+        .map_err(|e| format!("no se pudo leer '{}': {}", canon_dir.display(), e))?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .and_then(shard_number)
+                .is_some()
+        })
+        .collect();
+    shards.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+    if shards.is_empty() {
+        return Err(format!(
+            "no se encontraron shards tiddlers_*.jsonl en '{}'",
+            canon_dir.display()
+        ));
+    }
+
+    let mut sha = Sha256::new();
+    for shard in shards {
+        let name = shard
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| format!("nombre de shard invalido: {}", shard.display()))?;
+        let data = std::fs::read(&shard)
+            .map_err(|e| format!("no se pudo leer '{}': {}", shard.display(), e))?;
+        sha.update(name.as_bytes());
+        sha.update(&[0]);
+        sha.update(&data);
+        sha.update(&[0]);
+    }
+    Ok(format!("sha256:{}", hex_lower(&sha.finalize())))
+}
+
+fn sha256_file_label(path: &Path) -> Result<String, String> {
+    let data = std::fs::read(path)
+        .map_err(|e| format!("no se pudo leer '{}' para hash: {}", path.display(), e))?;
+    let mut sha = Sha256::new();
+    sha.update(&data);
+    Ok(format!("sha256:{}", hex_lower(&sha.finalize())))
+}
+
+fn is_sha256_label(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return false;
+    };
+    hex.len() == 64 && hex.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn hex_lower(bytes: &[u8; 32]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+struct Sha256 {
+    state: [u32; 8],
+    buffer: [u8; 64],
+    buffer_len: usize,
+    length_bytes: u64,
+}
+
+impl Sha256 {
+    fn new() -> Self {
+        Self {
+            state: [
+                0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+                0x5be0cd19,
+            ],
+            buffer: [0; 64],
+            buffer_len: 0,
+            length_bytes: 0,
+        }
+    }
+
+    fn update(&mut self, mut data: &[u8]) {
+        self.length_bytes = self.length_bytes.wrapping_add(data.len() as u64);
+        if self.buffer_len > 0 {
+            let needed = 64 - self.buffer_len;
+            let take = needed.min(data.len());
+            self.buffer[self.buffer_len..self.buffer_len + take].copy_from_slice(&data[..take]);
+            self.buffer_len += take;
+            data = &data[take..];
+            if self.buffer_len == 64 {
+                let block = self.buffer;
+                self.process_block(&block);
+                self.buffer_len = 0;
+            }
+        }
+
+        while data.len() >= 64 {
+            let block: [u8; 64] = data[..64].try_into().expect("64 byte block");
+            self.process_block(&block);
+            data = &data[64..];
+        }
+
+        if !data.is_empty() {
+            self.buffer[..data.len()].copy_from_slice(data);
+            self.buffer_len = data.len();
+        }
+    }
+
+    fn finalize(mut self) -> [u8; 32] {
+        let bit_len = self.length_bytes.wrapping_mul(8);
+        self.update_padding_byte(0x80);
+        while self.buffer_len != 56 {
+            self.update_padding_byte(0);
+        }
+        for byte in bit_len.to_be_bytes() {
+            self.update_padding_byte(byte);
+        }
+
+        let mut out = [0u8; 32];
+        for (index, word) in self.state.iter().enumerate() {
+            out[index * 4..index * 4 + 4].copy_from_slice(&word.to_be_bytes());
+        }
+        out
+    }
+
+    fn update_padding_byte(&mut self, byte: u8) {
+        self.buffer[self.buffer_len] = byte;
+        self.buffer_len += 1;
+        if self.buffer_len == 64 {
+            let block = self.buffer;
+            self.process_block(&block);
+            self.buffer_len = 0;
+        }
+    }
+
+    fn process_block(&mut self, block: &[u8; 64]) {
+        const K: [u32; 64] = [
+            0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+            0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+            0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+            0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+            0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+            0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+            0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+            0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+            0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+            0xc67178f2,
+        ];
+
+        let mut w = [0u32; 64];
+        for (index, chunk) in block.chunks_exact(4).take(16).enumerate() {
+            w[index] = u32::from_be_bytes(chunk.try_into().expect("4 byte word"));
+        }
+        for index in 16..64 {
+            let s0 = w[index - 15].rotate_right(7)
+                ^ w[index - 15].rotate_right(18)
+                ^ (w[index - 15] >> 3);
+            let s1 = w[index - 2].rotate_right(17)
+                ^ w[index - 2].rotate_right(19)
+                ^ (w[index - 2] >> 10);
+            w[index] = w[index - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[index - 7])
+                .wrapping_add(s1);
+        }
+
+        let mut a = self.state[0];
+        let mut b = self.state[1];
+        let mut c = self.state[2];
+        let mut d = self.state[3];
+        let mut e = self.state[4];
+        let mut f = self.state[5];
+        let mut g = self.state[6];
+        let mut h = self.state[7];
+
+        for index in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ ((!e) & g);
+            let temp1 = h
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[index])
+                .wrapping_add(w[index]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let temp2 = s0.wrapping_add(maj);
+
+            h = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(temp1);
+            d = c;
+            c = b;
+            b = a;
+            a = temp1.wrapping_add(temp2);
+        }
+
+        self.state[0] = self.state[0].wrapping_add(a);
+        self.state[1] = self.state[1].wrapping_add(b);
+        self.state[2] = self.state[2].wrapping_add(c);
+        self.state[3] = self.state[3].wrapping_add(d);
+        self.state[4] = self.state[4].wrapping_add(e);
+        self.state[5] = self.state[5].wrapping_add(f);
+        self.state[6] = self.state[6].wrapping_add(g);
+        self.state[7] = self.state[7].wrapping_add(h);
     }
 }
 
@@ -760,6 +1279,292 @@ fn check_reconstruction_target(
                 );
             }
         }
+    }
+}
+
+fn check_reconstruction_run_dir(
+    root: &Path,
+    run_dir: Option<&Path>,
+    reconstruction_dir: &Path,
+    reconstruction_mode: &ReconstructionMode,
+    checks: &mut Vec<PerimeterCheck>,
+) {
+    match reconstruction_mode {
+        ReconstructionMode::WriteLocalCanon => match run_dir {
+            Some(path) if path_under(path, reconstruction_dir) && path != reconstruction_dir => {
+                push_ok(
+                    checks,
+                    "plan-reconstruction-run-dir",
+                    "write_local_canon declara run_id bajo data/tmp/reconstruction",
+                );
+            }
+            Some(path) => {
+                push_error(
+                    checks,
+                    "plan-reconstruction-run-dir",
+                    &format!(
+                        "write_local_canon debe declarar run_id bajo data/tmp/reconstruction, no {}",
+                        display_plan_path(root, path)
+                    ),
+                );
+            }
+            None => {
+                push_error(
+                    checks,
+                    "plan-reconstruction-run-dir",
+                    "write_local_canon requiere run_id de evidencia bajo data/tmp/reconstruction",
+                );
+            }
+        },
+        ReconstructionMode::Diagnostic
+        | ReconstructionMode::Staging
+        | ReconstructionMode::ReverseProjection => {
+            if let Some(path) = run_dir {
+                if path_under(path, reconstruction_dir) {
+                    push_ok(
+                        checks,
+                        "plan-reconstruction-run-dir",
+                        "run_id de evidencia permanece bajo data/tmp/reconstruction",
+                    );
+                } else {
+                    push_error(
+                        checks,
+                        "plan-reconstruction-run-dir",
+                        "run_id de evidencia debe permanecer bajo data/tmp/reconstruction",
+                    );
+                }
+            } else {
+                push_ok(
+                    checks,
+                    "plan-reconstruction-run-dir",
+                    "modo no destructivo no requiere run_id de reconstruccion",
+                );
+            }
+        }
+    }
+}
+
+fn check_input_jsonl_origin(
+    root: &Path,
+    source_html: &Path,
+    input_jsonl: Option<&Path>,
+    html_export_dir: &Path,
+    reconstruction_mode: &ReconstructionMode,
+    checks: &mut Vec<PerimeterCheck>,
+) {
+    if reconstruction_mode != &ReconstructionMode::WriteLocalCanon {
+        if let Some(path) = input_jsonl {
+            if path_under(path, html_export_dir) {
+                push_ok(
+                    checks,
+                    "plan-input-jsonl-scope",
+                    "JSONL temporal permanece bajo data/tmp/html_export",
+                );
+            } else {
+                push_error(
+                    checks,
+                    "plan-input-jsonl-scope",
+                    "JSONL temporal debe provenir de data/tmp/html_export",
+                );
+            }
+        } else {
+            push_ok(
+                checks,
+                "plan-input-jsonl-scope",
+                "modo sin shardizacion no requiere JSONL temporal",
+            );
+        }
+        return;
+    }
+
+    let input_jsonl = match input_jsonl {
+        Some(path) => path,
+        None => {
+            push_error(
+                checks,
+                "plan-input-jsonl-required",
+                "write_local_canon requiere JSONL temporal seleccionado",
+            );
+            return;
+        }
+    };
+    push_ok(
+        checks,
+        "plan-input-jsonl-required",
+        "write_local_canon declara JSONL temporal seleccionado",
+    );
+
+    if path_under(input_jsonl, html_export_dir) {
+        push_ok(
+            checks,
+            "plan-input-jsonl-scope",
+            "JSONL temporal esta bajo data/tmp/html_export",
+        );
+    } else {
+        push_error(
+            checks,
+            "plan-input-jsonl-scope",
+            "JSONL temporal debe estar bajo data/tmp/html_export; rutas legacy sin manifiesto quedan bloqueadas",
+        );
+    }
+
+    if input_jsonl.is_file() {
+        push_ok(
+            checks,
+            "plan-input-jsonl-exists",
+            "JSONL temporal existe y es archivo",
+        );
+    } else {
+        push_error(
+            checks,
+            "plan-input-jsonl-exists",
+            "JSONL temporal no existe o no es archivo",
+        );
+    }
+
+    if input_jsonl
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("jsonl"))
+        .unwrap_or(false)
+    {
+        push_ok(
+            checks,
+            "plan-input-jsonl-extension",
+            "JSONL temporal termina en .jsonl",
+        );
+    } else {
+        push_error(
+            checks,
+            "plan-input-jsonl-extension",
+            "JSONL temporal debe terminar en .jsonl",
+        );
+    }
+
+    let manifest_path = input_jsonl.with_file_name("tiddlers.export.manifest.json");
+    let manifest = match read_json_object(&manifest_path) {
+        Ok(value) => {
+            push_ok(
+                checks,
+                "plan-input-manifest-readable",
+                "manifiesto de export temporal es JSON valido",
+            );
+            value
+        }
+        Err(message) => {
+            push_error(checks, "plan-input-manifest-readable", &message);
+            return;
+        }
+    };
+
+    expect_json_string(
+        checks,
+        &manifest,
+        "plan-input-manifest-role",
+        "artifact_role",
+        "canon_export",
+    );
+
+    check_manifest_path_matches(
+        root,
+        checks,
+        &manifest,
+        "plan-input-manifest-output-match",
+        "output_path",
+        input_jsonl,
+    );
+    check_manifest_path_matches(
+        root,
+        checks,
+        &manifest,
+        "plan-input-manifest-source-match",
+        "source_html_path",
+        source_html,
+    );
+    check_manifest_hash_matches(
+        checks,
+        &manifest,
+        "plan-input-manifest-jsonl-hash",
+        "sha256",
+        input_jsonl,
+    );
+    check_manifest_hash_matches(
+        checks,
+        &manifest,
+        "plan-input-manifest-source-hash",
+        "source_html_sha256",
+        source_html,
+    );
+}
+
+fn check_manifest_path_matches(
+    root: &Path,
+    checks: &mut Vec<PerimeterCheck>,
+    manifest: &serde_json::Value,
+    check_id: &str,
+    key: &str,
+    expected: &Path,
+) {
+    let Some(actual) = manifest.get(key).and_then(|item| item.as_str()) else {
+        push_error(checks, check_id, &format!("manifiesto no declara {}", key));
+        return;
+    };
+    let actual_path = resolve_plan_path(root, Path::new(actual));
+    if actual_path == expected {
+        push_ok(
+            checks,
+            check_id,
+            &format!("{} del manifiesto coincide con el artefacto declarado", key),
+        );
+    } else {
+        push_error(
+            checks,
+            check_id,
+            &format!(
+                "{} del manifiesto apunta a {}, no a {}",
+                key,
+                display_plan_path(root, &actual_path),
+                display_plan_path(root, expected)
+            ),
+        );
+    }
+}
+
+fn check_manifest_hash_matches(
+    checks: &mut Vec<PerimeterCheck>,
+    manifest: &serde_json::Value,
+    check_id: &str,
+    key: &str,
+    expected_path: &Path,
+) {
+    let Some(actual) = manifest.get(key).and_then(|item| item.as_str()) else {
+        push_error(checks, check_id, &format!("manifiesto no declara {}", key));
+        return;
+    };
+    if !is_sha256_label(actual) {
+        push_error(
+            checks,
+            check_id,
+            &format!("{} no tiene formato sha256:<64 hex>", key),
+        );
+        return;
+    }
+    match sha256_file_label(expected_path) {
+        Ok(expected) if expected == actual => {
+            push_ok(
+                checks,
+                check_id,
+                &format!("{} coincide con el contenido real declarado", key),
+            );
+        }
+        Ok(expected) => {
+            push_error(
+                checks,
+                check_id,
+                &format!("{} esperado {}, encontrado {}", key, expected, actual),
+            );
+        }
+        Err(message) => push_error(checks, check_id, &message),
     }
 }
 

--- a/rust/doctor/src/report.rs
+++ b/rust/doctor/src/report.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::collections::BTreeMap;
 
 /// Veredicto de auditoría del Doctor.
 ///
@@ -102,6 +103,10 @@ pub struct ReconstructionPlanInput {
     pub source_role: ReconstructionSourceRole,
     pub reconstruction_mode: ReconstructionMode,
     pub output_target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_jsonl_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reconstruction_run_dir: Option<String>,
     pub requires_backup: bool,
     pub requires_hash_report: bool,
 }
@@ -115,4 +120,266 @@ pub struct ReconstructionPlanReport {
     pub checks_run: usize,
     pub errors: usize,
     pub checks: Vec<PerimeterCheck>,
+}
+
+/// Veredicto de la compuerta Rust para rollback guiado de reconstrucción.
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconstructionRollbackVerdict {
+    Ready,
+    Rejected,
+}
+
+/// Entrada normalizada de rollback guiado de reconstrucción.
+#[derive(Debug, Serialize)]
+pub struct ReconstructionRollbackInput {
+    pub report_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backup_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_canon_before_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub computed_backup_hash: Option<String>,
+}
+
+/// Reporte normativo previo a que Python restaure un backup de reconstrucción.
+#[derive(Debug, Serialize)]
+pub struct ReconstructionRollbackReport {
+    pub verdict: ReconstructionRollbackVerdict,
+    pub repo_root: String,
+    pub rollback: ReconstructionRollbackInput,
+    pub checks_run: usize,
+    pub errors: usize,
+    pub checks: Vec<PerimeterCheck>,
+}
+
+/// Veredicto graduado para una linea canonica o candidata.
+///
+/// No equivale a admision canonica: clasifica calidad estructural observable
+/// para priorizar validacion y reparacion sin escribir el canon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CanonicalLineVerdict {
+    CanonLineOk,
+    CanonLineWarning,
+    CanonLineIncomplete,
+    CanonLineInconsistent,
+    CanonLineRejected,
+}
+
+/// Issue puntual detectado por la compuerta de lineas canonicas.
+#[derive(Debug, Clone, Serialize)]
+pub struct CanonicalLineIssue {
+    pub rule_id: String,
+    pub severity: String,
+    pub impact: CanonicalLineVerdict,
+    pub message: String,
+}
+
+/// Clasificacion de una linea individual.
+#[derive(Debug, Serialize)]
+pub struct CanonicalLineItemReport {
+    pub source_path: String,
+    pub line: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role_primary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modality: Option<String>,
+    pub family: String,
+    pub verdict: CanonicalLineVerdict,
+    pub field_count: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub modal_projections: Vec<String>,
+    pub issues: Vec<CanonicalLineIssue>,
+}
+
+/// Conteos por veredicto de la compuerta canonica.
+#[derive(Debug, Default, Serialize)]
+pub struct CanonicalLineCounts {
+    pub canon_line_ok: usize,
+    pub canon_line_warning: usize,
+    pub canon_line_incomplete: usize,
+    pub canon_line_inconsistent: usize,
+    pub canon_line_rejected: usize,
+}
+
+/// Variante de plantilla detectada dentro de una familia de artefactos.
+#[derive(Debug, Serialize)]
+pub struct TemplateVariantReport {
+    pub count: usize,
+    pub signature: Vec<String>,
+    pub missing_from_baseline: Vec<String>,
+    pub extra_vs_baseline: Vec<String>,
+    pub examples: Vec<String>,
+}
+
+/// Reporte de estabilidad de plantilla por familia.
+#[derive(Debug, Serialize)]
+pub struct TemplateFamilyReport {
+    pub family: String,
+    pub verdict: CanonicalLineVerdict,
+    pub line_count: usize,
+    pub variant_count: usize,
+    pub baseline_source: String,
+    pub baseline_signature: Vec<String>,
+    pub variants: Vec<TemplateVariantReport>,
+}
+
+/// Resumen de issues detectados por un perfil focal de familia.
+#[derive(Debug, Serialize)]
+pub struct FamilyProfileIssueSummary {
+    pub rule_id: String,
+    pub impact: CanonicalLineVerdict,
+    pub count: usize,
+    pub examples: Vec<String>,
+}
+
+/// Evaluacion focal de una familia priorizada.
+#[derive(Debug, Serialize)]
+pub struct FamilyProfileReport {
+    pub family: String,
+    pub profile_id: String,
+    pub priority: String,
+    pub line_count: usize,
+    pub verdict: CanonicalLineVerdict,
+    pub issue_count: usize,
+    pub issues: Vec<FamilyProfileIssueSummary>,
+}
+
+/// Triage accionable de lineas incompletas.
+#[derive(Debug, Serialize)]
+pub struct IncompleteLineTriageReport {
+    pub family: String,
+    pub priority: String,
+    pub reason: String,
+    pub line_count: usize,
+    pub rule_ids: Vec<String>,
+    pub examples: Vec<String>,
+}
+
+/// Issue modal detectado al auditar `content` como proyeccion derivada.
+#[derive(Debug, Serialize)]
+pub struct ModalProjectionIssueReport {
+    pub source_path: String,
+    pub line: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role_primary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modality: Option<String>,
+    pub rule_id: String,
+    pub severity: String,
+    pub message: String,
+}
+
+/// Auditoria agregada de la proyeccion modal canonica.
+#[derive(Debug, Serialize)]
+pub struct ModalProjectionAuditReport {
+    pub profile_id: String,
+    pub inspected_lines: usize,
+    pub relevant_lines: usize,
+    pub projected_lines: usize,
+    pub missing_projection_lines: usize,
+    pub modality_counts: BTreeMap<String, usize>,
+    pub projection_counts: BTreeMap<String, usize>,
+    pub issues: Vec<ModalProjectionIssueReport>,
+}
+
+/// Separacion operacional entre deudas de naturaleza distinta.
+#[derive(Debug, Default, Serialize)]
+pub struct CanonQualityDebtSummary {
+    pub profile_id: String,
+    pub modal_debt_lines: usize,
+    pub modal_debt_issue_count: usize,
+    pub asset_modal_debt_lines: usize,
+    pub template_drift_families_total: usize,
+    pub template_drift_families_modal_related: usize,
+    pub template_drift_families_historical: usize,
+    pub template_drift_lines_historical: usize,
+    pub richness_warning_lines: usize,
+    pub incomplete_line_count: usize,
+    pub blocking_line_count: usize,
+}
+
+/// Reporte agregado de canonical-line gate.
+#[derive(Debug, Serialize)]
+pub struct CanonicalLineGateReport {
+    pub verdict: CanonicalLineVerdict,
+    pub repo_root: String,
+    pub input_path: String,
+    pub source_files: Vec<String>,
+    pub lines_read: usize,
+    pub parsed_lines: usize,
+    pub counts: CanonicalLineCounts,
+    pub template_families_with_drift: Vec<TemplateFamilyReport>,
+    pub family_profiles: Vec<FamilyProfileReport>,
+    pub incomplete_line_triage: Vec<IncompleteLineTriageReport>,
+    pub modal_projection_audit: ModalProjectionAuditReport,
+    pub debt_summary: CanonQualityDebtSummary,
+    pub lines: Vec<CanonicalLineItemReport>,
+}
+
+/// Veredicto agregado del inspector profundo de nodos.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeepNodeInspectorVerdict {
+    NoStructureFound,
+    StructureFound,
+    StructureFoundWithWarnings,
+}
+
+/// Conteos por tipo de hallazgo del deep-node inspector.
+#[derive(Debug, Default, Serialize)]
+pub struct DeepNodeFindingCounts {
+    pub structural_json: usize,
+    pub valid_json: usize,
+    pub recoverable_json: usize,
+    pub invalid_json: usize,
+    pub pedagogical_json: usize,
+    pub json_fragment: usize,
+    pub json_fence: usize,
+    pub yaml_front_matter: usize,
+    pub markdown_table: usize,
+    pub key_value_block: usize,
+}
+
+/// Hallazgo estructural dentro de un nodo.
+#[derive(Debug, Serialize)]
+pub struct DeepNodeFinding {
+    pub source_path: String,
+    pub line: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub field: String,
+    pub kind: String,
+    pub status: String,
+    pub byte_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_level_type: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub top_level_keys: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub array_len: Option<usize>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub recovery_actions: Vec<String>,
+    pub message: String,
+}
+
+/// Reporte no destructivo sobre riqueza estructural interna de nodos.
+#[derive(Debug, Serialize)]
+pub struct DeepNodeInspectionReport {
+    pub verdict: DeepNodeInspectorVerdict,
+    pub repo_root: String,
+    pub input_path: String,
+    pub source_files: Vec<String>,
+    pub nodes_read: usize,
+    pub inspected_text_fields: usize,
+    pub findings_count: usize,
+    pub counts: DeepNodeFindingCounts,
+    pub findings: Vec<DeepNodeFinding>,
 }

--- a/rust/doctor/tests/test_doctor.rs
+++ b/rust/doctor/tests/test_doctor.rs
@@ -10,8 +10,11 @@
 
 use std::path::{Path, PathBuf};
 use tdc_doctor::{
-    audit, audit_perimeter, audit_reconstruction_plan, DoctorError, DoctorVerdict,
-    PerimeterVerdict, ReconstructionMode, ReconstructionPlanVerdict, ReconstructionSourceRole,
+    audit, audit_canonical_lines, audit_perimeter, audit_reconstruction_plan,
+    audit_reconstruction_plan_with_artifacts, audit_reconstruction_rollback,
+    canonical_canon_tree_hash, inspect_deep_nodes, CanonicalLineVerdict, DoctorError,
+    DoctorVerdict, PerimeterVerdict, ReconstructionMode, ReconstructionPlanVerdict,
+    ReconstructionRollbackVerdict, ReconstructionSourceRole,
 };
 
 /// Ruta base a los fixtures compartidos del repositorio.
@@ -75,6 +78,89 @@ fn write_minimal_perimeter_fixture(root: &Path) {
           }
         }"#,
     );
+}
+
+fn write_export_manifest(
+    root: &Path,
+    source: &Path,
+    jsonl: &Path,
+    source_hash: &str,
+    jsonl_hash: &str,
+) {
+    let manifest = jsonl.with_file_name("tiddlers.export.manifest.json");
+    write_file(
+        &manifest,
+        &format!(
+            r#"{{
+              "run_id": "export-test",
+              "schema_version": "v0",
+              "artifact_role": "canon_export",
+              "source_html_path": "{}",
+              "source_html_sha256": "{}",
+              "sha256": "{}",
+              "output_path": "{}"
+            }}"#,
+            source.strip_prefix(root).unwrap_or(source).display(),
+            source_hash,
+            jsonl_hash,
+            jsonl.strip_prefix(root).unwrap_or(jsonl).display(),
+        ),
+    );
+}
+
+fn complete_canon_line(title: &str, family: &str, order: usize) -> String {
+    let source_folder = match family {
+        "contrato_de_sesion" => "00_contratos",
+        "procedencia_de_sesion" => "01_procedencia",
+        "detalles_de_sesion" => "02_detalles_de_sesion",
+        "hipotesis_de_sesion" => "03_hipotesis",
+        "balance_de_sesion" => "04_balance_de_sesion",
+        "propuesta_de_sesion" => "05_propuesta_de_sesion",
+        "diagnostico_de_sesion" => "06_diagnoses/sesion",
+        _ => "02_detalles_de_sesion",
+    };
+    let source_path = format!("data/sessions/{source_folder}/test.md.json");
+    serde_json::json!({
+        "schema_version": "v0",
+        "id": format!("123e4567-e89b-12d3-a456-426614174{order:03}"),
+        "key": title,
+        "title": title,
+        "canonical_slug": format!("session-{order}"),
+        "version_id": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "content_type": "text/markdown",
+        "modality": "text",
+        "encoding": "utf-8",
+        "is_binary": false,
+        "is_reference_only": false,
+        "role_primary": "note",
+        "tags": ["session:test", "milestone:m99", format!("artifact:{family}"), "status:candidate", "layer:session"],
+        "taxonomy_path": ["session"],
+        "semantic_text": null,
+        "content": {"plain": "Contenido"},
+        "raw_payload_ref": format!("node:123e4567-e89b-12d3-a456-426614174{order:03}"),
+        "mime_type": "text/markdown",
+        "document_id": "doc-test",
+        "section_path": ["session"],
+        "order_in_document": order,
+        "relations": [],
+        "source_tags": ["session:test", "milestone:m99", format!("artifact:{family}"), "status:candidate", "layer:session"],
+        "normalized_tags": ["session:test", "milestone:m99", format!("artifact:{family}"), "status:candidate", "layer:session"],
+        "source_fields": {
+            "session_origin": "m99-s99-test",
+            "artifact_family": family,
+            "source_path": source_path.clone(),
+            "canonical_status": "candidate_not_admitted",
+            "document_key": "data/sessions/m99-s99-test",
+            "provenance_ref": "data/sessions/01_procedencia/test.md.json"
+        },
+        "source_role": "reporte",
+        "text": "Contenido",
+        "source_type": "text/markdown",
+        "source_position": format!("{source_path}:{order}"),
+        "created": "20260430000000000",
+        "modified": "20260430000000000"
+    })
+    .to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -187,6 +273,352 @@ fn test_reporte_siempre_tiene_campos_minimos() {
         0,
         "fixture mínimo no debe tener errors"
     );
+}
+
+#[test]
+fn test_canonical_line_gate_clasifica_ok_incomplete_inconsistent_y_rejected() {
+    let root = temp_repo_root("canonical_line_gate_taxonomy");
+    let input = root.join("data/tmp/candidates.jsonl");
+    let complete = complete_canon_line(
+        "#### 🌀 Sesión 99 = canonical-line-ok",
+        "detalles_de_sesion",
+        1,
+    );
+    let incomplete = r#"{"schema_version":"v0","key":"Nodo incompleto","title":"Nodo incompleto"}"#;
+    let inconsistent =
+        r#"{"schema_version":"v0","key":"Nodo A","title":"Nodo B","order_in_document":"cero"}"#;
+    let rejected = r#"{"schema_version":"v0","id":"PENDIENTE-GENERACION-CONVERTIDOR","key":"Nodo pendiente","title":"Nodo pendiente"}"#;
+    write_file(
+        &input,
+        &format!("{complete}\n{incomplete}\n{inconsistent}\n{rejected}\n"),
+    );
+
+    let report = audit_canonical_lines(&root, &input);
+
+    assert_eq!(report.lines_read, 4);
+    assert_eq!(report.counts.canon_line_ok, 1);
+    assert_eq!(report.counts.canon_line_incomplete, 1);
+    assert_eq!(report.counts.canon_line_inconsistent, 1);
+    assert_eq!(report.counts.canon_line_rejected, 1);
+    assert_eq!(report.verdict, CanonicalLineVerdict::CanonLineRejected);
+
+    std::fs::remove_dir_all(root).expect("cleanup canonical line taxonomy fixture");
+}
+
+#[test]
+fn test_canonical_line_gate_detecta_deriva_de_plantilla_por_familia() {
+    let root = temp_repo_root("canonical_line_template_drift");
+    let input = root.join("data/tmp/candidates.jsonl");
+    let baseline = complete_canon_line("#### 🌀 Sesión 99 = template-a", "detalles_de_sesion", 1);
+    let variant = serde_json::json!({
+        "schema_version": "v0",
+        "id": "123e4567-e89b-12d3-a456-426614174002",
+        "key": "#### 🌀 Sesión 99 = template-b",
+        "title": "#### 🌀 Sesión 99 = template-b",
+        "canonical_slug": "template-b",
+        "version_id": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "content_type": "text/markdown",
+        "modality": "text",
+        "encoding": "utf-8",
+        "is_binary": false,
+        "is_reference_only": false,
+        "role_primary": "note",
+        "semantic_text": null,
+        "mime_type": "text/markdown",
+        "document_id": "doc-test",
+        "section_path": ["session"],
+        "order_in_document": 2,
+        "relations": [],
+        "source_fields": {"artifact_family": "detalles_de_sesion"},
+        "text": "Contenido",
+        "source_type": "text/markdown",
+        "source_position": "data/sessions/test.md.json:2",
+        "created": "20260430000000000",
+        "modified": "20260430000000000"
+    })
+    .to_string();
+    write_file(&input, &format!("{baseline}\n{variant}\n"));
+
+    let report = audit_canonical_lines(&root, &input);
+
+    assert!(
+        report
+            .template_families_with_drift
+            .iter()
+            .any(|family| family.family == "detalles_de_sesion" && family.variant_count == 2),
+        "expected detalles_de_sesion template drift, got {:?}",
+        report.template_families_with_drift
+    );
+
+    std::fs::remove_dir_all(root).expect("cleanup canonical line template drift fixture");
+}
+
+#[test]
+fn test_canonical_line_gate_reporta_perfiles_y_triage_de_incompletas() {
+    let root = temp_repo_root("canonical_line_family_profile");
+    let input = root.join("data/tmp/candidates.jsonl");
+    let session_line = complete_canon_line(
+        "#### 🌀 Sesión 99 = family-profile-ok",
+        "detalles_de_sesion",
+        1,
+    );
+    let asset_without_content = serde_json::json!({
+        "schema_version": "v0",
+        "id": "123e4567-e89b-12d3-a456-426614174099",
+        "key": "asset without content",
+        "title": "asset without content",
+        "canonical_slug": "asset-without-content",
+        "version_id": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "content_type": "image/png",
+        "modality": "image",
+        "encoding": "base64",
+        "is_binary": true,
+        "is_reference_only": false,
+        "role_primary": "asset",
+        "tags": ["asset:test"],
+        "taxonomy_path": ["asset"],
+        "semantic_text": null,
+        "raw_payload_ref": "node:123e4567-e89b-12d3-a456-426614174099",
+        "asset_id": "asset-1",
+        "mime_type": "image/png",
+        "document_id": "doc-test",
+        "section_path": ["assets"],
+        "order_in_document": 99,
+        "relations": [],
+        "source_tags": ["asset:test"],
+        "normalized_tags": ["asset:test"],
+        "source_fields": {"type": "image/png"},
+        "text": "iVBORw0KGgo=",
+        "source_type": "image/png",
+        "source_position": "html:block0:tiddler99",
+        "created": "20260430000000000",
+        "modified": "20260430000000000"
+    })
+    .to_string();
+    write_file(
+        &input,
+        &format!("{session_line}\n{asset_without_content}\n"),
+    );
+
+    let report = audit_canonical_lines(&root, &input);
+
+    assert!(report
+        .family_profiles
+        .iter()
+        .any(|profile| profile.family == "detalles_de_sesion"
+            && profile.profile_id == "session-artifact-profile-v1"));
+    assert!(report
+        .family_profiles
+        .iter()
+        .any(|profile| profile.family == "role:asset"
+            && profile.profile_id == "asset-canonical-payload-profile-v1"));
+    assert!(report.incomplete_line_triage.iter().any(|triage| {
+        triage.family == "role:asset"
+            && triage.reason == "asset_without_content_projection"
+            && triage.priority == "medium"
+            && triage.line_count == 1
+    }));
+
+    std::fs::remove_dir_all(root).expect("cleanup canonical line family profile fixture");
+}
+
+#[test]
+fn test_canonical_line_gate_audita_proyeccion_modal() {
+    let root = temp_repo_root("canonical_modal_projection");
+    let input = root.join("data/tmp/candidates.jsonl");
+    let asset_projected = serde_json::json!({
+        "schema_version": "v0",
+        "id": "123e4567-e89b-12d3-a456-426614174101",
+        "key": "asset projected",
+        "title": "asset projected",
+        "canonical_slug": "asset-projected",
+        "version_id": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "content_type": "image/png",
+        "modality": "image",
+        "encoding": "base64",
+        "is_binary": true,
+        "is_reference_only": false,
+        "role_primary": "asset",
+        "tags": ["asset:test"],
+        "taxonomy_path": ["asset"],
+        "semantic_text": null,
+        "content": {
+            "projection_kind": "asset",
+            "modalities": ["asset"],
+            "asset": {
+                "asset_id": "asset:123e4567-e89b-12d3-a456-426614174101",
+                "mime_type": "image/png",
+                "encoding": "base64",
+                "payload_ref": "node:123e4567-e89b-12d3-a456-426614174101",
+                "payload_present": true,
+                "payload_byte_count": 5,
+                "payload_sha256": "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            }
+        },
+        "raw_payload_ref": "node:123e4567-e89b-12d3-a456-426614174101",
+        "asset_id": "asset:123e4567-e89b-12d3-a456-426614174101",
+        "mime_type": "image/png",
+        "document_id": "doc-test",
+        "section_path": ["assets"],
+        "order_in_document": 1,
+        "relations": [],
+        "source_tags": ["asset:test"],
+        "normalized_tags": ["asset:test"],
+        "source_fields": {"type": "image/png"},
+        "text": "aGVsbG8=",
+        "source_type": "image/png",
+        "source_position": "html:block0:tiddler1",
+        "created": "20260430000000000",
+        "modified": "20260430000000000"
+    })
+    .to_string();
+    let mixed_projected = serde_json::json!({
+        "schema_version": "v0",
+        "id": "123e4567-e89b-12d3-a456-426614174102",
+        "key": "mixed projected",
+        "title": "mixed projected",
+        "canonical_slug": "mixed-projected",
+        "version_id": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "content_type": "text/markdown",
+        "modality": "mixed",
+        "encoding": "utf-8",
+        "is_binary": false,
+        "is_reference_only": false,
+        "role_primary": "note",
+        "tags": ["note:test"],
+        "taxonomy_path": ["note"],
+        "semantic_text": null,
+        "content": {
+            "projection_kind": "mixed",
+            "modalities": ["text", "code", "reference"],
+            "plain": "Ver paper fmt.Println(\"ok\")",
+            "code_blocks": [{"language":"go","text":"fmt.Println(\"ok\")","line_count":1,"byte_count":17,"source":"fenced_code_block:3"}],
+            "references": [{"kind":"url","target":"https://example.org","source":"bare_url"}]
+        },
+        "raw_payload_ref": "node:123e4567-e89b-12d3-a456-426614174102",
+        "mime_type": "text/markdown",
+        "document_id": "doc-test",
+        "section_path": ["notes"],
+        "order_in_document": 2,
+        "relations": [],
+        "source_tags": ["note:test"],
+        "normalized_tags": ["note:test"],
+        "source_fields": {"type": "text/markdown"},
+        "text": "Ver https://example.org\n\n```go\nfmt.Println(\"ok\")\n```",
+        "source_type": "text/markdown",
+        "source_position": "html:block0:tiddler2",
+        "created": "20260430000000000",
+        "modified": "20260430000000000"
+    })
+    .to_string();
+    let asset_missing = serde_json::json!({
+        "schema_version": "v0",
+        "id": "123e4567-e89b-12d3-a456-426614174103",
+        "key": "asset missing projection",
+        "title": "asset missing projection",
+        "canonical_slug": "asset-missing-projection",
+        "version_id": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "content_type": "image/png",
+        "modality": "image",
+        "encoding": "base64",
+        "is_binary": true,
+        "is_reference_only": false,
+        "role_primary": "asset",
+        "tags": ["asset:test"],
+        "taxonomy_path": ["asset"],
+        "semantic_text": null,
+        "raw_payload_ref": "node:123e4567-e89b-12d3-a456-426614174103",
+        "asset_id": "asset:123e4567-e89b-12d3-a456-426614174103",
+        "mime_type": "image/png",
+        "document_id": "doc-test",
+        "section_path": ["assets"],
+        "order_in_document": 3,
+        "relations": [],
+        "source_tags": ["asset:test"],
+        "normalized_tags": ["asset:test"],
+        "source_fields": {"type": "image/png"},
+        "text": "aGVsbG8=",
+        "source_type": "image/png",
+        "source_position": "html:block0:tiddler3",
+        "created": "20260430000000000",
+        "modified": "20260430000000000"
+    })
+    .to_string();
+    write_file(
+        &input,
+        &format!("{asset_projected}\n{mixed_projected}\n{asset_missing}\n"),
+    );
+
+    let report = audit_canonical_lines(&root, &input);
+    let debt = &report.debt_summary;
+    assert_eq!(debt.modal_debt_lines, 1);
+    assert_eq!(debt.asset_modal_debt_lines, 1);
+    assert!(debt.modal_debt_issue_count >= 1);
+    let modal = report.modal_projection_audit;
+
+    assert_eq!(modal.inspected_lines, 3);
+    assert_eq!(modal.projected_lines, 2);
+    assert_eq!(modal.missing_projection_lines, 1);
+    assert_eq!(modal.projection_counts.get("asset"), Some(&1));
+    assert_eq!(modal.projection_counts.get("code"), Some(&1));
+    assert_eq!(modal.projection_counts.get("reference"), Some(&1));
+    assert!(modal
+        .issues
+        .iter()
+        .any(|issue| issue.rule_id == "modal-projection-missing"));
+
+    std::fs::remove_dir_all(root).expect("cleanup canonical modal projection fixture");
+}
+
+#[test]
+fn test_deep_node_inspector_detecta_json_valido_y_recuperable() {
+    let root = temp_repo_root("deep_node_json");
+    let input = root.join("data/tmp/nodes.jsonl");
+    write_file(
+        &input,
+        r#"{"title":"json valido","text":"{\"id\":\"n1\",\"content\":{\"plain\":\"ok\"}}"}
+{"title":"json recuperable","text":"{\"items\":[{\"a\":1} {\"b\":2}]}"}
+"#,
+    );
+
+    let report = inspect_deep_nodes(&root, &input);
+
+    assert_eq!(report.nodes_read, 2);
+    assert_eq!(report.counts.valid_json, 1);
+    assert_eq!(report.counts.recoverable_json, 1);
+    assert_eq!(report.counts.invalid_json, 0);
+
+    std::fs::remove_dir_all(root).expect("cleanup deep node json fixture");
+}
+
+#[test]
+fn test_deep_node_inspector_distingue_json_pedagogico_y_fragmento_recuperable() {
+    let root = temp_repo_root("deep_node_json_pedagogical");
+    let input = root.join("data/tmp/nodes.jsonl");
+    write_file(
+        &input,
+        r#"{"title":"readme example","text":"Ejemplo:\n```json\n{\n  \"id\": \"uuid-v5\", // generado por el convertidor\n  \"title\": \"string\"\n}\n```"}
+{"title":"json fragment","text":"```json\n\"meta\": {\"memory_policy\": \"active\"},\n\"memory\": {\"status\": \"active\"}\n```"}
+"#,
+    );
+
+    let report = inspect_deep_nodes(&root, &input);
+
+    assert_eq!(report.nodes_read, 2);
+    assert_eq!(report.counts.pedagogical_json, 1);
+    assert_eq!(report.counts.recoverable_json, 1);
+    assert_eq!(report.counts.json_fragment, 1);
+    assert_eq!(report.counts.invalid_json, 0);
+    assert!(report
+        .findings
+        .iter()
+        .any(|finding| finding.status == "pedagogical_json"));
+    assert!(report
+        .findings
+        .iter()
+        .any(|finding| finding.status == "recoverable_json_fragment"));
+
+    std::fs::remove_dir_all(root).expect("cleanup deep node json pedagogical fixture");
 }
 
 #[test]
@@ -307,13 +739,21 @@ fn test_plan_reconstruccion_write_local_canon_exige_hash_y_backup() {
     let root = temp_repo_root("reconstruction_write_ok");
     write_minimal_perimeter_fixture(&root);
     let source = root.join("data/in/objeto_de_estudio_trazabilidad_y_desarrollo.html");
+    write_file(&source, "abc");
+    let jsonl = root.join("data/tmp/html_export/export-test/tiddlers.export.jsonl");
+    write_file(&jsonl, "abc");
+    let abc_hash = "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    write_export_manifest(&root, &source, &jsonl, abc_hash, abc_hash);
+    let run_dir = root.join("data/tmp/reconstruction/reconstruction-test");
 
-    let report = audit_reconstruction_plan(
+    let report = audit_reconstruction_plan_with_artifacts(
         &root,
         &source,
         ReconstructionSourceRole::Seed,
         ReconstructionMode::WriteLocalCanon,
         &root.join("data/out/local"),
+        Some(&jsonl),
+        Some(&run_dir),
         true,
         true,
     );
@@ -322,4 +762,134 @@ fn test_plan_reconstruccion_write_local_canon_exige_hash_y_backup() {
     assert_eq!(report.errors, 0);
 
     std::fs::remove_dir_all(root).expect("cleanup reconstruction write ok fixture");
+}
+
+#[test]
+fn test_plan_reconstruccion_rechaza_jsonl_sin_coherencia_html() {
+    let root = temp_repo_root("reconstruction_origin_mismatch");
+    write_minimal_perimeter_fixture(&root);
+    let source = root.join("data/in/tiddly-data-converter (Saved).html");
+    write_file(&source, "abc");
+    let other_source = root.join("data/in/objeto_de_estudio_trazabilidad_y_desarrollo.html");
+    write_file(&other_source, "abc");
+    let jsonl = root.join("data/tmp/html_export/export-test/tiddlers.export.jsonl");
+    write_file(&jsonl, "abc");
+    let abc_hash = "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    write_export_manifest(&root, &other_source, &jsonl, abc_hash, abc_hash);
+    let run_dir = root.join("data/tmp/reconstruction/reconstruction-test");
+
+    let report = audit_reconstruction_plan_with_artifacts(
+        &root,
+        &source,
+        ReconstructionSourceRole::Working,
+        ReconstructionMode::WriteLocalCanon,
+        &root.join("data/out/local"),
+        Some(&jsonl),
+        Some(&run_dir),
+        true,
+        true,
+    );
+
+    assert_eq!(report.verdict, ReconstructionPlanVerdict::Rejected);
+    assert!(report.checks.iter().any(
+        |check| check.check_id == "plan-input-manifest-source-match" && check.status == "error"
+    ));
+
+    std::fs::remove_dir_all(root).expect("cleanup reconstruction origin mismatch fixture");
+}
+
+#[test]
+fn test_plan_reconstruccion_rechaza_jsonl_legacy_sin_manifiesto() {
+    let root = temp_repo_root("reconstruction_legacy_jsonl");
+    write_minimal_perimeter_fixture(&root);
+    let source = root.join("data/in/tiddly-data-converter (Saved).html");
+    let jsonl = root.join("data/tmp/tiddlers.export.jsonl");
+    write_file(&jsonl, "abc");
+    let run_dir = root.join("data/tmp/reconstruction/reconstruction-test");
+
+    let report = audit_reconstruction_plan_with_artifacts(
+        &root,
+        &source,
+        ReconstructionSourceRole::Working,
+        ReconstructionMode::WriteLocalCanon,
+        &root.join("data/out/local"),
+        Some(&jsonl),
+        Some(&run_dir),
+        true,
+        true,
+    );
+
+    assert_eq!(report.verdict, ReconstructionPlanVerdict::Rejected);
+    assert!(report
+        .checks
+        .iter()
+        .any(|check| check.check_id == "plan-input-jsonl-scope" && check.status == "error"));
+
+    std::fs::remove_dir_all(root).expect("cleanup reconstruction legacy jsonl fixture");
+}
+
+#[test]
+fn test_rollback_guiado_valida_backup_y_hash_before() {
+    let root = temp_repo_root("reconstruction_rollback_ok");
+    write_minimal_perimeter_fixture(&root);
+    let backup = root.join("data/tmp/reconstruction/reconstruction-test/canon_before");
+    write_file(&backup.join("tiddlers_1.jsonl"), "{}\n");
+    let before_hash = canonical_canon_tree_hash(&backup).expect("backup hash");
+    let report_path =
+        root.join("data/tmp/reconstruction/reconstruction-test/reconstruction-report.json");
+    write_file(
+        &report_path,
+        &format!(
+            r#"{{
+              "run_id": "reconstruction-test",
+              "mode": "write_local_canon",
+              "output_target": "data/out/local",
+              "backup_dir": "data/tmp/reconstruction/reconstruction-test/canon_before",
+              "canon_before_hash": "{}",
+              "rollback_ready": true
+            }}"#,
+            before_hash,
+        ),
+    );
+
+    let report = audit_reconstruction_rollback(&root, &report_path);
+
+    assert_eq!(report.verdict, ReconstructionRollbackVerdict::Ready);
+    assert_eq!(report.errors, 0);
+    assert_eq!(
+        report.rollback.computed_backup_hash.as_deref(),
+        Some(before_hash.as_str())
+    );
+
+    std::fs::remove_dir_all(root).expect("cleanup reconstruction rollback ok fixture");
+}
+
+#[test]
+fn test_rollback_guiado_rechaza_hash_before_ambiguo() {
+    let root = temp_repo_root("reconstruction_rollback_hash_mismatch");
+    write_minimal_perimeter_fixture(&root);
+    let backup = root.join("data/tmp/reconstruction/reconstruction-test/canon_before");
+    write_file(&backup.join("tiddlers_1.jsonl"), "{}\n");
+    let report_path =
+        root.join("data/tmp/reconstruction/reconstruction-test/reconstruction-report.json");
+    write_file(
+        &report_path,
+        r#"{
+          "run_id": "reconstruction-test",
+          "mode": "write_local_canon",
+          "output_target": "data/out/local",
+          "backup_dir": "data/tmp/reconstruction/reconstruction-test/canon_before",
+          "canon_before_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+          "rollback_ready": true
+        }"#,
+    );
+
+    let report = audit_reconstruction_rollback(&root, &report_path);
+
+    assert_eq!(report.verdict, ReconstructionRollbackVerdict::Rejected);
+    assert!(report.checks.iter().any(|check| check.check_id
+        == "rollback-backup-hash-matches-report"
+        && check.status == "error"));
+
+    std::fs::remove_dir_all(root).expect("cleanup reconstruction rollback mismatch fixture");
 }

--- a/tests/fixtures/s77/test_stage_modal_delta.py
+++ b/tests/fixtures/s77/test_stage_modal_delta.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from python_scripts.stage_modal_delta import compare_and_stage
+
+
+def write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
+            handle.write("\n")
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def record(record_id: str, title: str, role: str, content: dict | None = None) -> dict:
+    payload = {
+        "schema_version": "v0",
+        "id": record_id,
+        "key": title,
+        "title": title,
+        "canonical_slug": title.replace(" ", "-"),
+        "version_id": "sha256:" + record_id[-1] * 64,
+        "content_type": "image/png" if role == "asset" else "text/markdown",
+        "modality": "image" if role == "asset" else "text",
+        "encoding": "base64" if role == "asset" else "utf-8",
+        "is_binary": role == "asset",
+        "is_reference_only": False,
+        "role_primary": role,
+        "text": "aGVsbG8=" if role == "asset" else "body",
+        "source_type": "image/png" if role == "asset" else "text/markdown",
+        "source_position": f"fixture:{title}",
+        "created": "20260430000000000",
+        "modified": "20260430000000000",
+    }
+    if content is not None:
+        payload["content"] = content
+    return payload
+
+
+class StageModalDeltaTests(unittest.TestCase):
+    def test_stages_only_missing_asset_projection(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="s77_modal_delta_") as raw_tmp:
+            tmp = Path(raw_tmp)
+            canon_dir = tmp / "canon"
+            normalized = tmp / "normalized.jsonl"
+            out_dir = tmp / "out"
+
+            live_asset = record("00000000-0000-5000-8000-000000000001", "asset missing", "asset")
+            live_text = record(
+                "00000000-0000-5000-8000-000000000002",
+                "text changed in normalized",
+                "note",
+                {"plain": "body"},
+            )
+            live_asset_already = record(
+                "00000000-0000-5000-8000-000000000003",
+                "asset already projected",
+                "asset",
+                {"projection_kind": "asset", "modalities": ["asset"], "asset": {"payload_present": False}},
+            )
+            write_jsonl(canon_dir / "tiddlers_1.jsonl", [live_asset, live_text, live_asset_already])
+
+            normalized_asset = dict(live_asset)
+            normalized_asset["content"] = {
+                "projection_kind": "asset",
+                "modalities": ["asset"],
+                "asset": {
+                    "mime_type": "image/png",
+                    "encoding": "base64",
+                    "payload_present": True,
+                },
+            }
+            normalized_text = dict(live_text)
+            normalized_text["content"] = {"plain": "body", "references": [{"kind": "url", "target": "https://example.test", "source": "bare_url"}]}
+            write_jsonl(normalized, [normalized_asset, normalized_text, live_asset_already])
+
+            report = compare_and_stage(canon_dir, normalized, out_dir, scope="asset-content")
+
+            self.assertEqual(report["comparison"]["changed_line_count"], 2)
+            self.assertEqual(report["comparison"]["field_change_counts"], {"content": 2})
+            self.assertEqual(report["delta"]["selected_count"], 1)
+            self.assertEqual(report["delta"]["ignored_changed_lines"], 1)
+
+            patch = read_jsonl(out_dir / "modal-assets.patch.jsonl")
+            self.assertEqual(len(patch), 1)
+            self.assertEqual(patch[0]["id"], live_asset["id"])
+            self.assertEqual(patch[0]["changed_fields"], ["content"])
+
+            staged = read_jsonl(out_dir / "staged-canon" / "tiddlers_1.jsonl")
+            self.assertIn("asset", staged[0]["content"])
+            self.assertEqual(staged[1], live_text)
+            self.assertEqual(staged[2], live_asset_already)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# feat(m03-m04/s70-s78): Rust kernel arc — operator menu centralizado, quality gates, modal projection y regeneración canónica secuencial

---

### Resumen ejecutivo

Este PR integra 9 sesiones consecutivas (s70–s78) que constituyen el arco completo de construcción del Rust kernel como capa de compuertas normativas del sistema, la capa de operación humana centralizada (operator menu), la auditoria de calidad canónica, la proyección modal y la regeneración completa del canon local con política de shardización secuencial.

El arco cierra m03 (s70) y completa el núcleo de m04 (s71–s78).
El canon local `data/out/local` fue regenerado en s78 con estado validado, 8 shards, 100 líneas máximas por shard, 724 líneas, 43/43 assets con `content.asset`.

---

### Sesiones cubiertas

| Sesión | Milestone | Nombre |
|--------|-----------|--------|
| s70 | m03 | operator-menu-and-session-sync |
| s71 | m04 | rust-kernel-perimeter-and-invariants |
| s72 | m04 | rust-kernel-reconstruction-plan-gate |
| s73 | m04 | rust-kernel-reconstruction-reversibility-gate |
| s74 | m04 | rust-kernel-canonical-line-gate-and-deep-node-inspector |
| s75 | m04 | rust-kernel-family-template-hardening-and-canonical-normalization |
| s76 | m04 | rust-kernel-modal-projection-and-asset-canonical-hardening |
| s77 | m04 | canonical-staging-and-controlled-modal-admission |
| s78 | m04 | full-canon-regeneration-shard-rebalance-and-flow-verification |

---

### Cambios por sesión

#### s70 — Operator menu y session sync (m03 cierre)
- Se creó `python_scripts/operator_menu.py` con menú principal de 11 opciones como única superficie de operación humana.
- Se creó `python_scripts/session_sync.py` para escanear entregables `.md.json`, derivar identidad canónica y generar inventarios.
- El wrapper se movió a `shell_scripts/tdc.sh`; único entry point humano declarado en `README.md`.
- La sincronización separa diferencias reemplazables de conflictos bloqueantes; admite `--allow-replacements` con backup, reporte y rollback exacto.
- Estado previo al arco m04: 7 shards, 696 líneas en `data/out/local`.

#### s71 — Rust kernel: perimeter e invariantes (m04 inicio)
- Se agregó `audit_perimeter` a `rust/doctor` con estructuras serializables de reporte.
- El binario `audit` incorpora subcomando `perimeter`; la opción 1 del menú ejecuta el chequeo y muestra `rust kernel perimeter: OK`.
- Invariantes cubiertas: semilla principal `data/in/`, sesiones bajo `data/sessions/` (bloqueado en raíz), shards canónicos contiguos en `data/out/local`, `reverse_html` declarado no autoritativo.
- Endurecimiento del test `test_s65_microsoft_copilot_flow.py` para no depender del README largo obsoleto.

#### s72 — Rust kernel: reconstruction plan gate
- Se agregaron `ReconstructionSourceRole`, `ReconstructionMode`, `ReconstructionPlanVerdict` y reporte de plan en `rust/doctor`.
- La CLI interna `audit` acepta subcomando `reconstruction-plan`.
- El menú obliga a seleccionar HTML desde `data/in/` y declarar rol (`seed`, `working`, `bootstrap_aux`).
- Extracción HTML → JSONL temporal, shardización y reverse pasan por la compuerta en modos `staging`, `write_local_canon` y `reverse_projection` respectivamente.

#### s73 — Rust kernel: reconstruction reversibility gate
- Se agregó `audit_reconstruction_plan_with_artifacts`; Rust valida que el JSONL temporal tenga manifiesto y coincida con el HTML declarado por ruta y SHA-256.
- Se agregó `audit reconstruction-rollback` como compuerta Rust de rollback guiado con hash de árbol canónico.
- El exportador Go incorpora `source_html_path` y `source_html_sha256` al manifiesto temporal.
- El menú persiste `gate-report.json` y `reconstruction-report.json` bajo `data/tmp/reconstruction/<run_id>/`.
- La shardización autorizada conserva `canon_before/`, `canon_after/`, manifiestos de árbol y hashes before/after.
- Se restauraron `data/sessions/00_contratos/policy/canon_policy_bundle.json` y `data/sessions/00_contratos/projections/derived_layers_registry.json`.
- Se restituyó `m03-s65-microsoft-copilot-execution-surface-and-readme-hardening-v0.md.json` requerido por test focal s65.
- Derivados (`enriched`, `ai`, `microsoft_copilot`) validados con `Rejected: 0` como prerequisito.
- Archivos principales modificados: `rust/doctor/src/report.rs`, `lib.rs`, `bin/audit.rs`, `tests/test_doctor.rs`, `go/canon/exporter_tiddler.go`, `go/bridge/cmd/export_tiddlers/main.go`, `main_test.go`, `python_scripts/operator_menu.py`, `README.md`.

#### s74 — Rust kernel: canonical-line gate y deep-node inspector
- Se creó `rust/doctor/src/canon_quality.rs`.
- Se extendieron `report.rs` y `lib.rs` con reportes de canonical-line gate y deep-node inspector.
- CLI interna: subcomandos `audit canonical-line-gate` y `audit deep-node-inspect`.
- Pruebas focales para taxonomía de líneas, deriva de plantilla y JSON incrustado.
- Opción no destructiva de auditoría integrada en `operator_menu.py`.
- Reportes generados en `data/tmp/s74-*` y `data/tmp/canonical_quality/quality-20260430125315/`.
- **Líneas candidatas s74**: 7 líneas generadas vía `session_sync`; pasaron canonical-line gate, `strict`, `reverse-preflight`, `validate` y dry-run (`reverse_rejected=0`). **No se ejecutó apply.**

#### s75 — Rust kernel: family template hardening y canonical normalization
- Se agregaron 8 perfiles focales de familia en `rust/doctor` (contrato, procedencia, detalles, hipótesis, balance, propuesta, diagnóstico, activos).
- `canonical-line-gate` incluye `family_profiles`, `incomplete_line_triage` y `baseline_source` en deriva de plantillas.
- 43 líneas incompletas heredadas de s74 agrupadas como `role:asset`, razón `asset_without_content_projection`, prioridad `medium`.
- El deep-node inspector separa `structural_json`, `pedagogical_json`, `json_fragment`, `valid_json`, `recoverable_json` e `invalid_json`. Fences pedagógicos dejan de contarse como inválidos.
- Resultado sobre canon: 724 líneas, 171 OK, 510 warning, 43 incompletas, 0 inconsistentes, 0 rechazadas.
- Resultado deep-node: 724 nodos, 1195 campos, 470 hallazgos, 365 JSON estructurales, 53 pedagógicos, 0 inválidos/reportables.
- **No se escribió en `data/out/local`.** Salida completamente no destructiva.

#### s76 — Rust kernel: modal projection y asset canonical hardening
- `ContentProjection` en Go extendido con `projection_kind`, `modalities`, `asset`, `code_blocks`, `equations`, `references`, `structured_payload`.
- Se implementó `DeriveContentProjection` como capa derivada no autoritativa.
- Proyección `content.asset` para activos binarios: conserva `asset_id`, `mime_type`, `encoding`, `payload_ref`, presencia, bytes y hash.
- `DetectModality` reconoce código dominante y contenido textual mixto.
- `ValidateStrict` endurecido para coherencia de proyecciones modales.
- `rust/doctor` extendido con `modal_projection_audit` e issues específicos de assets sin `content.asset`.
- Actualizado `esquemas/canon/derived_field_rules.md`.
- Resultado: canon vivo tiene 43 assets sin `content.asset`; normalización temporal los corrige todos con `strict` y `reverse-preflight` pasando. **No se aplicó al canon vivo.**

#### s77 — Canonical staging y controlled modal admission
- Se creó `python_scripts/stage_modal_delta.py`: compara canon vivo vs copia normalizada y construye staging de delta modal.
- Prueba focal: `tests/fixtures/s77/test_stage_modal_delta.py`.
- Rust `debt_summary` separa deuda modal, deriva histórica de plantillas, warnings de riqueza, incompletas y bloqueantes.
- Menú actualizado con opción `Staging delta modal S76/S77`.
- Delta seleccionado: 43 líneas `role_primary=asset` con `content.asset` ausente en canon vivo y presente en s76.
- Patch en `data/tmp/s77-modal-admission/s77-modal-assets-minimal/modal-assets.patch.jsonl`.
- **El canon vivo no fue modificado.**

#### s78 — Full canon regeneration, shard rebalance y flow verification
- Política de shardización histórica fija reemplazada por `sequential-max-lines-v0` (100 líneas/shard por defecto, configurable con `--max-lines`).
- `WriteShardSet` elimina shards canónicos obsoletos antes de escribir los nuevos, conservando otros directorios locales.
- Pruebas agregadas: partición secuencial, límite configurable, JSON inválido y limpieza de shards obsoletos.
- `python_scripts/audit_normative_projection.py` corregido para reportar shards por glob dinámico.
- **Canon escrito:** se exportó el HTML de trabajo, se validó en staging con compuerta de reconstrucción, se ejecutó `strict` + `reverse-preflight` + reverse autoritativo, y se escribió `data/out/local`.
- 7 líneas de s73 previamente admitidas desde `data/sessions` restituidas.
- Derivados locales regenerados; gobernanza validada.
- Se retiró del menú la opción separada de staging modal S76/S77 para no fragmentar el flujo humano.

---

### Estado canónico final (post s78)

| Métrica | Valor |
|---------|-------|
| Shards canónicos | 8 |
| Líneas totales | 724 |
| Máx. líneas/shard | 100 |
| Distribución | 100, 100, 100, 100, 100, 100, 100, 24 |
| Assets con `content.asset` | 43/43 |
| Canon path | `data/out/local/tiddlers_*.jsonl` |

---

### Líneas candidatas por sesión

| Sesión | Candidatas generadas | Apply ejecutado |
|--------|---------------------|-----------------|
| s74 | 7 líneas (pasaron todos los preflights) | No |
| s75 | No (salida no destructiva) | No |
| s76 | No (normalización temporal) | No |
| s77 | 43 líneas (patch modal staged) | No |
| s78 | 7 líneas s73 restituidas + 717 desde HTML | **Sí — canon escrito** |

---

### Estado de validación (s78 cierre)

| Validación | Estado |
|------------|--------|
| `strict` | ✅ Passed |
| `reverse-preflight` | ✅ Passed |
| Reverse autoritativo | ✅ `Rejected: 0` |
| `validate_corpus_governance.py` | ✅ Passed (warnings opcionales por capas `proposals`, `audit`, `export` ausentes) |
| Tests focales s55/s64/s65/s77 | ✅ Passed |
| `rollback_ready` (reconstrucción completa) | ⚠️ `false` — no había canon previo real; admisión s73 conserva rollback propio |

---

### Artefactos actualizados en `data/sessions/`

**`data/sessions/00_contratos/`** — Contratos de sesión presentes (`.md.json`):
- `m03-s70-operator-menu-and-session-sync-v0.md.json`
- `m04-s71-rust-kernel-perimeter-and-invariants-v0.md.json`
- `m04-s72-rust-kernel-reconstruction-plan-gate-v0.md.json`
- `m04-s73-rust-kernel-reconstruction-reversibility-gate-v0.md.json`
- `m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.md.json`
- `m04-s75-rust-kernel-family-template-hardening-and-canonical-normalization-v0.md.json`
- `m04-s76-rust-kernel-modal-projection-and-asset-canonical-hardening-v0.md.json`
- `m04-s77-canonical-staging-and-controlled-modal-admission-v0.md.json`
- `m04-s78-full-canon-regeneration-shard-rebalance-and-flow-verification-v0.md.json`
- `policy/canon_policy_bundle.json` (restaurado en s73)
- `projections/derived_layers_registry.json` (restaurado en s73)

**`data/sessions/02_detalles_de_sesion/`** — Detalles presentes para s70–s78.

**`data/sessions/04_balance_de_sesion/`** — Balances presentes para s70–s78.

**`data/sessions/06_diagnoses/sesion/`**:
- `m04-s74-rust-kernel-canonical-line-gate-and-deep-node-inspector-v0.canon-candidates.jsonl`

---

### Componentes modificados

| Componente | Sesiones |
|------------|---------|
| `rust/doctor/` | s71, s72, s73, s74, s75, s76, s77 |
| `go/canon/` + `go/bridge/` | s73, s76 |
| `python_scripts/operator_menu.py` | s70, s71, s72, s73, s74, s76, s77, s78 |
| `python_scripts/session_sync.py` | s70 |
| `python_scripts/stage_modal_delta.py` | s77 |
| `python_scripts/audit_normative_projection.py` | s78 |
| `shell_scripts/tdc.sh` | s70 |
| `tests/fixtures/s65/` | s71 |
| `tests/fixtures/s77/` | s77 |
| `data/out/local/` | s78 (**canon escrito**) |
| `esquemas/canon/derived_field_rules.md` | s76 |
| `README.md` | s70, s71, s72, s73, s74, s76, s77, s78 |

---

### Clasificación del cambio

- **tipo**: `feat` (dominante) + `refactor` (shardización secuencial)
- **alcance**: transversal — `rust-kernel`, `go/canon`, `python/operator`, `canon/local`, `shell`, `tests`, `esquemas`
- **milestone**: m03 (cierre s70) + m04 (núcleo s71–s78)
- **impacto en canon**: escritura confirmada en s78; no destructivo en s71–s77

---

### Pendientes y deuda conocida

- Deriva histórica de plantillas en 43 líneas `role:asset` no fue reparada en este arco; identificada y triaged en s75.
- El staging delta modal (patch s77) permanece como candidato no absorbido; requiere decisión de apply en sesión futura.
- `rollback_ready` de reconstrucción completa es `false` porque no existía canon previo real antes de s78.
- Capas opcionales `proposals.jsonl`, `audit` y `export` ausentes; governance las reporta como warnings no bloqueantes.