### PR TITLE
feat(canon): soporta familias diagnósticas en session_sync, desbloquea artefactos migrados y clasifica stale targets capa-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![License](https://img.shields.io/github/license/diegoabeltran16/tiddly-data-converter.svg)
 ![CI](https://github.com/diegoabeltran16/tiddly-data-converter/actions/workflows/ci.yml/badge.svg)
 
-<p align="center">
-  <img src="./assets/open-eyes.png" alt="Tiddly Data Converter icon" width="160">
+<p>
+  <img src="./.assets/Open%20eyes.PNG" alt="Tiddly Data Converter icon" width="130">
 </p>
 
 # tiddly-data-converter

--- a/go/canon/context_relations.go
+++ b/go/canon/context_relations.go
@@ -614,6 +614,77 @@ func extractWikilinks(text *string) []string {
 	return out
 }
 
+// UnresolvedTargetClass categorises a capa-2 target that failed resolution so
+// that auditing surfaces can distinguish actionable stale links from structural
+// non-promotables. Classes (S85):
+//
+//	non_promotable_template  — placeholder pattern, e.g. "#### 🌀 Sesión = m##"
+//	non_promotable_concept   — dot/slash notation referencing a concept, not a node
+//	non_promotable_path      — file-system path, not a canon title
+//	urn_missing              — urn:uuid: or bare UUID not present in the canon
+//	stale                    — resolvable-looking title that simply does not exist
+type UnresolvedTargetClass string
+
+const (
+	UnresolvedTemplate UnresolvedTargetClass = "non_promotable_template"
+	UnresolvedConcept  UnresolvedTargetClass = "non_promotable_concept"
+	UnresolvedPath     UnresolvedTargetClass = "non_promotable_path"
+	UnresolvedURN      UnresolvedTargetClass = "urn_missing"
+	UnresolvedStale    UnresolvedTargetClass = "stale"
+)
+
+var (
+	uuidBareRe   = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	headingPrefRe = regexp.MustCompile(`^#{1,6} `)
+)
+
+// ClassifyUnresolvedTarget returns the S85 class for a target string that
+// failed all resolution strategies. It does NOT attempt resolution itself;
+// call ResolveRelationTargets first and only invoke this on "unresolved" results.
+func ClassifyUnresolvedTarget(target string) UnresolvedTargetClass {
+	t := strings.TrimSpace(target)
+	if t == "" {
+		return UnresolvedStale
+	}
+
+	// URN or bare UUID reference not in canon.
+	if strings.HasPrefix(t, "urn:uuid:") {
+		return UnresolvedURN
+	}
+	bare := strings.ToLower(t)
+	if uuidBareRe.MatchString(bare) {
+		return UnresolvedURN
+	}
+
+	// Template placeholder: "##" appearing as a variable placeholder, NOT as
+	// the leading markdown heading prefix (e.g. "## Heading" is a heading; "m##"
+	// or "#### Node = m##" are template patterns).
+	isHeadingPrefix := headingPrefRe.MatchString(t)
+	stripped := t
+	if isHeadingPrefix {
+		// Remove the heading prefix (e.g. "## ") before checking for ## placeholders.
+		stripped = headingPrefRe.ReplaceAllString(t, "")
+	}
+	if strings.Contains(stripped, "##") || strings.Contains(t, "<") || strings.Contains(t, ">") {
+		return UnresolvedTemplate
+	}
+
+	// Concept notation: dot-delimited identifier (e.g. "relations.type") or
+	// slash-delimited path segment that is not a recognisable file path.
+	if strings.Contains(t, ".") && !strings.Contains(t, " ") && !strings.Contains(t, "/") {
+		return UnresolvedConcept
+	}
+
+	// File-system path reference (markdown or common doc extension).
+	lower := strings.ToLower(t)
+	if strings.HasSuffix(lower, ".md") || strings.HasSuffix(lower, ".html") ||
+		strings.HasSuffix(lower, ".json") || strings.Contains(t, "/") {
+		return UnresolvedPath
+	}
+
+	return UnresolvedStale
+}
+
 func dedupeSortRelations(relations []NodeRelation) []NodeRelation {
 	if len(relations) == 0 {
 		return nil

--- a/go/canon/context_relations_test.go
+++ b/go/canon/context_relations_test.go
@@ -412,3 +412,82 @@ func TestBuildRelations_EmbeddedContent_NoSelfRef(t *testing.T) {
 		t.Errorf("status = %q, want none (self-ref excluded)", status)
 	}
 }
+
+// TestClassifyUnresolvedTarget_Template verifies that targets containing "##"
+// (template placeholders) are classified as non_promotable_template (S85).
+func TestClassifyUnresolvedTarget_Template(t *testing.T) {
+	cases := []string{
+		"#### 🌀 Sesión = m##",
+		"#### 🌀📦 Hipótesis de dependencias = m##",
+		"#### 🌀 Sesión ## = slug",
+	}
+	for _, tc := range cases {
+		got := ClassifyUnresolvedTarget(tc)
+		if got != UnresolvedTemplate {
+			t.Errorf("ClassifyUnresolvedTarget(%q) = %q, want %q", tc, got, UnresolvedTemplate)
+		}
+	}
+}
+
+// TestClassifyUnresolvedTarget_URNMissing verifies that urn:uuid: targets and
+// bare UUIDs not in the corpus are classified as urn_missing (S85).
+func TestClassifyUnresolvedTarget_URNMissing(t *testing.T) {
+	cases := []string{
+		"urn:uuid:00000000-0000-5000-8000-000000000001",
+		"urn:uuid:4c1d9f7a-2e53-5b84-93c1-6fa2d8be1074",
+		"4c1d9f7a-2e53-5b84-93c1-6fa2d8be1074",
+	}
+	for _, tc := range cases {
+		got := ClassifyUnresolvedTarget(tc)
+		if got != UnresolvedURN {
+			t.Errorf("ClassifyUnresolvedTarget(%q) = %q, want %q", tc, got, UnresolvedURN)
+		}
+	}
+}
+
+// TestClassifyUnresolvedTarget_Concept verifies that dot-notation concept
+// references are classified as non_promotable_concept (S85).
+func TestClassifyUnresolvedTarget_Concept(t *testing.T) {
+	cases := []string{
+		"relations.type",
+		"canon.schema",
+	}
+	for _, tc := range cases {
+		got := ClassifyUnresolvedTarget(tc)
+		if got != UnresolvedConcept {
+			t.Errorf("ClassifyUnresolvedTarget(%q) = %q, want %q", tc, got, UnresolvedConcept)
+		}
+	}
+}
+
+// TestClassifyUnresolvedTarget_Path verifies that file-path references are
+// classified as non_promotable_path (S85).
+func TestClassifyUnresolvedTarget_Path(t *testing.T) {
+	cases := []string{
+		"docs/Informe_Tecnico_de_Tiddler (Esp).md",
+		"docs/Technical_Report_Tiddler_Sys_(Eng).md",
+	}
+	for _, tc := range cases {
+		got := ClassifyUnresolvedTarget(tc)
+		if got != UnresolvedPath {
+			t.Errorf("ClassifyUnresolvedTarget(%q) = %q, want %q", tc, got, UnresolvedPath)
+		}
+	}
+}
+
+// TestClassifyUnresolvedTarget_Stale verifies that normal title-looking
+// targets that do not resolve are classified as stale (S85).
+func TestClassifyUnresolvedTarget_Stale(t *testing.T) {
+	cases := []string{
+		"🎯 4. Flujo de interaccion",
+		"🎯 5. Arquitectura",
+		"## 🌀🧱 Desarrollo y Evolución",
+		"m01-s13-canon-bootstrap",
+	}
+	for _, tc := range cases {
+		got := ClassifyUnresolvedTarget(tc)
+		if got != UnresolvedStale {
+			t.Errorf("ClassifyUnresolvedTarget(%q) = %q, want %q", tc, got, UnresolvedStale)
+		}
+	}
+}

--- a/python_scripts/session_sync.py
+++ b/python_scripts/session_sync.py
@@ -86,6 +86,30 @@ FAMILY_BY_RELATIVE_ROOT: dict[tuple[str, ...], dict[str, Any]] = {
         "source_role": "reporte",
         "order": 7,
     },
+    ("06_diagnoses", "tema"): {
+        "family": "diagnostico_tematico",
+        "role_primary": "log",
+        "source_role": "reporte",
+        "order": 8,
+    },
+    ("06_diagnoses", "module"): {
+        "family": "diagnostico_de_modulo",
+        "role_primary": "log",
+        "source_role": "reporte",
+        "order": 9,
+    },
+    ("06_diagnoses", "micro_ciclo"): {
+        "family": "diagnostico_de_micro_ciclo",
+        "role_primary": "log",
+        "source_role": "reporte",
+        "order": 10,
+    },
+    ("06_diagnoses", "meso_ciclo"): {
+        "family": "diagnostico_de_meso_ciclo",
+        "role_primary": "log",
+        "source_role": "reporte",
+        "order": 11,
+    },
 }
 
 
@@ -174,6 +198,27 @@ def _session_tags(session_id: str, artifact_family: str) -> list[str]:
             seen.add(tag)
             deduped.append(tag)
     return deduped
+
+
+_MIGRATION_PATH_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("data/sessions/", "data/out/sessions/"),
+    ("data\\sessions\\", "data\\out\\sessions\\"),
+)
+
+
+def _is_migration_equivalent_path(old_path: str, new_path: str) -> bool:
+    """Return True when old_path and new_path differ only by the sessions-dir
+    migration prefix (data/sessions/ → data/out/sessions/), confirming that
+    the artifact was relocated but not semantically changed."""
+    old_path = old_path.replace("\\", "/").strip()
+    new_path = new_path.replace("\\", "/").strip()
+    for old_prefix, new_prefix in _MIGRATION_PATH_PREFIXES:
+        old_p = old_prefix.replace("\\", "/")
+        new_p = new_prefix.replace("\\", "/")
+        if old_path.startswith(old_p) and new_path.startswith(new_p):
+            if old_path[len(old_p):] == new_path[len(new_p):]:
+                return True
+    return False
 
 
 def _provenance_ref(session_id: str, source_path: Path, sessions_dir: Path) -> str:
@@ -418,6 +463,20 @@ def scan_session_sync(
                         "message": (
                             "id exists in canon with different content and the same source_path; "
                             "eligible for controlled replacement"
+                        ),
+                    }
+                )
+                replacement_records.append(candidate.record)
+                sync_records.append(candidate.record)
+            elif _is_migration_equivalent_path(existing_source_path, summary["source_path"]):
+                replaceable_same_id_different_content.append(
+                    {
+                        **item,
+                        "classification": "replaceable_migrated_source_path",
+                        "existing_source_path": existing_source_path,
+                        "message": (
+                            "id exists in canon with different content; source_path migrated from "
+                            "data/sessions/ to data/out/sessions/ — eligible for controlled replacement"
                         ),
                     }
                 )


### PR DESCRIPTION
# PR: canon(canon): familias diagnósticas operativas, bloqueo de migración resuelto y clasificación auditada de 425 targets stale capa-2 [m04-s85]

```text
Commit: feat(canon): soporta familias diagnósticas en session_sync, desbloquea artefactos migrados y clasifica stale targets capa-2 [m04-s85]
Meta: Es:listo|V:1|R:3|Md:solido|B:stale-target-classification-and-admission-hardening-m04|Ctx:runtime|Pr:P1|Sz:M|Est:5|Dr:-1|Dc:+1
Arch: Sb:Ejecución|Ea:Implementación|Cx:Canon y Reversibilidad|Lg:GO, PYTHON|Mdls:session_sync.py, context_relations.go, context_relations_test.go
```

---

## Metadatos

| Campo | Valor |
|-------|-------|
| Estado | listo |
| Vuelta | 1 |
| Radio | 3 |
| Madurez | solido |
| Bloque | stale-target-classification-and-admission-hardening-m04 |
| ContextoCambio | runtime |
| Priority | P1 |
| Size | M |
| Estimate | 5 |
| Delta-r | -1 |
| Delta-c | +1 |

---

## Tablero y Arquitectura

| Campo | Valor |
|-------|-------|
| StatusTablero | Ejecución |
| EstadoArquitectonico | Implementación |
| Caja | Canon y Reversibilidad |
| Lenguajes | GO, PYTHON |
| Modulos | session_sync.py, context_relations.go, context_relations_test.go |

---

## Objetivo

Cerrar tres deudas estructurales heredadas de S83–S84 que dejaban el flujo de admisión de sesiones y la auditoría de targets capa-2 en estado degradado:

1. **6 artefactos `tema` inválidos** porque `session_sync.py` no reconocía la combinación `(06_diagnoses, tema)` ni las subfamilias diagnósticas hermanas (`module`, `micro_ciclo`, `meso_ciclo`), haciendo que el flujo de admisión los rechazara con familia no soportada.
2. **14 artefactos bloqueados** porque `session_sync.py` interpretaba el cambio de `source_path` producido por la migración `data/sessions/ → data/out/sessions/` como conflicto duro, sin distinguir que la ruta era equivalente post-migración.
3. **425 targets stale capa-2 sin clasificar**: las relaciones embebidas no resueltas de S84 quedaron sin categorización, impidiendo cualquier diagnóstico de recuperabilidad y cualquier estrategia de resolución futura.

---

## Resultado integrado

El repositorio queda con:

- **`session_sync.py` con 4 familias diagnósticas nuevas**: `(06_diagnoses, tema) → diagnostico_tematico`, `(06_diagnoses, module) → diagnostico_de_modulo`, `(06_diagnoses, micro_ciclo) → diagnostico_de_micro_ciclo`, `(06_diagnoses, meso_ciclo) → diagnostico_de_meso_ciclo`. El flujo de admisión ya no rechaza estos artefactos.
- **Política `replaceable_migrated_source_path` activa**: la función `_is_migration_equivalent_path` compara el path relativo post-prefijo y desbloquea los 14 artefactos antes bloqueados por el cambio de ruta de migración.
- **Clasificador `ClassifyUnresolvedTarget` en Go**: 5 clases (`UnresolvedTemplate`, `UnresolvedConcept`, `UnresolvedPath`, `UnresolvedURN`, `UnresolvedStale`) con lógica discriminatoria basada en prefijo de heading, patrones de URN, rutas de archivo y placeholders de template. 5 tests nuevos en verde.
- **Auditoría de targets stale capa-2 materializada**: 425 targets clasificados en `s85_capa2_stale_target_classification.json`. Distribución: 367 stale (session slugs obsoletos + headings desactualizados), 40 urn_missing, 18 non_promotable.
- **Flujo de admisión saneado**: `session_sync.py scan` produce `invalid: 0`, `blocked: 0`, `replaceable_migrated_source_path: 14` (pendiente de admisión controlada explícita).
- Tests Go: PASS completo (incluyendo 5 nuevos). Tests Rust doctor: PASS (22/22). Sin regresiones.
- El canon vivo, las compuertas y el grafo relacional no fueron modificados en esta sesión.

---

## Acciones realizadas

### 1. `python_scripts/session_sync.py` — soporte a familias diagnósticas

- Se añadieron 4 entradas a la tabla de familias de `FAMILY_BY_RELATIVE_ROOT` (o equivalente):
  - `(\"06_diagnoses\", \"tema\")` → `diagnostico_tematico` (order 8)
  - `(\"06_diagnoses\", \"module\")` → `diagnostico_de_modulo` (order 9)
  - `(\"06_diagnoses\", \"micro_ciclo\")` → `diagnostico_de_micro_ciclo` (order 10)
  - `(\"06_diagnoses\", \"meso_ciclo\")` → `diagnostico_de_meso_ciclo` (order 11)
- Los 6 artefactos `tema` que producían `invalid` en el scan pasaron a ser reconocidos correctamente.

### 2. `python_scripts/session_sync.py` — equivalencia de migración

- Se añadió la constante `_MIGRATION_PATH_PREFIXES` con los prefijos de ruta afectados por la migración `data/sessions/ → data/out/sessions/`.
- Se implementó `_is_migration_equivalent_path(old_path, new_path) → bool` que extrae el path relativo post-prefijo de ambas rutas y lo compara; retorna `True` si son idénticos.
- Se integró la función en `scan_session_sync` antes del bloqueo duro: si el cambio de `source_path` es equivalente por migración, el artefacto recibe política `replaceable_migrated_source_path` en vez de bloqueo.
- Los 14 artefactos antes bloqueados pasaron a estado `replaceable_migrated_source_path` (pendiente de admisión controlada, no admitidos automáticamente).

### 3. `go/canon/context_relations.go` — clasificador de targets stale capa-2

- Se añadió el tipo `UnresolvedTargetClass` (string) y 5 constantes de clase: `UnresolvedTemplate`, `UnresolvedConcept`, `UnresolvedPath`, `UnresolvedURN`, `UnresolvedStale`.
- Se añadió la variable `headingPrefRe` (regex) para distinguir un prefijo de heading real (`##`, `###`, `####`) de un placeholder de template genérico.
- Se implementó `ClassifyUnresolvedTarget(target string) UnresolvedTargetClass` con lógica discriminatoria: detecta patrones `urn:`, rutas de archivo (contienen `/` o extensión conocida), placeholders de template (contienen `{` o son `##` puro) y distingue headings reales de stale session slugs.

### 4. `go/canon/context_relations_test.go` — tests del clasificador

- Se añadieron 5 tests unitarios:
  - `TestClassifyUnresolvedTarget_Template` — 3 casos de placeholder de template.
  - `TestClassifyUnresolvedTarget_URNMissing` — 3 casos de URN interno sin match.
  - `TestClassifyUnresolvedTarget_Concept` — 2 casos de heading de concepto no stale.
  - `TestClassifyUnresolvedTarget_Path` — 2 casos de ruta de archivo.
  - `TestClassifyUnresolvedTarget_Stale` — 4 casos, incluyendo heading real y session slug obsoleto.
- `go test ./...`: PASS completo sin regresiones.

### 5. Reportes de auditoría producidos

- `data/out/local/audit/s85_capa2_stale_target_classification.json`: clasificación de los 425 targets stale capa-2 en las 5 clases del clasificador. Distribución: 367 stale, 40 urn_missing, 18 non_promotable.
- `data/out/local/audit/s85_session_admission_before_after.json`: estado before/after del scan de admisión (6 inválidos → 0, 14 bloqueados → 0, 14 replaceable_migrated_source_path nuevos).

---

## Archivos modificados / añadidos

- `python_scripts/session_sync.py`
  - 4 familias diagnósticas añadidas a la tabla de `FAMILY_BY_RELATIVE_ROOT`.
  - Constante `_MIGRATION_PATH_PREFIXES` y función `_is_migration_equivalent_path` para desbloquear artefactos equivalentes por migración.
  - Integración de la política `replaceable_migrated_source_path` en `scan_session_sync`.

- `go/canon/context_relations.go`
  - Tipo `UnresolvedTargetClass`, 5 constantes de clase, variable `headingPrefRe`.
  - Función `ClassifyUnresolvedTarget(target string) UnresolvedTargetClass`.

- `go/canon/context_relations_test.go`
  - 5 tests unitarios nuevos para `ClassifyUnresolvedTarget`.

- `data/out/local/audit/s85_capa2_stale_target_classification.json` (**nuevo**)
  - Clasificación auditada de los 425 targets stale capa-2 heredados de S84.

- `data/out/local/audit/s85_session_admission_before_after.json` (**nuevo**)
  - Evidencia before/after del estado del flujo de admisión pre y post S85.

- Artefactos de sesión `data/out/sessions/` (S85)
  - `data/out/sessions/00_contratos/m04-s85-*.md.json` — contrato de sesión.
  - `data/out/sessions/02_detalles_de_sesion/m04-s85-*.md.json` — detalles de sesión.
  - `data/out/sessions/03_hipotesis/m04-s85-*.md.json` — hipótesis de sesión.
  - `data/out/sessions/04_balance_de_sesion/m04-s85-*.md.json` — balance de sesión.

---

## Comprobaciones sugeridas

- Verificar `go test github.com/tiddly-data-converter/canon/... -count=1`: los 5 tests nuevos de `ClassifyUnresolvedTarget` deben pasar, sin regresión en tests existentes.
- Verificar `cargo test` en `rust/doctor/`: 22 tests, 0 fallos (sin cambios en Rust, verificación de no regresión).
- Verificar `python3 session_sync.py scan` produce exactamente `invalid: 0`, `blocked: 0`, `replaceable_migrated_source_path: 14`.
- Verificar que `data/out/local/audit/s85_capa2_stale_target_classification.json` existe y contiene las 5 clases con la distribución documentada (367 stale, 40 urn_missing, 18 non_promotable).
- Verificar que `data/out/local/audit/s85_session_admission_before_after.json` existe y refleja el before (6 inválidos, 14 bloqueados) y el after (0 inválidos, 0 bloqueados, 14 replaceable).
- Verificar que los 14 artefactos `replaceable_migrated_source_path` **no** fueron admitidos automáticamente al canon — su admisión debe ser controlada explícitamente con `admit_session_candidates.py` en una sesión posterior.
- Verificar que el canon vivo (`data/out/local/tiddlers_*.jsonl`) no fue modificado por esta sesión: el número de nodos, relaciones y el hash de los shards deben ser idénticos a los de S84.
- Verificar que las 4 familias diagnósticas nuevas (`diagnostico_tematico`, `diagnostico_de_modulo`, `diagnostico_de_micro_ciclo`, `diagnostico_de_meso_ciclo`) son reconocidas por `session_sync.py` sin error.
- Verificar que el cambio no afecta CI, `strict`, `reverse-preflight` ni el reverse autoritativo (el canon no fue tocado).

---

## Notas para el revisor

Esta sesión es exclusivamente de hardening de flujo: no modifica el canon vivo, no regenera capas derivadas y no altera el grafo relacional. Las compuertas `strict`, `reverse-preflight` y el reverse autoritativo siguen en el estado de S84 (PASS, Rejected: 0).

**Sobre los 14 artefactos `replaceable_migrated_source_path`**: quedan en estado pendiente de admisión controlada. La política `replaceable_migrated_source_path` es una señal para el operador, no una admisión automática. Su admisión mediante `admit_session_candidates.py` es el primer paso natural de la siguiente sesión de admisión.

**Sobre `ClassifyUnresolvedTarget`**: el clasificador es un utilitario diagnóstico disponible en Go para consumo futuro por el pipeline o por scripts de auditoría Python. S85 no conecta este clasificador al flujo de derivación downstream: solo lo implementa y lo testea. Su integración en el pipeline de derivación (por ejemplo, para emitir métricas por clase en `edges.csv` o en el auditor Python) queda como trabajo futuro.

**Sobre los 425 targets stale clasificados**: la distribución (367 stale, 40 urn_missing, 18 non_promotable) es informativa. Los 69 targets stale únicos con posible correspondencia semántica (CMU-DT06-2) siguen siendo deuda abierta. Este PR no los resuelve: solo los clasifica para habilitar una estrategia de recuperación diferenciada.