### PR TITLE
feat(pipeline): secretless hardening, CI/CodeQL greenline, diagnostic infrastructure, relational chunks y legacy test cleanup

### DIFF
--- a/.github/instructions/procedencia_epistemologica.instructions.md
+++ b/.github/instructions/procedencia_epistemologica.instructions.md
@@ -33,6 +33,37 @@
 - Las líneas candidatas deben declarar procedencia suficiente y apuntar al archivo fuente bajo `data/out/local/sessions/`.
 - No admitir al canon líneas cuya procedencia, sesión de origen o familia de artefacto no sean verificables localmente.
 
+## Gobernanza de procedencia diagnóstica
+
+Cuando una sesión produce diagnósticos por ciclos, la procedencia debe separar
+fuente primaria, fuente auxiliar e inferencia del agente.
+
+Jerarquía operativa:
+
+1. **Diagnósticos previos específicos**: un mesociclo consume primero
+   microdiagnósticos ya producidos y válidos.
+2. **Sessions local**: `data/out/local/sessions/` conserva staging y memoria
+   reciente cuando existe.
+3. **Canon local**: `data/out/local/tiddlers_*.jsonl` sostiene memoria durable
+   cuando `sessions/` fue depurado.
+4. **Auditorías y derivados**: `data/out/local/audit/`, `enriched/` y `ai/`
+   se consultan solo para hipótesis concretas.
+5. **Repositorio**: código, tests, workflows e instrucciones validan el estado
+   arquitectónico actual.
+6. **Espejo remoto**: OneDrive o superficies remotas son paridad operativa, no
+   autoridad superior al canon local por defecto.
+
+Todo diagnóstico de ciclo debe declarar:
+
+- completitud en staging local;
+- completitud canónica;
+- fuente usada para cada conclusión importante;
+- si hubo consulta remota, si fue dry-run, estática o real.
+
+Si `sessions/` está ausente o depurado, no se debe concluir pérdida histórica
+sin revisar canon local. La ausencia de staging y la ausencia de evidencia
+histórica son estados distintos.
+
 ## Interacción con otros nodos
 - Requiere `## 🎯🧱 Detalles del tema` para situar la procedencia dentro del marco del tema.
 - Se articula con `## 🧰🧱 Elementos específicos` cuando existe un recurso concreto que también debe preservarse.

--- a/.github/instructions/tiddlers_sesiones.instructions.md
+++ b/.github/instructions/tiddlers_sesiones.instructions.md
@@ -69,6 +69,165 @@ Titulos obligatorios para las familias principales:
 el resto del identificador sin el prefijo `mXX-sNN-` y sin `session-` cuando
 aparezca como prefijo operativo.
 
+### Diagnósticos de ciclo de sesiones
+
+Los diagnósticos de ciclo son sesiones diagnósticas propias.
+No forman parte del paquete obligatorio de entregables de toda sesión.
+
+Una sesión normal produce sus 7 entregables ordinarios.
+
+Una sesión diagnóstica de microciclo produce:
+- sus 7 entregables normales de sesión;
+- el diagnóstico de microciclo correspondiente.
+
+Una sesión diagnóstica de mesociclo produce:
+- sus 7 entregables normales de sesión;
+- el diagnóstico de mesociclo correspondiente.
+
+#### Clasificación de tipos de sesión
+
+El sistema distingue seis tipos de sesión relevantes para la gobernanza de
+artefactos:
+
+1. **Diagnóstico puro**.
+   Lee evidencia y produce el diagnóstico solicitado.
+   No toca código, tests ni instrucciones.
+   Si descubre que necesita modificar infraestructura para poder producir el
+   diagnóstico, debe detenerse y reportar el bloqueo.
+
+2. **Infraestructura diagnóstica**.
+   Ajusta instrucciones, scripts o tests para mejorar el sistema diagnóstico.
+   Debe producir los 7 entregables normales de sesión, además de cualquier
+   diagnóstico explícitamente solicitado.
+
+3. **Sesión mixta**.
+   Combina ajuste técnico limitado con un diagnóstico mayor.
+   Debe producir los 7 entregables normales de sesión y declarar qué parte fue
+   infraestructura y qué parte fue diagnóstico.
+
+4. **Sesión práctica/desarrollo**.
+   Implementa o corrige superficies del sistema: código, tests, CI, canon,
+   scripts, documentación operativa o integraciones.
+   Debe producir los 7 entregables normales de sesión.
+
+5. **Sesión teórica/analítica**.
+   Produce análisis, contratos, decisiones, hipótesis o diseño sin necesidad de
+   tocar código.
+   Debe producir entregables normales cuando cambia memoria, procedencia o
+   dirección del proyecto.
+
+6. **Híbrida/transicional**.
+   Solo es aceptable mientras el flujo diagnóstico se está estabilizando.
+   Debe quedar marcada como excepción y explicar por qué no pudo separarse en
+   diagnóstico puro e infraestructura diagnóstica.
+
+Regla madura:
+
+Cuando el sistema diagnóstico ya está disponible, una sesión diagnóstica pura
+no debe tocar código. Las correcciones de scripts, tests o instrucciones deben
+abrirse como sesión de infraestructura diagnóstica.
+
+#### Gobernanza de procedencia diagnóstica
+
+Los diagnósticos deben declarar de dónde sale cada conclusión importante y no
+confundir ausencia de staging con ausencia histórica.
+
+Jerarquía de lectura:
+
+1. **Diagnósticos previos específicos**.
+   Para mesociclos, leer primero los microdiagnósticos ya producidos.
+
+2. **Sessions local**.
+   Leer `data/out/local/sessions/` cuando exista evidencia reciente o staging
+   operativo.
+
+3. **Canon local**.
+   Leer `data/out/local/tiddlers_*.jsonl` cuando `sessions/` haya sido depurado
+   o para validar completitud canónica.
+
+4. **Auditorías y derivados**.
+   Leer `data/out/local/audit/`, `data/out/local/enriched/` o
+   `data/out/local/ai/` solo si ayudan a validar una hipótesis concreta.
+
+5. **Repositorio**.
+   Leer código, tests, workflows e instrucciones para validar el estado
+   arquitectónico actual.
+
+6. **Espejo remoto**.
+   El remoto/OneDrive es superficie de sincronización y paridad. No es fuente
+   de verdad superior al canon local salvo que una sesión futura lo declare de
+   forma explícita.
+
+Completitud diagnóstica:
+
+- **Completitud en staging local**: `presente`, `parcial`, `ausente` o
+  `depurado`.
+- **Completitud canónica**: `admitida completa`, `admitida parcial` o
+  `no encontrada`.
+- **Fuente usada**: `microdiagnóstico`, `sessions`, `canon`, `auditoría`,
+  `repositorio` o `remoto dry-run`.
+
+Regla:
+
+Depurar `sessions/` es válido cuando el canon local ya absorbió la evidencia.
+El diagnóstico debe registrar esa diferencia en vez de interpretar la ausencia
+local como pérdida automática de memoria.
+
+#### Diagnóstico de microciclo
+
+Uso:
+
+Diagnóstico agregado de 10 sesiones recientes o consecutivas.
+
+Ruta oficial:
+
+```txt
+data/out/local/sessions/06_diagnoses/micro-ciclo/
+```
+
+Formato sugerido de archivo:
+
+```txt
+m04-micro-ciclo-s085-s094-diagnostico.md.json
+```
+
+Formato obligatorio de título:
+
+```txt
+#### 🌀 Diagnóstico de microciclo = sesiones S85-S94
+#### 🌀 Diagnóstico de microciclo = sesiones S65-S74
+```
+
+#### Diagnóstico de mesociclo
+
+Uso:
+
+Diagnóstico agregado de 3 microciclos.
+
+Ruta oficial:
+
+```txt
+data/out/local/sessions/06_diagnoses/meso-ciclo/
+```
+
+Formato sugerido de archivo:
+
+```txt
+m04-meso-ciclo-s064-s094-diagnostico.md.json
+```
+
+Formato obligatorio de título:
+
+```txt
+#### 🌀 Diagnóstico de mesociclo = microciclos S64-S94
+#### 🌀 Diagnóstico de mesociclo = microciclos S65-S94
+```
+
+Regla:
+
+El mesociclo debe consumir diagnósticos de microciclo ya existentes.
+No debe releer 30 sesiones crudas si los 3 microciclos requeridos ya existen.
+
 ## Regla central
 
 `data/out/local/sessions/` es una zona de entrega, trazabilidad y staging operativo. No es

--- a/README.md
+++ b/README.md
@@ -17,4 +17,6 @@ Desde la raíz del repositorio, usar ejecutable:
 shell_scripts/tdc.sh
 ```
 
-Este comando invoca de forma guiada al orquestador de admisión, al canonizador, al reverse y los scripts existentes; muestra métricas y exige confirmaciones robustas antes de cualquier acción que pueda escribirse en el canon local 
+Este comando invoca de forma guiada al orquestador de admisión, al canonizador, al reverse y los scripts existentes; muestra métricas y exige confirmaciones robustas antes de cualquier acción que pueda escribirse en el canon local.
+
+El menú incluye la opción `Generación de derivados`, que regenera las capas locales desde `data/out/local/tiddlers_*.jsonl` hacia `enriched/`, `ai/`, `audit/`, `export/` y `microsoft_copilot/` según corresponda. Los derivados no son fuente de verdad: pueden borrarse y regenerarse desde el canon local y sus artefactos gobernados.

--- a/python_scripts/audit_normative_projection.py
+++ b/python_scripts/audit_normative_projection.py
@@ -10,7 +10,7 @@ Reads:
   - data/out/local/ai/reports/*.json
   - docs/ (normative reference)
 
-Evaluates 21 normative rules, classifies findings, applies safe autofixes,
+Evaluates 23 normative rules, classifies findings, applies safe autofixes,
 rewrites affected canon shards, optionally regenerates derived layers, and emits:
   - data/out/local/audit/manifest.json
   - data/out/local/audit/compliance_report.json
@@ -175,7 +175,7 @@ def load_reports(reports_dir: Path) -> dict:
 
 
 def load_normative_rules() -> list[dict]:
-    """Return the static catalog of normative rules (23 as of S84)."""
+    """Return the static catalog of normative rules (23 as of S98)."""
     return [
         {"id": "RULE-01", "block": "structural", "description": "id, key, title present", "level": "obligatoria", "severity": "critical"},
         {"id": "RULE-02", "block": "structural", "description": "schema_version present and non-empty", "level": "obligatoria", "severity": "major"},
@@ -199,7 +199,7 @@ def load_normative_rules() -> list[dict]:
         {"id": "RULE-20", "block": "normative_report", "description": "non-binary text nodes have content.plain non-null", "level": "recomendada", "severity": "minor"},
         {"id": "RULE-21", "block": "normative_report", "description": "unclassified fraction < 0.25 (soft threshold)", "level": "flexible", "severity": "info"},
         {"id": "RULE-22", "block": "normative_report", "description": "section_path auto-referential fraction < 0.70 (depth-1 quality gate, S81)", "level": "flexible", "severity": "info"},
-        {"id": "RULE-23", "block": "relations", "description": "relational coverage gate: log-family isolation < 95% (S84 capa-2 exposure)", "level": "flexible", "severity": "info"},
+        {"id": "RULE-23", "block": "relations", "description": "relational coverage across canon and AI chunks", "level": "flexible", "severity": "info"},
     ]
 
 
@@ -471,6 +471,166 @@ def evaluate_record(
     return findings
 
 
+def _pct(part: int, total: int) -> float:
+    return round((100.0 * part / total), 2) if total else 0.0
+
+
+def _new_coverage_bucket() -> dict:
+    return {
+        "total_nodes": 0,
+        "nodes_with_relations": 0,
+        "nodes_without_relations": 0,
+        "coverage_pct": 0.0,
+    }
+
+
+def _record_family(rec: dict) -> str:
+    taxonomy_path = rec.get("taxonomy_path")
+    if isinstance(taxonomy_path, list) and taxonomy_path:
+        return str(taxonomy_path[0])[:160]
+
+    for key in ("source_tags", "tags", "normalized_tags"):
+        tags = rec.get(key)
+        if not isinstance(tags, list):
+            continue
+        for tag in tags:
+            tag_s = str(tag)
+            if tag_s.startswith(("session:", "topic:", "layer:", "core:", "channel:")):
+                return tag_s[:160]
+        for tag in tags:
+            tag_s = str(tag)
+            if tag_s.startswith(("#", "##", "###", "####")):
+                return tag_s[:160]
+
+    return str(rec.get("role_primary") or "unknown")
+
+
+def _finalize_coverage_bucket(bucket: dict) -> dict:
+    bucket["coverage_pct"] = _pct(bucket["nodes_with_relations"], bucket["total_nodes"])
+    return bucket
+
+
+def build_rule23_metrics(canon_records: list[dict], chunks: list[dict]) -> dict:
+    total_nodes = len(canon_records)
+    nodes_with_relations = 0
+    by_role: dict[str, dict] = {}
+    by_family: dict[str, dict] = {}
+
+    for rec in canon_records:
+        has_relations = bool(rec.get("relations"))
+        if has_relations:
+            nodes_with_relations += 1
+
+        role = str(rec.get("role_primary") or "unknown")
+        role_bucket = by_role.setdefault(role, _new_coverage_bucket())
+        role_bucket["total_nodes"] += 1
+        if has_relations:
+            role_bucket["nodes_with_relations"] += 1
+        else:
+            role_bucket["nodes_without_relations"] += 1
+
+        family = _record_family(rec)
+        family_bucket = by_family.setdefault(family, _new_coverage_bucket())
+        family_bucket["total_nodes"] += 1
+        if has_relations:
+            family_bucket["nodes_with_relations"] += 1
+        else:
+            family_bucket["nodes_without_relations"] += 1
+
+    for bucket in by_role.values():
+        _finalize_coverage_bucket(bucket)
+    for bucket in by_family.values():
+        _finalize_coverage_bucket(bucket)
+
+    total_chunks = len(chunks)
+    chunks_with_relation_targets = sum(1 for c in chunks if "relation_targets" in c)
+    chunks_with_non_empty_relation_targets = sum(
+        1 for c in chunks
+        if isinstance(c.get("relation_targets"), list) and bool(c.get("relation_targets"))
+    )
+    chunks_with_bad_relation_targets = sum(
+        1 for c in chunks
+        if "relation_targets" in c and not isinstance(c.get("relation_targets"), list)
+    )
+    chunks_with_relation_count = sum(1 for c in chunks if "relation_count" in c)
+    chunks_with_relation_count_mismatch = sum(
+        1 for c in chunks
+        if isinstance(c.get("relation_targets"), list)
+        and "relation_count" in c
+        and c.get("relation_count") != len(c.get("relation_targets") or [])
+    )
+
+    log_bucket = by_role.get("log") or _new_coverage_bucket()
+    log_isolation_pct = _pct(log_bucket.get("nodes_without_relations", 0), log_bucket.get("total_nodes", 0))
+    fully_isolated_families = sorted(
+        family for family, bucket in by_family.items()
+        if bucket["total_nodes"] > 0 and bucket["nodes_with_relations"] == 0
+    )
+
+    notes: list[str] = []
+    if total_chunks and chunks_with_relation_targets < total_chunks:
+        notes.append(
+            f"{total_chunks - chunks_with_relation_targets} chunks_ai records lack relation_targets."
+        )
+    if chunks_with_bad_relation_targets:
+        notes.append(
+            f"{chunks_with_bad_relation_targets} chunks_ai records have non-list relation_targets."
+        )
+    if chunks_with_relation_count_mismatch:
+        notes.append(
+            f"{chunks_with_relation_count_mismatch} chunks_ai records have relation_count mismatches."
+        )
+    if log_bucket.get("total_nodes", 0) and log_isolation_pct >= 95.0:
+        notes.append(
+            f"log nodes remain isolated: {log_bucket['nodes_without_relations']}/{log_bucket['total_nodes']} without relations."
+        )
+    if fully_isolated_families:
+        notes.append(
+            "Families with zero relational coverage observed: "
+            + ", ".join(fully_isolated_families[:12])
+            + ("..." if len(fully_isolated_families) > 12 else "")
+        )
+
+    status = "PASS"
+    if chunks_with_bad_relation_targets or chunks_with_relation_count_mismatch:
+        status = "FAIL"
+    elif (
+        (total_chunks and chunks_with_relation_targets < total_chunks)
+        or log_isolation_pct >= 95.0
+        or _pct(nodes_with_relations, total_nodes) < 25.0
+        or fully_isolated_families
+    ):
+        status = "WARN"
+
+    return {
+        "rule": "RULE-23",
+        "name": "relational_coverage",
+        "status": status,
+        "total_nodes": total_nodes,
+        "nodes_with_relations": nodes_with_relations,
+        "nodes_without_relations": total_nodes - nodes_with_relations,
+        "coverage_pct": _pct(nodes_with_relations, total_nodes),
+        "by_role_primary": dict(sorted(by_role.items())),
+        "by_family": dict(sorted(by_family.items())),
+        "chunks_ai": {
+            "total_chunks": total_chunks,
+            "chunks_with_relation_targets": chunks_with_relation_targets,
+            "chunks_without_relation_targets": total_chunks - chunks_with_relation_targets,
+            "chunks_with_non_empty_relation_targets": chunks_with_non_empty_relation_targets,
+            "chunks_with_relation_count": chunks_with_relation_count,
+            "chunks_with_relation_count_mismatch": chunks_with_relation_count_mismatch,
+            "chunks_with_bad_relation_targets": chunks_with_bad_relation_targets,
+        },
+        "observations": {
+            "log_nodes_total": log_bucket.get("total_nodes", 0),
+            "log_nodes_without_relations": log_bucket.get("nodes_without_relations", 0),
+            "log_isolation_pct": log_isolation_pct,
+            "fully_isolated_families": fully_isolated_families,
+        },
+        "notes": notes,
+    }
+
+
 def evaluate_corpus_level(
     canon_records: list[dict],
     enriched_records: list[dict],
@@ -576,75 +736,33 @@ def evaluate_corpus_level(
             "proposed_value": None,
         })
 
-    # RULE-23 (S84): relational coverage gate by family.
-    # Measures the fraction of non-code nodes with at least one effective
-    # relation in the top-level relations field. Emits per-family isolation
-    # metrics. Threshold: warn if log-family isolation >= 95%.
-    non_code = [r for r in canon_records if r.get("role_primary") not in ("code", None)]
-    nc_total = len(non_code)
-    if nc_total > 0:
-        by_role: dict[str, dict] = {}
-        for r in non_code:
-            role = r.get("role_primary", "unknown")
-            if role not in by_role:
-                by_role[role] = {"total": 0, "with_relations": 0, "isolated": 0}
-            by_role[role]["total"] += 1
-            if r.get("relations"):
-                by_role[role]["with_relations"] += 1
-            else:
-                by_role[role]["isolated"] += 1
-
-        nc_isolated = sum(v["isolated"] for v in by_role.values())
-        nc_isolated_frac = nc_isolated / nc_total
-
-        log_data = by_role.get("log", {"total": 0, "isolated": 0})
-        log_total = log_data["total"]
-        log_isolated_frac = log_data["isolated"] / log_total if log_total else 0.0
-
-        per_role_summary = {
-            role: {
-                "total": v["total"],
-                "with_relations": v["with_relations"],
-                "isolated": v["isolated"],
-                "isolated_pct": round(100 * v["isolated"] / v["total"], 1) if v["total"] else 0,
-            }
-            for role, v in sorted(by_role.items())
-        }
-
-        status_23 = "warn" if log_isolated_frac >= 0.95 else "pass"
-        findings.append({
-            "rule_id": "RULE-23",
-            "node_id": "CORPUS",
-            "title": "corpus",
-            "shard_file": "all",
-            "compliance_status": status_23,
-            "severity": "info",
-            "fix_type": "review_needed" if status_23 == "warn" else "none",
-            "field": "relations",
-            "detail": (
-                f"non-code relational coverage: {nc_total - nc_isolated}/{nc_total} connected "
-                f"({100*(1-nc_isolated_frac):.1f}%). "
-                f"log-family isolation: {log_data['isolated']}/{log_total} "
-                f"({100*log_isolated_frac:.1f}%). "
-                f"per_role={per_role_summary}"
-            ),
-            "evidence_sources": ["canon_shards"],
-            "proposed_value": None,
-        })
-    else:
-        findings.append({
-            "rule_id": "RULE-23",
-            "node_id": "CORPUS",
-            "title": "corpus",
-            "shard_file": "all",
-            "compliance_status": "pass",
-            "severity": "info",
-            "fix_type": "none",
-            "field": "relations",
-            "detail": "No non-code nodes found; coverage trivially met.",
-            "evidence_sources": [],
-            "proposed_value": None,
-        })
+    # RULE-23 (S98): relational coverage across canon and AI chunks.
+    rule23 = build_rule23_metrics(canon_records, chunks)
+    status_23 = rule23["status"].lower()
+    detail = (
+        f"relational coverage: {rule23['nodes_with_relations']}/{rule23['total_nodes']} "
+        f"nodes ({rule23['coverage_pct']:.2f}%). "
+        f"chunks with relation_targets: "
+        f"{rule23['chunks_ai']['chunks_with_relation_targets']}/"
+        f"{rule23['chunks_ai']['total_chunks']}; "
+        f"non-empty chunks: "
+        f"{rule23['chunks_ai']['chunks_with_non_empty_relation_targets']}. "
+        f"notes={rule23['notes']}"
+    )
+    findings.append({
+        "rule_id": "RULE-23",
+        "node_id": "CORPUS",
+        "title": "corpus",
+        "shard_file": "all",
+        "compliance_status": status_23,
+        "severity": "info",
+        "fix_type": "review_needed" if status_23 in ("warn", "fail") else "none",
+        "field": "relations/relation_targets",
+        "detail": detail,
+        "evidence_sources": ["canon_shards", "ai_chunks"],
+        "proposed_value": None,
+        "metrics": rule23,
+    })
 
     return findings
 
@@ -847,6 +965,7 @@ def emit_audit_reports(
     rules_catalog = load_normative_rules()
     rules_by_id = {r["id"]: r for r in rules_catalog}
     by_rule: dict[str, dict] = {}
+    rule_metrics: dict[str, dict] = {}
     for f in all_findings:
         rid = f["rule_id"]
         if rid not in by_rule:
@@ -862,6 +981,9 @@ def emit_audit_reports(
                 "fail_count": 0,
                 "affected_nodes": [],
             }
+        if f.get("metrics") is not None:
+            by_rule[rid]["metrics"] = f["metrics"]
+            rule_metrics[rid] = f["metrics"]
         status = f["compliance_status"]
         if status == "pass":
             by_rule[rid]["pass_count"] += 1
@@ -899,6 +1021,8 @@ def emit_audit_reports(
         "global_compliance": "pass" if global_pass else "fail",
         "total_nodes_audited": total_nodes,
         "compliance_by_rule": list(by_rule.values()),
+        "rule_metrics": rule_metrics,
+        "relational_coverage": rule_metrics.get("RULE-23"),
         "summary_by_severity": dict(by_severity),
         "summary_by_block": dict(by_layer),
         "rules_with_issues": failed_rules,
@@ -957,6 +1081,24 @@ def emit_audit_reports(
         lines_md.append(
             f"| {r['rule_id']} | {r['block']} | {r['description']} | {r['fail_count']} | {r['warn_count']} |"
         )
+    relational_coverage = rule_metrics.get("RULE-23")
+    if relational_coverage:
+        chunks_ai = relational_coverage.get("chunks_ai", {})
+        lines_md += [
+            f"",
+            f"## RULE-23 Relational Coverage",
+            f"",
+            f"| Metric | Value |",
+            f"|--------|-------|",
+            f"| Status | `{relational_coverage.get('status')}` |",
+            f"| Canon nodes with relations | {relational_coverage.get('nodes_with_relations')}/{relational_coverage.get('total_nodes')} ({relational_coverage.get('coverage_pct')}%) |",
+            f"| Chunks with relation_targets | {chunks_ai.get('chunks_with_relation_targets')}/{chunks_ai.get('total_chunks')} |",
+            f"| Chunks with non-empty relation_targets | {chunks_ai.get('chunks_with_non_empty_relation_targets')} |",
+            f"| Chunks with relation_count mismatch | {chunks_ai.get('chunks_with_relation_count_mismatch')} |",
+            f"",
+        ]
+        for note in relational_coverage.get("notes", []):
+            lines_md.append(f"- {note}")
     lines_md += [
         f"",
         f"## Notes for UI Readiness",

--- a/python_scripts/derive_layers.py
+++ b/python_scripts/derive_layers.py
@@ -1246,6 +1246,48 @@ def extract_chunk_heading(chunk_text: str, section_path: list, title: str) -> st
     return safe_str(title)[:160]
 
 
+def normalize_relation_targets(relation_targets: list | None) -> list[dict]:
+    """Return deterministic compact relation targets for AI projections."""
+    normalized: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for rel in relation_targets or []:
+        if isinstance(rel, dict):
+            target = rel.get("target_id") or rel.get("target") or rel.get("id")
+            rel_type = rel.get("type") or ""
+            evidence = rel.get("evidence") or ""
+        elif isinstance(rel, str):
+            target = rel
+            rel_type = ""
+            evidence = ""
+        else:
+            continue
+        if not target:
+            continue
+        key = (safe_str(rel_type), safe_str(target), safe_str(evidence))
+        if key in seen:
+            continue
+        seen.add(key)
+        compact = {"target_id": safe_str(target)}
+        if rel_type:
+            compact["type"] = safe_str(rel_type)
+        if evidence:
+            compact["evidence"] = safe_str(evidence)
+        normalized.append(compact)
+    return normalized
+
+
+def relation_targets_from_relations(relations: list | None) -> list[dict]:
+    """Derive compact relation_targets from canonical relations."""
+    return normalize_relation_targets(relations)
+
+
+def relation_targets_from_record(rec: dict) -> list[dict]:
+    """Prefer existing relation_targets; fall back to canonical relations."""
+    if isinstance(rec.get("relation_targets"), list):
+        return normalize_relation_targets(rec.get("relation_targets"))
+    return relation_targets_from_relations(rec.get("relations") or [])
+
+
 def chunk_node(
     rec: dict,
     node_id: str,
@@ -1258,6 +1300,7 @@ def chunk_node(
     payload_info: dict,
     target_tokens: int,
     max_tokens: int,
+    relation_targets: list | None = None,
 ) -> tuple:
     """
     Chunk a node using hierarchical strategy.
@@ -1274,7 +1317,14 @@ def chunk_node(
     }
 
     # Non-chunkable cases
-    if strategy in ("binary_skip", "no_chunk_type", "archival_only_skip", "historical_out_artifact_skip"):
+    if strategy in (
+        "binary_skip",
+        "no_chunk_type",
+        "archival_only",
+        "archival_only_skip",
+        "historical_snapshot",
+        "historical_out_artifact_skip",
+    ):
         return [], False, strategy
     if strategy == "json_no_chunk":
         return [], False, "json_payload_no_chunk"
@@ -1311,6 +1361,11 @@ def chunk_node(
             validated.append(ct)
 
     validated = densify_microchunks(validated, target_tokens)
+    compact_relation_targets = (
+        normalize_relation_targets(relation_targets)
+        if relation_targets is not None
+        else relation_targets_from_record(rec)
+    )
 
     # Build chunk records
     chunks = []
@@ -1337,6 +1392,8 @@ def chunk_node(
             "section_path": section,
             "taxonomy_path": taxonomy,
             "retrieval_hints": retrieval_hints[:8],
+            "relation_targets": list(compact_relation_targets),
+            "relation_count": len(compact_relation_targets),
             "corpus_state": payload_info["corpus_state"],
             "corpus_state_rule_id": payload_info["corpus_state_rule_id"],
             "chunk_eligibility": payload_info["chunk_eligibility"],
@@ -3387,8 +3444,6 @@ def render_copilot_agent_corpus_lines(
 
     for family in COPILOT_AGENT_FAMILY_ORDER:
         family_entities = by_family.get(family, [])
-        if not family_entities:
-            continue
         lines.extend(
             [
                 f"SECTION_ID: {family}",
@@ -3900,13 +3955,9 @@ def build_ai_record(rec: dict, shard_file: str, line_num: int,
     raw_rels = rec.get("relations") or []
     valid_rels, invalid_rels = validate_relations(raw_rels, known_ids)
 
-    # Compact relation targets (capa-1)
-    rel_targets = []
-    for r in valid_rels:
-        rt = {"type": r.get("type"), "target_id": r.get("target_id")}
-        if r.get("evidence"):
-            rt["evidence"] = r["evidence"]
-        rel_targets.append(rt)
+    # Compact relation targets (capa-1 plus any content_embedded relations
+    # already materialized in the canonical top-level relations field).
+    rel_targets = relation_targets_from_relations(valid_rels)
 
     # S84: extract capa-2 embedded relations from content.plain
     embedded_rels, _stale, _urn = extract_embedded_content_rels(rec, by_title_to_id)
@@ -3983,6 +4034,7 @@ def build_ai_record(rec: dict, shard_file: str, line_num: int,
             payload_info,
             target_tokens,
             max_tokens,
+            relation_targets=rel_targets,
         )
 
     return ai_rec, chunks, invalid_rels, payload_info

--- a/python_scripts/path_governance.py
+++ b/python_scripts/path_governance.py
@@ -90,6 +90,8 @@ def ensure_runtime_directories() -> None:
         DEFAULT_SESSIONS_DIR / "06_diagnoses" / "sesion",
         DEFAULT_SESSIONS_DIR / "06_diagnoses" / "tema",
         DEFAULT_SESSIONS_DIR / "06_diagnoses" / "module",
+        DEFAULT_SESSIONS_DIR / "06_diagnoses" / "micro-ciclo",
+        DEFAULT_SESSIONS_DIR / "06_diagnoses" / "meso-ciclo",
     ):
         directory.mkdir(parents=True, exist_ok=True)
 

--- a/python_scripts/session_cycle_diagnostics.py
+++ b/python_scripts/session_cycle_diagnostics.py
@@ -1,0 +1,1751 @@
+#!/usr/bin/env python3
+"""Local diagnostics for session micro-cycles and meso-cycles.
+
+The active source of raw session evidence is data/out/local/sessions/.
+Micro-cycle diagnostics read session artifacts. Meso-cycle diagnostics read
+micro-cycle diagnostics only; they do not re-read raw session artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from path_governance import DEFAULT_SESSIONS_DIR, REPO_ROOT, as_display_path  # noqa: E402
+
+
+MICRO_DIAG_DIR = DEFAULT_SESSIONS_DIR / "06_diagnoses" / "micro-ciclo"
+MESO_DIAG_DIR = DEFAULT_SESSIONS_DIR / "06_diagnoses" / "meso-ciclo"
+DEFAULT_CANON_DIR = REPO_ROOT / "data" / "out" / "local"
+PROHIBITED_SESSION_ROOTS = (
+    REPO_ROOT / "data" / "sessions",
+    REPO_ROOT / "data" / "out" / "sessions",
+    REPO_ROOT / "sessions",
+)
+PROHIBITED_CYCLE_ROUTE_NAMES = ("microciclo", "mesociclo")
+LEGACY_CYCLE_ROUTE_NAMES = ("micro_ciclo", "meso_ciclo")
+CANON_WRITE_GUARD_GLOBS = ("data/out/local/tiddlers_*.jsonl",)
+
+SESSION_FILE_RE = re.compile(r"^(m\d+)-s(\d+)([a-z]?)-(.+)\.md\.json$")
+SESSION_TAG_RE = re.compile(r"^session:(m\d+)-s(\d+)([a-z]?)$")
+MICRO_FILE_RE = re.compile(
+    r"^(m\d+)-micro-ciclo-s(?P<start>\d{3})-s(?P<end>\d{3})-diagnostico\.md\.json$"
+)
+
+REQUIRED_SESSION_FAMILIES: dict[str, tuple[str, ...]] = {
+    "contrato": ("00_contratos",),
+    "procedencia": ("01_procedencia",),
+    "detalles": ("02_detalles_de_sesion",),
+    "hipotesis": ("03_hipotesis",),
+    "balance": ("04_balance_de_sesion",),
+    "propuesta": ("05_propuesta_de_sesion",),
+    "diagnostico_sesion": ("06_diagnoses", "sesion"),
+}
+
+CANON_ARTIFACT_TAG_TO_FAMILY = {
+    "artifact:contrato_de_sesion": "contrato",
+    "artifact:procedencia_de_sesion": "procedencia",
+    "artifact:detalles_de_sesion": "detalles",
+    "artifact:hipotesis_de_sesion": "hipotesis",
+    "artifact:balance_de_sesion": "balance",
+    "artifact:propuesta_de_sesion": "propuesta",
+    "artifact:diagnostico_de_sesion": "diagnostico_sesion",
+}
+
+THEMATIC_DIAG_FAMILIES: tuple[tuple[str, ...], ...] = (
+    ("06_diagnoses", "tema"),
+    ("06_diagnoses", "tematico"),
+    ("06_diagnoses", "contexto"),
+    ("06_diagnoses", "arquitectura"),
+    ("06_diagnoses", "seguridad"),
+    ("06_diagnoses", "rutas"),
+)
+
+PREFERRED_EXISTING_TAGS = (
+    "layer:session",
+    "## 🧭🧱 Protocolo de Sesión",
+    "## 🌀🧱 Desarrollo y Evolución",
+    "## 🧠🧱 Política de Memoria Activa",
+    "## 🧪🧱 Hipótesis",
+    "## 🧾🧱 Procedencia epistemológica",
+    "## 🗂🧱 Principios de Gestion",
+)
+
+SESSION_KIND_POLICIES = {
+    "diagnostico-puro": (
+        "lee evidencia y produce diagnóstico; si requiere modificar código, "
+        "debe detenerse y reportar bloqueo"
+    ),
+    "infraestructura-diagnostica": (
+        "puede ajustar instrucciones, scripts o tests del flujo diagnóstico y "
+        "debe cerrar con los 7 entregables normales"
+    ),
+    "sesion-mixta": (
+        "combina ajuste técnico limitado con diagnóstico mayor y debe declarar "
+        "qué parte fue infraestructura y qué parte fue diagnóstico"
+    ),
+    "sesion-practica-desarrollo": "implementa o corrige superficies del sistema y produce cierre normal",
+    "sesion-teorica-analitica": "produce análisis, decisiones o diseño con trazabilidad de memoria",
+    "desarrollo-normal": "alias histórico de sesión práctica/desarrollo",
+    "hibrida-transicional": "excepción temporal mientras se estabiliza el flujo diagnóstico",
+}
+
+
+@dataclass(frozen=True)
+class SessionIdentity:
+    milestone: str
+    number: int
+    suffix: str = ""
+
+    @property
+    def session_id(self) -> str:
+        return f"{self.milestone}-s{self.number}{self.suffix}"
+
+    @property
+    def display(self) -> str:
+        return f"S{self.number}{self.suffix}"
+
+    @property
+    def sort_key(self) -> tuple[int, int, str]:
+        milestone_num = int(self.milestone[1:]) if self.milestone[1:].isdigit() else 0
+        return (milestone_num, self.number, self.suffix)
+
+
+@dataclass
+class ArtifactLoad:
+    family: str
+    path: Path
+    valid: bool
+    title: str = ""
+    text: str = ""
+    type: str = ""
+    tags: str = ""
+    error: str = ""
+
+
+@dataclass
+class SessionRecord:
+    identity: SessionIdentity
+    slug: str
+    artifacts: dict[str, ArtifactLoad] = field(default_factory=dict)
+
+    @property
+    def session_id(self) -> str:
+        return self.identity.session_id
+
+    @property
+    def display(self) -> str:
+        return self.identity.display
+
+    @property
+    def valid_family_count(self) -> int:
+        return sum(1 for artifact in self.artifacts.values() if artifact.valid)
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.missing_families() and not self.invalid_artifacts()
+
+    def missing_families(self) -> list[str]:
+        return [family for family in REQUIRED_SESSION_FAMILIES if family not in self.artifacts]
+
+    def invalid_artifacts(self) -> list[ArtifactLoad]:
+        return [artifact for artifact in self.artifacts.values() if not artifact.valid]
+
+
+@dataclass(frozen=True)
+class MicrocycleRef:
+    milestone: str
+    start: int
+    end: int
+    path: Path
+
+    @property
+    def display(self) -> str:
+        return f"S{self.start}-S{self.end}"
+
+
+@dataclass
+class MicrodiagnosticLoad:
+    ref: MicrocycleRef
+    valid_json: bool
+    valid_title: bool
+    valid_type: bool
+    title: str = ""
+    text: str = ""
+    type: str = ""
+    tags: str = ""
+    error: str = ""
+
+    @property
+    def is_valid(self) -> bool:
+        return self.valid_json and self.valid_title and self.valid_type
+
+
+@dataclass
+class TagPlan:
+    tags: list[str]
+    existing_tags_used: list[str]
+    new_tag_justifications: dict[str, str]
+
+
+@dataclass
+class MesocycleStatus:
+    can_produce: bool
+    available: list[MicrocycleRef]
+    missing_ranges: list[tuple[int, int]]
+    reason: str
+    selected: list[MicrocycleRef] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class CanonEvidence:
+    session_id: str
+    display: str
+    family: str
+    title: str
+    shard: Path
+    line_number: int
+
+
+def stamp_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S000")
+
+
+def parse_session_filename(name: str) -> tuple[SessionIdentity, str] | None:
+    match = SESSION_FILE_RE.match(name)
+    if not match:
+        return None
+    milestone, number, suffix, slug = match.groups()
+    if slug.startswith("session-"):
+        slug = slug[len("session-") :]
+    return SessionIdentity(milestone=milestone, number=int(number), suffix=suffix), slug
+
+
+def load_tiddler(path: Path, family: str) -> ArtifactLoad:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, list):
+            if not payload or not isinstance(payload[0], dict):
+                raise ValueError("JSON array does not contain a tiddler object")
+            tiddler = payload[0]
+        elif isinstance(payload, dict):
+            tiddler = payload
+        else:
+            raise ValueError("JSON payload is not an object or tiddler array")
+    except Exception as exc:  # noqa: BLE001 - diagnostic must preserve malformed artifacts.
+        return ArtifactLoad(family=family, path=path, valid=False, error=str(exc))
+
+    return ArtifactLoad(
+        family=family,
+        path=path,
+        valid=True,
+        title=str(tiddler.get("title", "")),
+        text=str(tiddler.get("text", "")),
+        type=str(tiddler.get("type", "")),
+        tags=str(tiddler.get("tags", "")),
+    )
+
+
+def discover_sessions(sessions_dir: Path = DEFAULT_SESSIONS_DIR) -> list[SessionRecord]:
+    records: dict[tuple[str, int, str], SessionRecord] = {}
+    for family, relative_root in REQUIRED_SESSION_FAMILIES.items():
+        root = sessions_dir.joinpath(*relative_root)
+        if not root.is_dir():
+            continue
+        for path in sorted(root.glob("*.md.json")):
+            parsed = parse_session_filename(path.name)
+            if parsed is None:
+                continue
+            identity, slug = parsed
+            key = (identity.milestone, identity.number, identity.suffix)
+            records.setdefault(key, SessionRecord(identity=identity, slug=slug))
+            records[key].artifacts[family] = load_tiddler(path, family)
+    return sorted(records.values(), key=lambda record: record.identity.sort_key)
+
+
+def discover_canon_session_records(
+    start: int,
+    end: int,
+    canon_dir: Path = DEFAULT_CANON_DIR,
+) -> tuple[list[SessionRecord], list[CanonEvidence]]:
+    records: dict[tuple[str, int, str], SessionRecord] = {}
+    evidence: list[CanonEvidence] = []
+    for shard in sorted(canon_dir.glob("tiddlers_*.jsonl")):
+        for line_number, line in enumerate(shard.read_text(encoding="utf-8").splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            tags = set()
+            for field_name in ("tags", "source_tags", "normalized_tags"):
+                tags.update(parse_tw_tags(payload.get(field_name)))
+            session_tag = next((tag for tag in tags if SESSION_TAG_RE.match(tag)), None)
+            if not session_tag:
+                continue
+            session_match = SESSION_TAG_RE.match(session_tag)
+            if session_match is None:
+                continue
+            milestone, raw_number, suffix = session_match.groups()
+            number = int(raw_number)
+            if number < start or number > end:
+                continue
+            family = next(
+                (CANON_ARTIFACT_TAG_TO_FAMILY[tag] for tag in tags if tag in CANON_ARTIFACT_TAG_TO_FAMILY),
+                None,
+            )
+            if family is None:
+                continue
+            identity = SessionIdentity(milestone=milestone, number=number, suffix=suffix)
+            title = str(payload.get("title", ""))
+            slug = _slug_from_title_or_session(title, session_tag)
+            key = (identity.milestone, identity.number, identity.suffix)
+            records.setdefault(key, SessionRecord(identity=identity, slug=slug))
+            if family not in records[key].artifacts:
+                records[key].artifacts[family] = ArtifactLoad(
+                    family=family,
+                    path=shard,
+                    valid=True,
+                    title=title,
+                    text=str(payload.get("text", "")),
+                    type=str(payload.get("mime_type") or payload.get("source_type") or "text/markdown"),
+                    tags=" ".join(sorted(tags)),
+                )
+            evidence.append(
+                CanonEvidence(
+                    session_id=identity.session_id,
+                    display=identity.display,
+                    family=family,
+                    title=title,
+                    shard=shard,
+                    line_number=line_number,
+                )
+            )
+    return sorted(records.values(), key=lambda record: record.identity.sort_key), evidence
+
+
+def _slug_from_title_or_session(title: str, session_tag: str) -> str:
+    if "=" in title:
+        return title.rsplit("=", 1)[-1].strip()
+    return session_tag.removeprefix("session:")
+
+
+def select_latest_sessions(records: Iterable[SessionRecord], count: int = 10) -> list[SessionRecord]:
+    ordered = sorted(records, key=lambda record: record.identity.sort_key)
+    return ordered[-count:]
+
+
+def select_session_range(
+    records: Iterable[SessionRecord],
+    milestone: str,
+    start: int,
+    end: int,
+) -> list[SessionRecord]:
+    if start > end:
+        raise ValueError("start session must be less than or equal to end session")
+    indexed: dict[tuple[str, int], SessionRecord] = {
+        (record.identity.milestone, record.identity.number): record
+        for record in records
+        if record.identity.suffix == ""
+    }
+    selected: list[SessionRecord] = []
+    for number in range(start, end + 1):
+        record = indexed.get((milestone, number))
+        if record is None:
+            record = SessionRecord(
+                identity=SessionIdentity(milestone=milestone, number=number),
+                slug="sin-artefactos-locales",
+            )
+        selected.append(record)
+    return selected
+
+
+def records_for_analysis(local_records: list[SessionRecord], canon_records: list[SessionRecord]) -> list[SessionRecord]:
+    canon_by_number = {record.identity.number: record for record in canon_records}
+    merged: list[SessionRecord] = []
+    for record in local_records:
+        if record.artifacts:
+            merged.append(record)
+        else:
+            merged.append(canon_by_number.get(record.identity.number, record))
+    return merged
+
+
+def format_range_slug(start: int, end: int) -> str:
+    return f"s{start:03d}-s{end:03d}"
+
+
+def microcycle_filename(milestone: str, start: int, end: int) -> str:
+    return f"{milestone}-micro-ciclo-{format_range_slug(start, end)}-diagnostico.md.json"
+
+
+def mesocycle_filename(milestone: str, start: int, end: int) -> str:
+    return f"{milestone}-meso-ciclo-{format_range_slug(start, end)}-diagnostico.md.json"
+
+
+def microcycle_title(start: int, end: int) -> str:
+    return f"#### 🌀 Diagnóstico de microciclo = sesiones S{start}-S{end}"
+
+
+def mesocycle_title(start: int, end: int) -> str:
+    return f"#### 🌀 Diagnóstico de mesociclo = microciclos S{start}-S{end}"
+
+
+def parse_tw_tags(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    if not isinstance(value, str):
+        return []
+    tags: list[str] = []
+    index = 0
+    while index < len(value):
+        if value.startswith("[[", index):
+            end = value.find("]]", index + 2)
+            if end == -1:
+                break
+            tags.append(value[index + 2 : end])
+            index = end + 2
+            continue
+        if value[index].isspace():
+            index += 1
+            continue
+        end = index
+        while end < len(value) and not value[end].isspace():
+            end += 1
+        tags.append(value[index:end])
+        index = end
+    return [tag for tag in tags if tag]
+
+
+def load_existing_tags(
+    canon_dir: Path = REPO_ROOT / "data" / "out" / "local",
+    fixture_path: Path = REPO_ROOT / "tests" / "fixtures" / "canon_policy_bundle.json",
+) -> set[str]:
+    tags: set[str] = set()
+    for shard in sorted(canon_dir.glob("tiddlers_*.jsonl")):
+        for line in shard.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            for field_name in ("tags", "source_tags", "normalized_tags"):
+                for tag in parse_tw_tags(payload.get(field_name)):
+                    tags.add(tag)
+
+    if fixture_path.is_file():
+        try:
+            fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            fixture = {}
+        for section in ("tag_role_mappings", "source_role_mappings"):
+            mapping = fixture.get("role_primary_contract", {}).get(section, {})
+            if isinstance(mapping, dict):
+                tags.update(str(key) for key in mapping)
+    return tags
+
+
+def _session_tag_from_origin(session_origin: str | None) -> str | None:
+    if not session_origin:
+        return None
+    parsed = parse_session_filename(f"{session_origin}.md.json")
+    if parsed is not None:
+        identity, _slug = parsed
+        return f"session:{identity.session_id}"
+    simple = re.match(r"^(m\d+)-s(\d+)", session_origin)
+    if simple:
+        return f"session:{simple.group(1)}-s{int(simple.group(2))}"
+    return f"session:{session_origin}"
+
+
+def build_cycle_tags(
+    milestone: str,
+    cycle_type: str,
+    start: int,
+    end: int,
+    existing_tags: set[str] | None = None,
+    session_origin: str | None = None,
+    source_microcycles: bool = False,
+    diagnostic_provenance: bool = False,
+    remote_read_root: bool = False,
+) -> TagPlan:
+    tags: list[str] = []
+    new_justifications: dict[str, str] = {}
+
+    def add(tag: str, justification: str | None = None) -> None:
+        if tag in tags:
+            return
+        tags.append(tag)
+        if existing_tags is not None and tag not in existing_tags and justification:
+            new_justifications[tag] = justification
+
+    origin_tag = _session_tag_from_origin(session_origin)
+    if origin_tag:
+        add(origin_tag, "instancia nueva del patrón canónico session:mXX-sNN para trazar la sesión que produjo el diagnóstico")
+    add(f"milestone:{milestone}", "instancia de milestone requerida por el rango analizado")
+
+    for tag in PREFERRED_EXISTING_TAGS:
+        if existing_tags is None or tag in existing_tags:
+            add(tag)
+
+    add(
+        f"diagnostic:{cycle_type}",
+        f"no existe un tag canónico específico para diagnóstico de {cycle_type}; evita reutilizar tags de sesión simple",
+    )
+    add(
+        f"range:{format_range_slug(start, end)}",
+        "el rango operativo del ciclo necesita búsqueda directa sin crear una familia extensa de tags",
+    )
+    if source_microcycles:
+        add(
+            "source:micro-ciclos",
+            "el mesociclo consume microciclos como fuente primaria, no sesiones crudas",
+        )
+    if diagnostic_provenance:
+        add(
+            "governance:diagnostic-provenance",
+            "S97 formaliza la jerarquía de fuentes diagnósticas entre microdiagnósticos, sessions, canon, repositorio y remoto",
+        )
+    if remote_read_root:
+        add(
+            "agent:remote-read-root",
+            "el contrato remoto debe recordar que el agente lee `data/out/local/` y escribe candidatos bajo sessions, no canon directo",
+        )
+
+    existing_used = [tag for tag in tags if existing_tags is None or tag in existing_tags]
+    return TagPlan(tags=tags, existing_tags_used=existing_used, new_tag_justifications=new_justifications)
+
+
+def format_tw_tag(tag: str) -> str:
+    raw = tag.strip()
+    if raw.startswith("[[") and raw.endswith("]]"):
+        return raw
+    return f"[[{raw}]]"
+
+
+def format_tw_tags(tags: Iterable[str]) -> str:
+    return " ".join(format_tw_tag(tag) for tag in tags if tag.strip())
+
+
+def discover_thematic_diagnostics(sessions_dir: Path = DEFAULT_SESSIONS_DIR) -> list[Path]:
+    paths: list[Path] = []
+    for relative_root in THEMATIC_DIAG_FAMILIES:
+        root = sessions_dir.joinpath(*relative_root)
+        if root.is_dir():
+            paths.extend(sorted(root.glob("*.md.json")))
+    return sorted(paths)
+
+
+def _lines_from_section(text: str, headings: tuple[str, ...], limit: int = 4) -> list[str]:
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith("##"):
+            continue
+        if not any(heading.lower() in stripped.lower() for heading in headings):
+            continue
+        body: list[str] = []
+        for body_line in lines[index + 1 :]:
+            if body_line.startswith("## "):
+                break
+            clean = body_line.strip()
+            if not clean or clean.startswith("|---"):
+                continue
+            if clean.startswith("###") or clean.startswith("```"):
+                continue
+            if clean.startswith("|"):
+                cells = [cell.strip() for cell in clean.strip("|").split("|")]
+                clean = " — ".join(cell for cell in cells if cell)
+            if clean.startswith(("- ", "* ")):
+                clean = clean[2:].strip()
+            body.append(clean)
+            if len(body) >= limit:
+                return body
+        if body:
+            return body[:limit]
+    return []
+
+
+def _snippet(text: str, limit: int = 180) -> str:
+    compact = " ".join(line.strip() for line in text.splitlines() if line.strip())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3].rstrip() + "..."
+
+
+def _collect_section_bullets(
+    records: Iterable[SessionRecord],
+    family: str,
+    headings: tuple[str, ...],
+    limit_per_session: int = 2,
+    total_limit: int = 12,
+) -> list[str]:
+    bullets: list[str] = []
+    for record in records:
+        artifact = record.artifacts.get(family)
+        if not artifact or not artifact.valid:
+            continue
+        items = _lines_from_section(artifact.text, headings, limit=limit_per_session)
+        if not items:
+            items = _lines_from_keyed_list(artifact.text, headings, limit=limit_per_session)
+        for item in items:
+            bullets.append(f"{record.display}: {item}")
+            if len(bullets) >= total_limit:
+                return bullets
+    return bullets
+
+
+def _lines_from_keyed_list(text: str, keys: tuple[str, ...], limit: int = 4) -> list[str]:
+    normalized_keys = {_normalize_label(key) for key in keys}
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        clean = line.strip()
+        label = clean[2:].strip() if clean.startswith("- ") else clean
+        if not label.endswith(":"):
+            continue
+        if _normalize_label(label[:-1]) not in normalized_keys:
+            continue
+        body: list[str] = []
+        for body_line in lines[index + 1 :]:
+            stripped = body_line.strip()
+            if not stripped:
+                continue
+            if stripped.startswith("## "):
+                break
+            if stripped.startswith("- ") and stripped.endswith(":"):
+                break
+            if stripped.startswith("- "):
+                body.append(stripped[2:].strip())
+            elif body_line.startswith(("  ", "\t")):
+                body.append(stripped)
+            if len(body) >= limit:
+                return body
+        return body[:limit]
+    return []
+
+
+def _normalize_label(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def _keyword_hits(records: Iterable[SessionRecord], keywords: tuple[str, ...], total_limit: int = 10) -> list[str]:
+    hits: list[str] = []
+    for record in records:
+        for artifact in record.artifacts.values():
+            if not artifact.valid:
+                continue
+            for line in artifact.text.splitlines():
+                clean = line.strip()
+                if not clean or clean.startswith("```"):
+                    continue
+                if any(_line_has_keyword(clean, keyword) for keyword in keywords):
+                    hits.append(f"{record.display}: {_snippet(clean)}")
+                    break
+            if hits and hits[-1].startswith(f"{record.display}:"):
+                break
+        if len(hits) >= total_limit:
+            break
+    return hits
+
+
+def _line_has_keyword(line: str, keyword: str) -> bool:
+    if len(keyword) <= 3 and keyword.isalnum():
+        return re.search(rf"(?<![A-Za-z0-9_]){re.escape(keyword)}(?![A-Za-z0-9_])", line, re.IGNORECASE) is not None
+    return keyword.lower() in line.lower()
+
+
+def _session_list(records: Iterable[SessionRecord]) -> list[str]:
+    lines: list[str] = []
+    for record in records:
+        status = "completa" if record.is_complete else "incompleta"
+        lines.append(
+            f"- {record.display} ({record.session_id}): {record.slug} "
+            f"({record.valid_family_count}/{len(REQUIRED_SESSION_FAMILIES)} artefactos válidos, {status})"
+        )
+    return lines
+
+
+def _missing_or_incomplete_lines(records: Iterable[SessionRecord]) -> list[str]:
+    lines: list[str] = []
+    for record in records:
+        if not record.artifacts:
+            lines.append(f"- {record.display}: sin artefactos locales bajo `data/out/local/sessions/`")
+            continue
+        missing = record.missing_families()
+        invalid = record.invalid_artifacts()
+        if not missing and not invalid:
+            continue
+        details: list[str] = []
+        if missing:
+            details.append("faltan " + ", ".join(missing))
+        if invalid:
+            details.extend(
+                f"{artifact.family} inválido ({artifact.path.name}: {artifact.error})"
+                for artifact in invalid
+            )
+        lines.append(f"- {record.display}: " + "; ".join(details))
+    return lines or ["- ninguna"]
+
+
+def _artifact_inventory_lines(records: Iterable[SessionRecord]) -> list[str]:
+    lines: list[str] = []
+    for record in records:
+        if not record.artifacts:
+            lines.append(f"- {record.display}: ninguno")
+            continue
+        parts: list[str] = []
+        for family in REQUIRED_SESSION_FAMILIES:
+            artifact = record.artifacts.get(family)
+            if artifact is None:
+                parts.append(f"{family}=faltante")
+                continue
+            status = "válido" if artifact.valid else "inválido"
+            parts.append(f"{family}={as_display_path(artifact.path)} ({status})")
+        lines.append(f"- {record.display}: " + "; ".join(parts))
+    return lines
+
+
+def _canon_evidence_lines(canon_evidence: list[CanonEvidence]) -> list[str]:
+    if not canon_evidence:
+        return ["- ninguna"]
+    grouped: dict[str, list[CanonEvidence]] = {}
+    for item in canon_evidence:
+        grouped.setdefault(item.display, []).append(item)
+    lines: list[str] = []
+    for display in sorted(grouped, key=lambda item: int(item[1:])):
+        items = grouped[display]
+        families = sorted({item.family for item in items})
+        locations = sorted({f"{as_display_path(item.shard)}:{item.line_number}" for item in items})
+        lines.append(
+            f"- {display}: {len(items)} artefactos canónicos ({', '.join(families)}); "
+            f"evidencia en {', '.join(locations[:4])}"
+            + (" ..." if len(locations) > 4 else "")
+        )
+    return lines
+
+
+def _repo_evidence_lines(paths: list[str]) -> list[str]:
+    return [f"- {path}" for path in paths] if paths else ["- ninguna"]
+
+
+def _legacy_route_lines(records: Iterable[SessionRecord], sessions_dir: Path) -> list[str]:
+    lines: list[str] = []
+    diagnoses_root = sessions_dir / "06_diagnoses"
+    for legacy_name in (*PROHIBITED_CYCLE_ROUTE_NAMES, *LEGACY_CYCLE_ROUTE_NAMES):
+        legacy_dir = diagnoses_root / legacy_name
+        if legacy_dir.exists():
+            lines.append(f"- Ruta legacy/deriva detectada: `{as_display_path(legacy_dir)}`. No se movió ni borró.")
+    for record in records:
+        for artifact in record.artifacts.values():
+            if not artifact.valid:
+                continue
+            if "data/out/sessions" in artifact.text or "data/sessions" in artifact.text:
+                lines.append(
+                    f"- {record.display}: referencia histórica a rutas no activas en `{as_display_path(artifact.path)}`."
+                )
+                break
+    return lines or ["- No se detectaron carpetas activas `microciclo/` ni `mesociclo/` sin guion."]
+
+
+def _fallback_or_none(items: list[str], fallback: str) -> list[str]:
+    return items if items else [f"- {fallback}"]
+
+
+def _bulletize(items: list[str]) -> str:
+    if not items:
+        return "- ninguno"
+    return "\n".join(item if item.startswith("- ") else f"- {item}" for item in items)
+
+
+def _build_prognosis(records: list[SessionRecord], mesocycle_status: MesocycleStatus | None) -> str:
+    incomplete = [line for line in _missing_or_incomplete_lines(records) if line != "- ninguna"]
+    if mesocycle_status and mesocycle_status.can_produce:
+        next_topic = "Abrir diagnóstico de mesociclo S65-S94"
+        next_type = "necesidad real"
+        next_justification = "Ya existen tres microciclos continuos y el mesociclo debe consumir esos diagnósticos, no 30 sesiones crudas."
+        next_evidence = "Microciclos disponibles y continuos: " + ", ".join(ref.display for ref in mesocycle_status.available[-3:])
+        next_risk = "El sistema seguirá usando contexto de microciclo de forma manual y perderá la oportunidad de sintetizar decisiones persistentes entre ciclos."
+    elif incomplete:
+        next_topic = "Reparar artefactos `.md.json` inválidos o incompletos del ciclo"
+        next_type = "necesidad real"
+        next_justification = "Un diagnóstico cíclico pierde autoridad si el staging de sesiones no puede parsearse de forma completa."
+        next_evidence = "; ".join(line[2:] for line in incomplete[:2])
+        next_risk = "La admisión futura al canon o el reverse podrían rechazar candidatos por errores de serialización ya visibles."
+    else:
+        next_topic = "Generar los microciclos faltantes previos al mesociclo"
+        next_type = "mejora conveniente"
+        next_justification = "El microciclo actual ya existe, pero el mesociclo requiere tres microciclos continuos."
+        next_evidence = "No hay sesiones incompletas en el rango seleccionado."
+        next_risk = "El sistema seguirá dependiendo de lectura cruda para contexto histórico de mayor escala."
+
+    missing = mesocycle_status.missing_ranges if mesocycle_status else []
+    if missing:
+        missing_text = ", ".join(f"S{start}-S{end}" for start, end in missing)
+    else:
+        missing_text = "sin faltantes detectados"
+
+    return "\n".join(
+        [
+            "## Pronóstico operativo",
+            "",
+            "### Próxima sesión recomendada",
+            f"- Tema: {next_topic}",
+            f"- Tipo: {next_type}",
+            f"- Justificación: {next_justification}",
+            f"- Evidencia desde el microciclo: {next_evidence}",
+            f"- Riesgo si se ignora: {next_risk}",
+            "",
+            "### Segunda sesión probable",
+            "- Tema: Recuperar o documentar explícitamente la ausencia de staging local para S65-S74",
+            "- Tipo: mejora conveniente",
+            "- Justificación: El microciclo puede apoyarse en canon admitido, pero la ausencia de `.md.json` locales limita auditorías reversibles desde staging.",
+            f"- Evidencia desde el microciclo: Microciclos faltantes o no continuos: {missing_text}; sesiones locales incompletas: {len(incomplete)}.",
+            "- Riesgo si se ignora: Futuras auditorías podrían confundir ausencia de staging local con ausencia histórica de sesión.",
+            "",
+            "### Tercera sesión posible",
+            "- Tema: Retomar frentes de integración solo después de cerrar la trazabilidad local del rango",
+            "- Tipo: tentación prematura",
+            "- Justificación: Un microciclo con sesiones ausentes o incompletas debe estabilizar su evidencia local antes de abrir frentes laterales.",
+            "- Evidencia desde el microciclo: El inventario local del rango determina qué sesiones tienen artefactos y cuáles no.",
+            "- Riesgo si se ignora: Se confunde avance operativo con acumulación de deuda documental no diagnosticada.",
+        ]
+    )
+
+
+def build_microcycle_markdown(
+    records: list[SessionRecord],
+    thematic_diagnostics: list[Path],
+    tag_plan: TagPlan,
+    sessions_dir: Path = DEFAULT_SESSIONS_DIR,
+    mesocycle_status: MesocycleStatus | None = None,
+    include_mesocycle_status: bool = True,
+    canon_records: list[SessionRecord] | None = None,
+    canon_evidence: list[CanonEvidence] | None = None,
+    repository_evidence: list[str] | None = None,
+    session_kind: str = "infraestructura-diagnostica",
+) -> str:
+    if not records:
+        raise ValueError("microcycle requires at least one session")
+    canon_records = canon_records or []
+    canon_evidence = canon_evidence or []
+    repository_evidence = repository_evidence or []
+    analysis_records = records_for_analysis(records, canon_records)
+    start = records[0].identity.number
+    end = records[-1].identity.number
+    session_range = f"S{start}-S{end}"
+    partial_warning = ""
+    if len(records) < 10:
+        partial_warning = "\n\nAdvertencia: diagnóstico parcial; hay menos de 10 sesiones disponibles."
+
+    thematic_lines = (
+        [f"- {as_display_path(path)}" for path in thematic_diagnostics]
+        if thematic_diagnostics
+        else ["- ninguno"]
+    )
+    decisions = _collect_section_bullets(analysis_records, "balance", ("Decisiones a conservar", "decisiones_a_conservar", "Objetivos cumplidos", "Producido"))
+    confirmed = _collect_section_bullets(analysis_records, "hipotesis", ("Hipótesis confirmadas", "CONFIRMADA", "confirmadas"))
+    open_hypotheses = _collect_section_bullets(analysis_records, "hipotesis", ("Hipótesis abiertas", "pendiente", "abiertas"))
+    closed_debt = _collect_section_bullets(analysis_records, "balance", ("Deuda técnica cerrada", "Criterios de cierre", "Confirmado", "aciertos"))
+    persistent_debt = _collect_section_bullets(analysis_records, "balance", ("Deuda técnica persistente", "riesgos_detectados", "errores", "Riesgos detectados"))
+    new_debt = _collect_section_bullets(analysis_records, "balance", ("Deuda técnica nueva", "Deuda técnica introducida", "Deuda técnica identificada", "Riesgos detectados"))
+    route_hits = _keyword_hits(analysis_records, ("data/out/local/sessions", "data/sessions", "data/out/sessions", "AGENT_SESSION_ROOT"))
+    canon_hits = _keyword_hits(analysis_records, ("canon", "reverse", "strict", "reverse-preflight", "admisión"))
+    ci_hits = _keyword_hits(analysis_records, ("CI", "GitHub Actions", "CodeQL", "workflow"))
+    security_hits = _keyword_hits(analysis_records, ("secret", "secrets", "CodeQL", ".env", "token", "credentials"))
+    agent_hits = _keyword_hits(analysis_records, ("MCP", "remote", "OneDrive", "agente", "mirror"))
+    legacy_lines = _legacy_route_lines(analysis_records, sessions_dir)
+
+    mesocycle_lines: list[str] = []
+    if mesocycle_status and not mesocycle_status.can_produce:
+        mesocycle_lines = [
+            "- Mesociclo no producido todavía.",
+            f"- Razón: {mesocycle_status.reason}",
+            "- Microciclos requeridos:",
+        ]
+        if mesocycle_status.missing_ranges:
+            mesocycle_lines.extend(f"  - S{start_missing}-S{end_missing}" for start_missing, end_missing in mesocycle_status.missing_ranges)
+        else:
+            mesocycle_lines.append("  - tres diagnósticos continuos de microciclo")
+        mesocycle_lines.append("- Microciclos disponibles:")
+        if mesocycle_status.available:
+            mesocycle_lines.extend(f"  - {item.display}: {as_display_path(item.path)}" for item in mesocycle_status.available)
+        else:
+            mesocycle_lines.append("  - ninguno")
+
+    tag_lines = [f"- {tag}" for tag in tag_plan.tags]
+    new_tag_lines = (
+        [f"- {tag}: {reason}" for tag, reason in tag_plan.new_tag_justifications.items()]
+        if tag_plan.new_tag_justifications
+        else ["- ninguno"]
+    )
+
+    sections = [
+        f"# Diagnóstico de microciclo {session_range}",
+        "",
+        "## Tipo de sesión diagnóstica",
+        f"{session_kind}: {SESSION_KIND_POLICIES.get(session_kind, 'clasificación no registrada')}.",
+        "",
+        "## Rango de sesiones analizadas",
+        f"{session_range}.{partial_warning}",
+        "",
+        "## Lista de sesiones incluidas",
+        "\n".join(_session_list(analysis_records)),
+        "",
+        "## Sesiones ausentes o incompletas",
+        "\n".join(_missing_or_incomplete_lines(records)),
+        "",
+        "## Artefactos leídos por sesión",
+        "\n".join(_artifact_inventory_lines(analysis_records)),
+        "",
+        "## Diagnósticos temáticos consultados",
+        "\n".join(thematic_lines),
+        "",
+        "## Evidencia consultada desde canon",
+        "\n".join(_canon_evidence_lines(canon_evidence)),
+        "",
+        "## Evidencia consultada desde repositorio",
+        "\n".join(_repo_evidence_lines(repository_evidence)),
+        "",
+        "## Decisiones estabilizadas",
+        _bulletize(_fallback_or_none(decisions, "sin decisiones estabilizadas extraídas automáticamente")),
+        "",
+        "## Hipótesis confirmadas",
+        _bulletize(_fallback_or_none(confirmed, "sin hipótesis confirmadas extraídas automáticamente")),
+        "",
+        "## Hipótesis abiertas",
+        _bulletize(_fallback_or_none(open_hypotheses, "sin hipótesis abiertas extraídas automáticamente")),
+        "",
+        "## Deuda técnica cerrada",
+        _bulletize(_fallback_or_none(closed_debt, "sin deuda cerrada extraída automáticamente")),
+        "",
+        "## Deuda técnica persistente",
+        _bulletize(_fallback_or_none(persistent_debt, "sin deuda persistente extraída automáticamente")),
+        "",
+        "## Deuda técnica nueva",
+        _bulletize(_fallback_or_none(new_debt, "sin deuda nueva extraída automáticamente")),
+        "",
+        "## Cambios en gobernanza de rutas",
+        _bulletize(route_hits + legacy_lines),
+        "",
+        "## Cambios en canon/reverse",
+        _bulletize(_fallback_or_none(canon_hits, "sin señales canon/reverse extraídas automáticamente")),
+        "",
+        "## Cambios en CI/CD",
+        _bulletize(_fallback_or_none(ci_hits, "sin señales CI/CD extraídas automáticamente")),
+        "",
+        "## Cambios en seguridad",
+        _bulletize(_fallback_or_none(security_hits, "sin señales de seguridad extraídas automáticamente")),
+        "",
+        "## Impacto sobre agentes locales/remotos",
+        _bulletize(_fallback_or_none(agent_hits, "sin señales sobre agentes locales/remotos extraídas automáticamente")),
+        "",
+        "## Patrones repetidos",
+        "\n".join(
+            [
+                "- Local-first: el ciclo vuelve una y otra vez a `data/out/local/` como raíz operativa.",
+                "- Staging antes de canon: las sesiones estabilizan evidencia local y posponen admisión canónica directa.",
+                "- Endurecimiento incremental: las sesiones alternan entre UX operativa, seguridad, rutas y CI.",
+                "- Tests como cierre real: cada estabilización intenta quedar respaldada por pruebas locales o de CI.",
+            ]
+        ),
+        "",
+        "## Riesgos actuales",
+        "\n".join(
+            [
+                *_missing_or_incomplete_lines(records),
+                "- El mesociclo no debe producirse hasta contar con tres microciclos continuos.",
+                "- El trabajo remoto/MCP puede mezclar secretos, red y CI si se retoma antes de cerrar deudas locales.",
+            ]
+        ),
+        "",
+        "## Señales de madurez",
+        "\n".join(
+            [
+                "- La raíz `data/out/local/sessions/` aparece como decisión operativa estabilizada.",
+                "- El canon local queda protegido contra escritura directa por defecto.",
+                "- Los fallos de CI se diagnostican con cadena causal y tests de regresión.",
+                "- Las decisiones de seguridad sobre secrets se convierten en guardias y tests.",
+            ]
+        ),
+        "",
+        "## Señales de deriva",
+        "\n".join(legacy_lines),
+        "",
+        _build_prognosis(records, mesocycle_status),
+        "",
+        "## Tags usados y justificación de tags nuevos",
+        "Tags usados:",
+        "\n".join(tag_lines),
+        "",
+        "Tags nuevos o instancias nuevas justificadas:",
+        "\n".join(new_tag_lines),
+    ]
+    if include_mesocycle_status and mesocycle_lines:
+        sections.extend(["", "## Estado de mesociclo", "\n".join(mesocycle_lines)])
+    return "\n".join(sections).rstrip() + "\n"
+
+
+def build_microcycle_tiddler(
+    records: list[SessionRecord],
+    tag_plan: TagPlan,
+    thematic_diagnostics: list[Path],
+    sessions_dir: Path = DEFAULT_SESSIONS_DIR,
+    session_origin: str | None = None,
+    mesocycle_status: MesocycleStatus | None = None,
+    timestamp: str | None = None,
+    include_mesocycle_status: bool = True,
+    canon_records: list[SessionRecord] | None = None,
+    canon_evidence: list[CanonEvidence] | None = None,
+    repository_evidence: list[str] | None = None,
+    session_kind: str = "infraestructura-diagnostica",
+) -> dict[str, Any]:
+    if not records:
+        raise ValueError("cannot build microcycle tiddler without sessions")
+    start = records[0].identity.number
+    end = records[-1].identity.number
+    created = timestamp or stamp_now()
+    title = microcycle_title(start, end)
+    text = build_microcycle_markdown(
+        records,
+        thematic_diagnostics,
+        tag_plan,
+        sessions_dir,
+        mesocycle_status,
+        include_mesocycle_status=include_mesocycle_status,
+        canon_records=canon_records,
+        canon_evidence=canon_evidence,
+        repository_evidence=repository_evidence,
+        session_kind=session_kind,
+    )
+    source_path = MICRO_DIAG_DIR / microcycle_filename(records[-1].identity.milestone, start, end)
+    tiddler: dict[str, Any] = {
+        "created": created,
+        "modified": created,
+        "title": title,
+        "text": text,
+        "tags": format_tw_tags(tag_plan.tags),
+        "type": "text/vnd.tiddlywiki",
+        "source_path": as_display_path(source_path),
+    }
+    if session_origin:
+        tiddler["session_origin"] = session_origin
+    return tiddler
+
+
+def write_tiddler(path: Path, tiddler: dict[str, Any]) -> None:
+    try:
+        rel_path = path.resolve().relative_to(REPO_ROOT)
+    except ValueError:
+        rel_path = path.resolve()
+    if any(rel_path.match(glob) for glob in CANON_WRITE_GUARD_GLOBS):
+        raise ValueError("refusing to write protected canon shard")
+    for root in PROHIBITED_SESSION_ROOTS:
+        try:
+            path.resolve().relative_to(root.resolve())
+        except ValueError:
+            continue
+        raise ValueError(f"refusing to write under prohibited session root: {root}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps([tiddler], ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def parse_microcycle_filename(path: Path) -> MicrocycleRef | None:
+    match = MICRO_FILE_RE.match(path.name)
+    if not match:
+        return None
+    return MicrocycleRef(
+        milestone=path.name.split("-", 1)[0],
+        start=int(match.group("start")),
+        end=int(match.group("end")),
+        path=path,
+    )
+
+
+def discover_microcycles(micro_dir: Path = MICRO_DIAG_DIR) -> list[MicrocycleRef]:
+    if not micro_dir.is_dir():
+        return []
+    refs = [ref for path in sorted(micro_dir.glob("*.md.json")) if (ref := parse_microcycle_filename(path))]
+    return sorted(refs, key=lambda item: (int(item.milestone[1:]), item.start, item.end))
+
+
+def load_microdiagnostic(ref: MicrocycleRef) -> MicrodiagnosticLoad:
+    artifact = load_tiddler(ref.path, "microdiagnostico")
+    if not artifact.valid:
+        return MicrodiagnosticLoad(
+            ref=ref,
+            valid_json=False,
+            valid_title=False,
+            valid_type=False,
+            error=artifact.error,
+        )
+    expected_title = microcycle_title(ref.start, ref.end)
+    return MicrodiagnosticLoad(
+        ref=ref,
+        valid_json=True,
+        valid_title=artifact.title == expected_title,
+        valid_type=artifact.type == "text/vnd.tiddlywiki",
+        title=artifact.title,
+        text=artifact.text,
+        type=artifact.type,
+        tags=artifact.tags,
+        error="" if artifact.title == expected_title else f"title mismatch: expected {expected_title!r}",
+    )
+
+
+def load_microdiagnostics(refs: Iterable[MicrocycleRef]) -> list[MicrodiagnosticLoad]:
+    return [load_microdiagnostic(ref) for ref in refs]
+
+
+def plan_mesocycle(micro_dir: Path = MICRO_DIAG_DIR) -> MesocycleStatus:
+    available = discover_microcycles(micro_dir)
+    if len(available) < 3:
+        missing = _missing_previous_microcycle_ranges(available)
+        return MesocycleStatus(
+            can_produce=False,
+            available=available,
+            missing_ranges=missing,
+            reason="faltan microciclos suficientes",
+        )
+
+    selected = available[-3:]
+    continuous = all(left.end + 1 == right.start for left, right in zip(selected, selected[1:]))
+    if not continuous:
+        missing_ranges: list[tuple[int, int]] = []
+        for left, right in zip(selected, selected[1:]):
+            if left.end + 1 < right.start:
+                missing_ranges.append((left.end + 1, right.start - 1))
+        return MesocycleStatus(
+            can_produce=False,
+            available=available,
+            missing_ranges=missing_ranges,
+            reason="los últimos tres microciclos no son continuos",
+            selected=selected,
+        )
+    return MesocycleStatus(
+        can_produce=True,
+        available=available,
+        missing_ranges=[],
+        reason="tres microciclos continuos disponibles",
+        selected=selected,
+    )
+
+
+def _section_body(text: str, heading: str) -> str:
+    target = heading.strip().lower()
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line.strip().lower() != target:
+            continue
+        body: list[str] = []
+        for body_line in lines[index + 1 :]:
+            if body_line.startswith("## "):
+                break
+            body.append(body_line)
+        return "\n".join(body).strip()
+    return ""
+
+
+def _clean_body_lines(body: str, limit: int) -> list[str]:
+    lines: list[str] = []
+    for raw in body.splitlines():
+        clean = raw.strip()
+        if not clean or clean.startswith(("```", "|---", "Tags usados:", "Tags nuevos")):
+            continue
+        if clean.startswith("###"):
+            continue
+        if clean.startswith(("- ", "* ")):
+            clean = clean[2:].strip()
+        elif clean.startswith("|"):
+            cells = [cell.strip() for cell in clean.strip("|").split("|")]
+            clean = " — ".join(cell for cell in cells if cell)
+        if not clean or clean in {"ninguno", "ninguna"}:
+            continue
+        lines.append(clean)
+        if len(lines) >= limit:
+            break
+    return lines
+
+
+def _micro_section_lines(load: MicrodiagnosticLoad, headings: tuple[str, ...], limit: int = 4) -> list[str]:
+    for heading in headings:
+        body = _section_body(load.text, heading)
+        if body:
+            return _clean_body_lines(body, limit)
+    return []
+
+
+def _meso_collect(
+    loads: list[MicrodiagnosticLoad],
+    headings: tuple[str, ...],
+    fallback: str,
+    limit_per_micro: int = 3,
+    total_limit: int = 12,
+) -> list[str]:
+    bullets: list[str] = []
+    for load in loads:
+        if not load.is_valid:
+            continue
+        for line in _micro_section_lines(load, headings, limit=limit_per_micro):
+            bullets.append(f"- {load.ref.display}: {line} (Fuente principal: microdiagnóstico)")
+            if len(bullets) >= total_limit:
+                return bullets
+    return bullets or [f"- {fallback} (Fuente principal: microdiagnóstico)"]
+
+
+def _micro_summary_lines(load: MicrodiagnosticLoad) -> list[str]:
+    decisions = _micro_section_lines(load, ("## Decisiones estabilizadas",), limit=2)
+    risks = _micro_section_lines(load, ("## Riesgos actuales",), limit=2)
+    maturity = _micro_section_lines(load, ("## Señales de madurez",), limit=1)
+    lines = [
+        f"- Fuente principal: microdiagnóstico `{as_display_path(load.ref.path)}`.",
+        f"- Validez: {'válido' if load.is_valid else 'inválido'}; título observado: `{load.title}`.",
+    ]
+    if decisions:
+        lines.append(f"- Decisiones dominantes: {'; '.join(decisions)}.")
+    if risks:
+        lines.append(f"- Riesgos dominantes: {'; '.join(risks)}.")
+    if maturity:
+        lines.append(f"- Señal de madurez: {'; '.join(maturity)}.")
+    return lines
+
+
+def _microdiagnostic_validity_lines(loads: list[MicrodiagnosticLoad]) -> list[str]:
+    lines: list[str] = []
+    for load in loads:
+        checks = [
+            "JSON válido" if load.valid_json else f"JSON inválido ({load.error})",
+            "título exacto" if load.valid_title else f"título no exacto ({load.title})",
+            "tipo reversible" if load.valid_type else f"tipo inesperado ({load.type})",
+        ]
+        lines.append(f"- {load.ref.display}: " + "; ".join(checks))
+    return lines
+
+
+def _staging_completeness_lines(loads: list[MicrodiagnosticLoad]) -> list[str]:
+    lines: list[str] = []
+    for load in loads:
+        total_sessions = load.ref.end - load.ref.start + 1
+        missing = _micro_section_lines(load, ("## Sesiones ausentes o incompletas",), limit=total_sessions)
+        if not missing:
+            lines.append(f"- {load.ref.display}: presente según microdiagnóstico. Fuente usada: microdiagnóstico.")
+            continue
+        missing_local_count = sum(1 for item in missing if "sin artefactos locales" in item)
+        if missing_local_count >= total_sessions and all("sin artefactos locales" in item for item in missing):
+            status = "depurado o ausente en staging local"
+        else:
+            status = "parcial en staging local"
+        lines.append(
+            f"- {load.ref.display}: {status}; señales: {'; '.join(missing[:3])}. "
+            "Fuente usada: microdiagnóstico."
+        )
+    return lines
+
+
+def _canonical_completeness_lines(start: int, end: int) -> list[str]:
+    records, _evidence = discover_canon_session_records(start, end)
+    by_number = {record.identity.number: record for record in records}
+    lines: list[str] = []
+    for number in range(start, end + 1):
+        record = by_number.get(number)
+        if record is None:
+            status = "no encontrada"
+            session = f"S{number}"
+            count = "0/7"
+        else:
+            status = "admitida completa" if record.is_complete else "admitida parcial"
+            session = f"{record.display} ({record.session_id})"
+            count = f"{record.valid_family_count}/{len(REQUIRED_SESSION_FAMILIES)}"
+        lines.append(f"- {session}: {status} ({count}). Fuente usada: canon.")
+    return lines
+
+
+def _mesocycle_prognosis() -> str:
+    return "\n".join(
+        [
+            "## Pronóstico operativo",
+            "",
+            "### Próxima sesión recomendada",
+            "- Tema: m04-s98-project-level-diagnostic-readiness",
+            "- Tipo: diagnóstico puro",
+            "- Clasificación: necesidad real",
+            "- Justificación: El mesociclo ya existe y permite evaluar si hay evidencia suficiente para un diagnóstico arquitectónico global sin abrir todavía ese diagnóstico.",
+            "- Evidencia desde el mesociclo: Tres microdiagnósticos continuos S65-S94 fueron consumidos como fuente principal y muestran madurez local-first, canon protegido y deuda remota delimitada.",
+            "- Riesgo si se ignora: El proyecto podría saltar a diagnóstico global sin verificar antes si la procedencia y completitud sostienen esa escala.",
+            "",
+            "### Segunda sesión probable",
+            "- Tema: m04-s98-remote-agent-dry-run-diagnostic-readiness",
+            "- Tipo: sesión mixta",
+            "- Clasificación: mejora conveniente",
+            "- Justificación: El contrato remoto está declarado, pero conviene probar lectura remota en dry-run antes de permitir cualquier espejo operativo.",
+            "- Evidencia desde el mesociclo: S85-S94 acumuló decisiones sobre OneDrive, secrets, CodeQL y raíz `data/out/local/`; S97 conserva `SYNC_DRY_RUN=true` como contención.",
+            "- Riesgo si se ignora: Un mirror con `REMOTE_DELETE_EXTRANEOUS=true` puede amplificar errores de ruta si se activa antes de validar paridad y permisos.",
+            "",
+            "### Tercera sesión posible",
+            "- Tema: diagnóstico arquitectónico global del proyecto completo",
+            "- Tipo: diagnóstico puro",
+            "- Clasificación: tentación prematura",
+            "- Justificación: La cadena microciclos → mesociclo ya quedó preparada, pero falta una sesión de readiness que confirme alcance, fuentes y criterios de corte.",
+            "- Evidencia desde el mesociclo: Hay memoria cíclica consolidada, pero todavía aparecen staging depurado, S90 incompleto y superficie remota no ejercitada en dry-run real.",
+            "- Riesgo si se ignora: El diagnóstico global mezclaría evidencia madura con deuda local no clasificada y produciría conclusiones demasiado amplias.",
+        ]
+    )
+
+
+def build_mesocycle_markdown(refs: list[MicrocycleRef], thematic_diagnostics: list[Path], tag_plan: TagPlan) -> str:
+    if len(refs) != 3:
+        raise ValueError("mesocycle requires exactly 3 microcycle diagnostics")
+    loads = load_microdiagnostics(refs)
+    invalid = [load for load in loads if not load.is_valid]
+    if invalid:
+        details = "; ".join(f"{load.ref.display}: {load.error or load.title}" for load in invalid)
+        raise ValueError(f"invalid microcycle diagnostics: {details}")
+    start = refs[0].start
+    end = refs[-1].end
+    thematic_lines = (
+        [f"- {as_display_path(path)}" for path in thematic_diagnostics]
+        if thematic_diagnostics
+        else ["- ninguno"]
+    )
+    consumed_lines = [f"- {ref.display}: {as_display_path(ref.path)}" for ref in refs]
+    workflow_path = REPO_ROOT / ".github" / "workflows" / "remote_mirror_out_local.yml"
+    auxiliary_lines = [
+        "- microdiagnóstico: los tres archivos de `micro-ciclo/` son la fuente principal.",
+        "- sessions: `data/out/local/sessions/` se usa para ubicar diagnósticos y staging, no para releer 30 sesiones crudas.",
+        "- canon: `data/out/local/tiddlers_*.jsonl` se usa para tags y completitud canónica.",
+        "- auditoría: `data/out/local/audit/` queda disponible como apoyo; no se leyó ningún reporte concreto porque no hubo hipótesis de auditoría que validar.",
+        "- repositorio: instrucciones, script diagnóstico, tests y workflow remoto.",
+    ]
+    if workflow_path.is_file():
+        auxiliary_lines.append(f"- remoto dry-run: inspección estática de `{as_display_path(workflow_path)}`; no se ejecutó sincronización.")
+    tag_lines = [f"- {tag}" for tag in tag_plan.tags]
+    new_tag_lines = (
+        [f"- {tag}: {reason}" for tag, reason in tag_plan.new_tag_justifications.items()]
+        if tag_plan.new_tag_justifications
+        else ["- ninguno"]
+    )
+    return "\n".join(
+        [
+            f"# Diagnóstico de mesociclo S{start}-S{end}",
+            "",
+            "## Rango de microciclos analizados",
+            f"S{start}-S{end}.",
+            "",
+            "## Microciclos incluidos",
+            "\n".join(f"- {load.ref.display}" for load in loads),
+            "",
+            "## Archivos de microdiagnóstico leídos",
+            "\n".join(consumed_lines),
+            "",
+            "## Validez de cada microdiagnóstico",
+            "\n".join(_microdiagnostic_validity_lines(loads)),
+            "",
+            "## Fuentes auxiliares consultadas",
+            "\n".join(auxiliary_lines),
+            "",
+            "## Diagnósticos temáticos consultados",
+            "\n".join(thematic_lines),
+            "",
+            "## Gobernanza de procedencia aplicada",
+            "\n".join(
+                [
+                    "- Nivel 1: microdiagnósticos previos específicos como fuente principal del mesociclo.",
+                    "- Nivel 2: `data/out/local/sessions/` como staging local y raíz oficial de sesiones.",
+                    "- Nivel 3: canon local para completitud durable cuando `sessions/` fue depurado.",
+                    "- Nivel 4: auditorías y derivados solo como apoyo para hipótesis concretas.",
+                    "- Nivel 5: repositorio para validar scripts, tests, instrucciones y workflow actual.",
+                    "- Nivel 6: remoto/OneDrive como paridad operativa, no autoridad superior al canon local.",
+                ]
+            ),
+            "",
+            "## Completitud en staging local",
+            "\n".join(_staging_completeness_lines(loads)),
+            "",
+            "## Completitud canónica",
+            "\n".join(_canonical_completeness_lines(start, end)),
+            "",
+            f"## Síntesis de S{refs[0].start}-S{refs[0].end}",
+            "\n".join(_micro_summary_lines(loads[0])),
+            "",
+            f"## Síntesis de S{refs[1].start}-S{refs[1].end}",
+            "\n".join(_micro_summary_lines(loads[1])),
+            "",
+            f"## Síntesis de S{refs[2].start}-S{refs[2].end}",
+            "\n".join(_micro_summary_lines(loads[2])),
+            "",
+            "## Continuidad entre microciclos",
+            "\n".join(
+                [
+                    "- La continuidad principal es local-first: primero canon/admisión/reverse, luego rutas, después remoto/CI. Fuente principal: microdiagnóstico.",
+                    "- Los tres ciclos sostienen la separación entre staging, canon local y derivados. Fuente principal: microdiagnóstico.",
+                    "- La producción diagnóstica escala de sesiones a microciclos y ahora a mesociclo sin releer 30 sesiones crudas. Fuente principal: microdiagnóstico.",
+                ]
+            ),
+            "",
+            "## Cambios de dirección entre microciclos",
+            "\n".join(
+                [
+                    "- S65-S74 estabiliza admisión canónica, reverse y primeras compuertas locales. Fuente principal: microdiagnóstico.",
+                    "- S75-S84 gira hacia vocabulario de roles, relaciones, rutas y propagación downstream. Fuente principal: microdiagnóstico.",
+                    "- S85-S94 desplaza el foco hacia MCP, `.env`, CI/CodeQL, remoto OneDrive y gobernanza de rutas de sesión. Fuente principal: microdiagnóstico.",
+                ]
+            ),
+            "",
+            "## Decisiones estabilizadas",
+            "\n".join(
+                _meso_collect(
+                    loads,
+                    ("## Decisiones estabilizadas", "## Cambios en gobernanza de rutas", "## Cambios en canon/reverse"),
+                    "sin decisiones estabilizadas extraídas",
+                    limit_per_micro=4,
+                    total_limit=14,
+                )
+            ),
+            "",
+            "## Hipótesis confirmadas",
+            "\n".join(_meso_collect(loads, ("## Hipótesis confirmadas",), "sin hipótesis confirmadas extraídas")),
+            "",
+            "## Hipótesis abiertas",
+            "\n".join(_meso_collect(loads, ("## Hipótesis abiertas",), "sin hipótesis abiertas extraídas")),
+            "",
+            "## Deuda técnica persistente",
+            "\n".join(_meso_collect(loads, ("## Deuda técnica persistente", "## Riesgos actuales"), "sin deuda persistente extraída")),
+            "",
+            "## Deuda técnica cerrada",
+            "\n".join(_meso_collect(loads, ("## Deuda técnica cerrada",), "sin deuda cerrada extraída")),
+            "",
+            "## Deuda técnica nueva",
+            "\n".join(_meso_collect(loads, ("## Deuda técnica nueva",), "sin deuda nueva extraída")),
+            "",
+            "## Riesgos acumulados",
+            "\n".join(
+                [
+                    *_meso_collect(loads, ("## Riesgos actuales",), "sin riesgos actuales extraídos", limit_per_micro=3, total_limit=10),
+                    "- Riesgo remoto: `REMOTE_DELETE_EXTRANEOUS=true` y modo mirror requieren dry-run y raíz local correcta antes de cualquier ejecución real. Fuente principal: repositorio.",
+                    "- Riesgo de interpretación: `sessions/` depurado no equivale a memoria perdida si canon conserva evidencia. Fuente principal: canon.",
+                ]
+            ),
+            "",
+            "## Señales de madurez",
+            "\n".join(_meso_collect(loads, ("## Señales de madurez",), "sin señales de madurez extraídas", total_limit=10)),
+            "",
+            "## Señales de deriva",
+            "\n".join(_meso_collect(loads, ("## Señales de deriva",), "sin señales de deriva extraídas", total_limit=10)),
+            "",
+            "## Impacto sobre canon",
+            "\n".join(
+                [
+                    "- El canon local queda como memoria durable y fuente de completitud cuando el staging fue depurado. Fuente principal: canon.",
+                    "- La admisión sigue pasando por compuertas locales; el mesociclo no promueve líneas automáticamente. Fuente principal: repositorio.",
+                ]
+            ),
+            "",
+            "## Impacto sobre reverse",
+            "\n".join(_meso_collect(loads, ("## Cambios en canon/reverse",), "sin impacto reverse extraído", total_limit=10)),
+            "",
+            "## Impacto sobre CI/CD",
+            "\n".join(_meso_collect(loads, ("## Cambios en CI/CD",), "sin impacto CI/CD extraído", total_limit=10)),
+            "",
+            "## Impacto sobre seguridad",
+            "\n".join(
+                [
+                    *_meso_collect(loads, ("## Cambios en seguridad",), "sin impacto de seguridad extraído", total_limit=6),
+                    "- La revisión remota no imprime tokens ni exige `MSA_REFRESH_TOKEN`; el workflow usa secrets y `SYNC_DRY_RUN=true` por defecto. Fuente principal: repositorio.",
+                ]
+            ),
+            "",
+            "## Impacto sobre agente local",
+            "\n".join(
+                [
+                    "- El agente local debe leer primero `data/out/local/`, producir bajo `data/out/local/sessions/` y no escribir `tiddlers_*.jsonl`. Fuente principal: repositorio.",
+                    "- Los diagnósticos de ciclo ahora permiten resumir evolución sin reabrir todo el historial crudo. Fuente principal: microdiagnóstico.",
+                ]
+            ),
+            "",
+            "## Impacto sobre agente remoto",
+            "\n".join(
+                [
+                    "- El agente remoto debe leer desde `AGENT_PRIMARY_READ_ROOT=data/out/local/`. Fuente principal: repositorio.",
+                    "- Debe producir candidatos bajo `AGENT_SESSION_ROOT=data/out/local/sessions/` y respetar `AGENT_DIRECT_CANON_WRITE=false`. Fuente principal: repositorio.",
+                    "- Con `SYNC_DRY_RUN=true`, cualquier mirror debe ser simulación o inspección no destructiva. Fuente principal: repositorio.",
+                ]
+            ),
+            "",
+            "## Preparación para diagnóstico global del proyecto",
+            "\n".join(
+                [
+                    "- La cadena sesiones → microciclos → mesociclo ya tiene un primer artefacto reversible. Fuente principal: microdiagnóstico.",
+                    "- Antes del diagnóstico global conviene abrir una sesión de readiness para fijar corte, fuentes y criterios de escala. Fuente principal: mesociclo.",
+                ]
+            ),
+            "",
+            _mesocycle_prognosis(),
+            "",
+            "## Tags usados y justificación de tags nuevos",
+            "Tags usados:",
+            "\n".join(tag_lines),
+            "",
+            "Tags nuevos o instancias nuevas justificadas:",
+            "\n".join(new_tag_lines),
+        ]
+    ) + "\n"
+
+
+def build_mesocycle_tiddler(
+    refs: list[MicrocycleRef],
+    tag_plan: TagPlan,
+    thematic_diagnostics: list[Path],
+    session_origin: str | None = None,
+    timestamp: str | None = None,
+) -> dict[str, Any]:
+    if len(refs) != 3:
+        raise ValueError("cannot build mesocycle tiddler without exactly three microcycles")
+    start = refs[0].start
+    end = refs[-1].end
+    created = timestamp or stamp_now()
+    title = mesocycle_title(start, end)
+    source_path = MESO_DIAG_DIR / mesocycle_filename(refs[-1].milestone, start, end)
+    tiddler: dict[str, Any] = {
+        "created": created,
+        "modified": created,
+        "title": title,
+        "text": build_mesocycle_markdown(refs, thematic_diagnostics, tag_plan),
+        "tags": format_tw_tags(tag_plan.tags),
+        "type": "text/vnd.tiddlywiki",
+        "source_path": as_display_path(source_path),
+    }
+    if session_origin:
+        tiddler["session_origin"] = session_origin
+    return tiddler
+
+
+def generate_microcycle(
+    sessions_dir: Path = DEFAULT_SESSIONS_DIR,
+    count: int = 10,
+    include_thematic: bool = False,
+    session_origin: str | None = None,
+    write: bool = False,
+    milestone: str = "m04",
+    start_session: int | None = None,
+    end_session: int | None = None,
+    include_mesocycle_status: bool = True,
+    include_canon_evidence: bool = True,
+    repository_evidence: list[str] | None = None,
+    session_kind: str = "infraestructura-diagnostica",
+) -> tuple[Path, dict[str, Any], MesocycleStatus]:
+    discovered = discover_sessions(sessions_dir)
+    canon_records: list[SessionRecord] = []
+    canon_evidence: list[CanonEvidence] = []
+    if (start_session is None) != (end_session is None):
+        raise ValueError("start_session and end_session must be provided together")
+    if start_session is not None and end_session is not None:
+        records = select_session_range(discovered, milestone=milestone, start=start_session, end=end_session)
+        if include_canon_evidence:
+            canon_records, canon_evidence = discover_canon_session_records(start_session, end_session)
+    else:
+        records = select_latest_sessions(discovered, count=count)
+        if include_canon_evidence:
+            canon_records, canon_evidence = discover_canon_session_records(
+                records[0].identity.number,
+                records[-1].identity.number,
+            ) if records else ([], [])
+    if not records:
+        raise ValueError(f"no session artifacts found under {as_display_path(sessions_dir)}")
+    start = records[0].identity.number
+    end = records[-1].identity.number
+    milestone = records[-1].identity.milestone
+    thematic = discover_thematic_diagnostics(sessions_dir) if include_thematic else []
+    existing_tags = load_existing_tags()
+    tag_plan = build_cycle_tags(
+        milestone=milestone,
+        cycle_type="micro-ciclo",
+        start=start,
+        end=end,
+        existing_tags=existing_tags,
+        session_origin=session_origin,
+    )
+    path = MICRO_DIAG_DIR / microcycle_filename(milestone, start, end)
+    projected_refs = discover_microcycles(MICRO_DIAG_DIR)
+    current_ref = MicrocycleRef(milestone=milestone, start=start, end=end, path=path)
+    if all(ref.path != current_ref.path for ref in projected_refs):
+        projected_refs.append(current_ref)
+    temp_dir = path.parent
+    meso_status = _plan_mesocycle_from_refs(sorted(projected_refs, key=lambda item: (int(item.milestone[1:]), item.start, item.end)))
+    tiddler = build_microcycle_tiddler(
+        records=records,
+        tag_plan=tag_plan,
+        thematic_diagnostics=thematic,
+        sessions_dir=sessions_dir,
+        session_origin=session_origin,
+        mesocycle_status=meso_status,
+        include_mesocycle_status=include_mesocycle_status,
+        canon_records=canon_records,
+        canon_evidence=canon_evidence,
+        repository_evidence=repository_evidence or [],
+        session_kind=session_kind,
+    )
+    if write:
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        MESO_DIAG_DIR.mkdir(parents=True, exist_ok=True)
+        write_tiddler(path, tiddler)
+        meso_status = plan_mesocycle(MICRO_DIAG_DIR)
+    return path, tiddler, meso_status
+
+
+def _missing_previous_microcycle_ranges(available: list[MicrocycleRef]) -> list[tuple[int, int]]:
+    if not available:
+        return []
+    latest = available[-1]
+    expected = [(latest.start - 20, latest.start - 11), (latest.start - 10, latest.start - 1)]
+    available_ranges = {(item.start, item.end) for item in available}
+    return [
+        (start, end)
+        for start, end in expected
+        if start > 0 and (start, end) not in available_ranges
+    ]
+
+
+def _plan_mesocycle_from_refs(available: list[MicrocycleRef]) -> MesocycleStatus:
+    if len(available) < 3:
+        missing = _missing_previous_microcycle_ranges(available)
+        return MesocycleStatus(False, available, missing, "faltan microciclos suficientes")
+    selected = available[-3:]
+    continuous = all(left.end + 1 == right.start for left, right in zip(selected, selected[1:]))
+    if continuous:
+        return MesocycleStatus(True, available, [], "tres microciclos continuos disponibles", selected)
+    missing_ranges: list[tuple[int, int]] = []
+    for left, right in zip(selected, selected[1:]):
+        if left.end + 1 < right.start:
+            missing_ranges.append((left.end + 1, right.start - 1))
+    return MesocycleStatus(False, available, missing_ranges, "los últimos tres microciclos no son continuos", selected)
+
+
+def maybe_generate_mesocycle(
+    session_origin: str | None = None,
+    include_thematic: bool = False,
+    write: bool = False,
+) -> tuple[Path | None, dict[str, Any] | None, MesocycleStatus]:
+    status = plan_mesocycle(MICRO_DIAG_DIR)
+    if not status.can_produce:
+        return None, None, status
+    refs = status.selected
+    start = refs[0].start
+    end = refs[-1].end
+    milestone = refs[-1].milestone
+    thematic = discover_thematic_diagnostics(DEFAULT_SESSIONS_DIR) if include_thematic else []
+    tag_plan = build_cycle_tags(
+        milestone=milestone,
+        cycle_type="meso-ciclo",
+        start=start,
+        end=end,
+        existing_tags=load_existing_tags(),
+        session_origin=session_origin,
+        source_microcycles=True,
+        diagnostic_provenance=True,
+        remote_read_root=True,
+    )
+    path = MESO_DIAG_DIR / mesocycle_filename(milestone, start, end)
+    tiddler = build_mesocycle_tiddler(refs, tag_plan, thematic, session_origin=session_origin)
+    if write:
+        write_tiddler(path, tiddler)
+    return path, tiddler, status
+
+
+def _summary(path: Path, tiddler: dict[str, Any], meso_status: MesocycleStatus) -> dict[str, Any]:
+    title = str(tiddler["title"])
+    range_match = re.search(r"S(\d+)-S(\d+)", title)
+    return {
+        "microcycle_path": as_display_path(path),
+        "microcycle_title": title,
+        "microcycle_range": f"S{range_match.group(1)}-S{range_match.group(2)}" if range_match else "",
+        "mesocycle_can_produce": meso_status.can_produce,
+        "mesocycle_reason": meso_status.reason,
+        "mesocycle_available": [ref.display for ref in meso_status.available],
+        "mesocycle_missing_ranges": [f"S{start}-S{end}" for start, end in meso_status.missing_ranges],
+    }
+
+
+def _meso_summary(path: Path | None, tiddler: dict[str, Any] | None, meso_status: MesocycleStatus) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "mesocycle_can_produce": meso_status.can_produce,
+        "mesocycle_reason": meso_status.reason,
+        "mesocycle_available": [ref.display for ref in meso_status.available],
+        "mesocycle_missing_ranges": [f"S{start}-S{end}" for start, end in meso_status.missing_ranges],
+    }
+    if path is not None:
+        summary["mesocycle_path"] = as_display_path(path)
+    if tiddler is not None:
+        summary["mesocycle_title"] = tiddler["title"]
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sessions-dir", type=Path, default=DEFAULT_SESSIONS_DIR)
+    parser.add_argument("--count", type=int, default=10)
+    parser.add_argument("--milestone", default="m04")
+    parser.add_argument("--start-session", type=int, default=None)
+    parser.add_argument("--end-session", type=int, default=None)
+    parser.add_argument("--session-origin", default=None)
+    parser.add_argument("--include-thematic", action="store_true")
+    parser.add_argument("--omit-meso-status", action="store_true")
+    parser.add_argument("--no-canon-evidence", action="store_true")
+    parser.add_argument("--repo-evidence", action="append", default=[])
+    parser.add_argument("--session-kind", choices=sorted(SESSION_KIND_POLICIES), default="infraestructura-diagnostica")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--produce-meso", action="store_true")
+    parser.add_argument("--meso-only", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.meso_only:
+        meso_path, meso_tiddler, meso_status = maybe_generate_mesocycle(
+            session_origin=args.session_origin,
+            include_thematic=args.include_thematic,
+            write=args.write,
+        )
+        print(json.dumps(_meso_summary(meso_path, meso_tiddler, meso_status), ensure_ascii=False, indent=2))
+        return 0 if meso_status.can_produce else 2
+
+    path, tiddler, meso_status = generate_microcycle(
+        sessions_dir=args.sessions_dir,
+        count=args.count,
+        include_thematic=args.include_thematic,
+        session_origin=args.session_origin,
+        write=args.write,
+        milestone=args.milestone,
+        start_session=args.start_session,
+        end_session=args.end_session,
+        include_mesocycle_status=not args.omit_meso_status,
+        include_canon_evidence=not args.no_canon_evidence,
+        repository_evidence=args.repo_evidence,
+        session_kind=args.session_kind,
+    )
+
+    meso_path = None
+    if args.produce_meso:
+        meso_path, _meso_tiddler, meso_status = maybe_generate_mesocycle(
+            session_origin=args.session_origin,
+            include_thematic=args.include_thematic,
+            write=args.write,
+        )
+
+    summary = _summary(path, tiddler, meso_status)
+    if meso_path is not None:
+        summary["mesocycle_path"] = as_display_path(meso_path)
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python_scripts/session_sync.py
+++ b/python_scripts/session_sync.py
@@ -98,13 +98,13 @@ FAMILY_BY_RELATIVE_ROOT: dict[tuple[str, ...], dict[str, Any]] = {
         "source_role": "reporte",
         "order": 9,
     },
-    ("06_diagnoses", "micro_ciclo"): {
+    ("06_diagnoses", "micro-ciclo"): {
         "family": "diagnostico_de_micro_ciclo",
         "role_primary": "log",
         "source_role": "reporte",
         "order": 10,
     },
-    ("06_diagnoses", "meso_ciclo"): {
+    ("06_diagnoses", "meso-ciclo"): {
         "family": "diagnostico_de_meso_ciclo",
         "role_primary": "log",
         "source_role": "reporte",

--- a/tests/fixtures/s52/test_chunking_structure.py
+++ b/tests/fixtures/s52/test_chunking_structure.py
@@ -45,7 +45,7 @@ class ChunkingStructureTests(unittest.TestCase):
         }
         payload = derive_layers.classify_payload(rec, "html_artifact", 1800)
         self.assertFalse(payload["is_chunkable_text"])
-        self.assertEqual(payload["chunk_exclusion_reason"], "archival_only_skip")
+        self.assertEqual(payload["chunk_exclusion_reason"], "archival_only")
         self.assertEqual(payload["corpus_state"], "archival_only")
 
     def test_structural_split_respects_target(self) -> None:
@@ -93,6 +93,47 @@ class ChunkingStructureTests(unittest.TestCase):
         self.assertEqual(first["source_anchor"]["shard_file"], "tiddlers_1.jsonl")
         self.assertEqual(first["section_path"], ["README.md"])
         self.assertEqual(first["taxonomy_path"], ["project/docs/readme"])
+        self.assertEqual(first["relation_targets"], [])
+        self.assertEqual(first["relation_count"], 0)
+
+    def test_chunk_records_inherit_compact_relation_context(self) -> None:
+        rec = {
+            "id": "node-1",
+            "title": "README.md",
+            "text": "# Intro\n" + ("texto de prueba. " * 900),
+            "content_type": "text/markdown",
+            "tags": ["⚙️ Markdown", "README.md", "--- Codigo", "state:live-path"],
+        }
+        payload = derive_layers.classify_payload(rec, "readme", 1800)
+        relation_targets = [
+            {"type": "usa", "target_id": "target-1", "evidence": "content_embedded"},
+            {"type": "usa", "target_id": "target-1", "evidence": "content_embedded"},
+            {"type": "define", "target_id": "target-2"},
+        ]
+        chunks, _, _ = derive_layers.chunk_node(
+            rec,
+            "node-1",
+            "tiddlers_1.jsonl",
+            1,
+            "readme",
+            ["project/docs/readme"],
+            ["README.md"],
+            ["readme", "repo"],
+            payload,
+            1800,
+            4000,
+            relation_targets=relation_targets,
+        )
+        self.assertGreater(len(chunks), 0)
+        first = chunks[0]
+        self.assertEqual(
+            first["relation_targets"],
+            [
+                {"target_id": "target-1", "type": "usa", "evidence": "content_embedded"},
+                {"target_id": "target-2", "type": "define"},
+            ],
+        )
+        self.assertEqual(first["relation_count"], 2)
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/s54/test_semantic_microchunk.py
+++ b/tests/fixtures/s54/test_semantic_microchunk.py
@@ -41,7 +41,7 @@ class SemanticMicrochunkTests(unittest.TestCase):
         payload = derive_layers.classify_payload(rec, "manifest", 1800)
         self.assertFalse(payload["is_chunkable_text"])
         self.assertEqual(payload["corpus_state"], "archival_only")
-        self.assertEqual(payload["chunk_exclusion_reason"], "archival_only_skip")
+        self.assertEqual(payload["chunk_exclusion_reason"], "archival_only")
 
     def test_densify_microchunks_merges_heading_stub_into_context(self) -> None:
         parts = [

--- a/tests/fixtures/s65/test_s65_microsoft_copilot_flow.py
+++ b/tests/fixtures/s65/test_s65_microsoft_copilot_flow.py
@@ -44,6 +44,8 @@ class S65MicrosoftCopilotFlowTests(unittest.TestCase):
     CONTRACT_PATH = (
         REPO_ROOT
         / "data"
+        / "out"
+        / "local"
         / "sessions"
         / "00_contratos"
         / "m03-s65-microsoft-copilot-execution-surface-and-readme-hardening-v0.md.json"
@@ -73,8 +75,12 @@ class S65MicrosoftCopilotFlowTests(unittest.TestCase):
         self.assertTrue(self.COPILOT_AGENT_DIR.exists(), "copilot_agent sub-directory missing")
 
     def test_contract_file_exists(self) -> None:
-        """S65 must leave an importable contract in contratos/."""
-        self.assertTrue(self.CONTRACT_PATH.exists(), "S65 contract file is missing")
+        """S65 contract must be present in canon or staged under the governed session root."""
+        titles = {record.get("title") for record in load_canon_records()}
+        self.assertTrue(
+            self.CONTRACT_TITLE in titles or self.CONTRACT_PATH.exists(),
+            "S65 contract is neither in canon nor staged under data/out/local/sessions",
+        )
 
     def test_s65_contract_is_absorbed_or_staged(self) -> None:
         """S65 contract must be staged in data/out/local/sessions or already present in canon."""

--- a/tests/fixtures/s69/test_session_admission.py
+++ b/tests/fixtures/s69/test_session_admission.py
@@ -13,22 +13,30 @@ import unittest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_DIR = REPO_ROOT / "python_scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import admit_session_candidates as asc
+
 ADMIT_SCRIPT = REPO_ROOT / "python_scripts" / "admit_session_candidates.py"
-BASE_CANDIDATES = (
+SESSIONS_DIR = REPO_ROOT / "data" / "out" / "local" / "sessions"
+BASE_CONTRACT_SOURCE = (
     REPO_ROOT
     / "data"
+    / "out"
+    / "local"
     / "sessions"
-    / "06_diagnoses"
-    / "sesion"
-    / "m03-s66-session-family-and-canonical-closure-flow-v0.canon-candidates.jsonl"
+    / "00_contratos"
+    / "m04-s98-propagacion-relacional-chunks-ai-y-rule23.md.json"
 )
-SESSIONS_DIR = REPO_ROOT / "data" / "out" / "local" / "sessions"
 REAL_CANON_DIR = REPO_ROOT / "data" / "out" / "local"
 DATA_TMP = REPO_ROOT / "data" / "tmp"
 REPORT_DIR = DATA_TMP / "admissions" / "s69_unittest"
 WORK_DIR = DATA_TMP / "session_admission_s69_unittest"
-S66_PROVENANCE_SOURCE = (
-    "data/out/local/sessions/01_procedencia/m03-s66-session-family-and-canonical-closure-flow-v0.md.json"
+BASE_SESSION_ORIGIN = "m04-s98-propagacion-relacional-chunks-ai-y-rule23"
+ALT_EXISTING_SOURCE = (
+    "data/out/local/sessions/01_procedencia/m04-s98-propagacion-relacional-chunks-ai-y-rule23.md.json"
 )
 
 
@@ -52,7 +60,7 @@ def copy_canon_fixture(target_dir: Path) -> None:
     target_dir.mkdir(parents=True, exist_ok=True)
     for shard in sorted(REAL_CANON_DIR.glob("tiddlers_*.jsonl")):
         shutil.copy2(shard, target_dir / shard.name)
-    remove_session_origin(target_dir, "m03-s66-session-family-and-canonical-closure-flow-v0")
+    remove_session_origin(target_dir, BASE_SESSION_ORIGIN)
 
 
 def remove_session_origin(canon_dir: Path, session_origin: str) -> None:
@@ -69,13 +77,11 @@ def remove_session_origin(canon_dir: Path, session_origin: str) -> None:
         shard.write_text("\n".join(kept) + ("\n" if kept else ""), encoding="utf-8")
 
 
-def first_s66_candidate() -> dict:
-    with BASE_CANDIDATES.open("r", encoding="utf-8") as handle:
-        for raw in handle:
-            line = raw.strip()
-            if line:
-                return json.loads(line)
-    raise AssertionError(f"{BASE_CANDIDATES} has no JSONL records")
+def base_session_candidate(tmp_dir: Path) -> dict:
+    raw = asc._contract_candidate_from_artifact(BASE_CONTRACT_SOURCE, SESSIONS_DIR)
+    normalized = normalize_records([raw], tmp_dir)[0]
+    normalized["raw_payload_ref"] = f"node:{normalized['id']}"
+    return normalized
 
 
 def write_jsonl(path: Path, records: list[dict]) -> None:
@@ -167,7 +173,7 @@ class SessionAdmissionFixtureTests(unittest.TestCase):
         self.real_canon_before = canon_hash(REAL_CANON_DIR)
         self.tmp = tempfile.TemporaryDirectory(prefix="s69_admission_", dir=DATA_TMP)
         self.tmp_dir = Path(self.tmp.name)
-        self.base_candidate = first_s66_candidate()
+        self.base_candidate = base_session_candidate(self.tmp_dir)
 
     def tearDown(self) -> None:
         self.tmp.cleanup()
@@ -288,7 +294,7 @@ class SessionAdmissionFixtureTests(unittest.TestCase):
         )
         session_family_conflict = self.make_variant(
             "#### 🌀 Contrato de sesión 69 = session-family-conflict-fixture-v0",
-            source_path=S66_PROVENANCE_SOURCE,
+            source_path=ALT_EXISTING_SOURCE,
         )
         same_id_drift = self.make_content_drift()
         missing_source = copy.deepcopy(self.base_candidate)

--- a/tests/test_rule23_relational_coverage.py
+++ b/tests/test_rule23_relational_coverage.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Focused tests for RULE-23 relational coverage metrics."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import audit_normative_projection as audit  # noqa: E402
+
+
+def test_rule23_reports_canon_and_chunk_coverage() -> None:
+    canon_records = [
+        {
+            "id": "n1",
+            "title": "#### 🌀 Balance de sesión 1 = ejemplo",
+            "role_primary": "log",
+            "taxonomy_path": ["session/log"],
+            "relations": [],
+        },
+        {
+            "id": "n2",
+            "title": "## 🧭🧱 Protocolo de Sesión",
+            "role_primary": "glossary",
+            "taxonomy_path": ["core/protocol"],
+            "relations": [{"type": "usa", "target_id": "n1"}],
+        },
+    ]
+    chunks = [
+        {
+            "chunk_id": "n2::chunk:0",
+            "relation_targets": [{"type": "usa", "target_id": "n1"}],
+            "relation_count": 1,
+        },
+        {
+            "chunk_id": "n1::chunk:0",
+            "relation_targets": [],
+            "relation_count": 0,
+        },
+    ]
+
+    findings = audit.evaluate_corpus_level(canon_records, [], [], chunks)
+    rule23 = next(f for f in findings if f["rule_id"] == "RULE-23")
+    metrics = rule23["metrics"]
+
+    assert metrics["rule"] == "RULE-23"
+    assert metrics["name"] == "relational_coverage"
+    assert metrics["total_nodes"] == 2
+    assert metrics["nodes_with_relations"] == 1
+    assert metrics["coverage_pct"] == 50.0
+    assert metrics["by_role_primary"]["log"]["nodes_without_relations"] == 1
+    assert metrics["chunks_ai"]["total_chunks"] == 2
+    assert metrics["chunks_ai"]["chunks_with_relation_targets"] == 2
+    assert metrics["chunks_ai"]["chunks_with_non_empty_relation_targets"] == 1
+    assert metrics["chunks_ai"]["chunks_with_relation_count_mismatch"] == 0
+    assert rule23["compliance_status"] == "warn"

--- a/tests/test_session_cycle_diagnostics.py
+++ b/tests/test_session_cycle_diagnostics.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_DIR = REPO_ROOT / "python_scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import session_cycle_diagnostics as scd
+
+
+def write_session_artifact(
+    sessions_dir: Path,
+    family: str,
+    number: int,
+    slug: str = "cycle-test",
+    text: str = "## Decisiones a conservar\n- decisión estable\n",
+    valid: bool = True,
+) -> Path:
+    relative = Path(*scd.REQUIRED_SESSION_FAMILIES[family])
+    path = sessions_dir / relative / f"m04-s{number}-{slug}.md.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not valid:
+        path.write_text("[{\"title\": \"broken\"", encoding="utf-8")
+        return path
+    payload = [
+        {
+            "created": "20260505000000000",
+            "modified": "20260505000000000",
+            "title": f"#### 🌀 Sesión {number} = {slug}",
+            "type": "text/markdown",
+            "tags": f"[[session:m04-s{number}]] [[milestone:m04]] [[layer:session]]",
+            "text": text,
+        }
+    ]
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def write_microcycle(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ref = scd.parse_microcycle_filename(path)
+    assert ref is not None
+    payload = [
+        {
+            "created": "20260505000000000",
+            "modified": "20260505000000000",
+            "title": scd.microcycle_title(ref.start, ref.end),
+            "type": "text/vnd.tiddlywiki",
+            "tags": "[[diagnostic:micro-ciclo]]",
+            "text": (
+                "# micro\n\n"
+                "## Decisiones estabilizadas\n- decisión estable\n\n"
+                "## Riesgos actuales\n- riesgo acumulado\n\n"
+                "## Señales de madurez\n- madurez local-first\n"
+            ),
+        }
+    ]
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def test_detects_sessions_groups_artifacts_and_marks_invalid(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions"
+    write_session_artifact(sessions_dir, "contrato", 94, slug="alpha")
+    write_session_artifact(sessions_dir, "balance", 94, slug="alpha")
+    write_session_artifact(sessions_dir, "contrato", 95, slug="beta", valid=False)
+
+    records = scd.discover_sessions(sessions_dir)
+
+    assert [record.session_id for record in records] == ["m04-s94", "m04-s95"]
+    assert records[0].slug == "alpha"
+    assert records[0].artifacts["contrato"].valid is True
+    assert records[1].artifacts["contrato"].valid is False
+    assert "Expecting" in records[1].artifacts["contrato"].error
+
+
+def test_orders_by_session_number_and_selects_latest_10(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions"
+    for number in range(80, 95):
+        write_session_artifact(sessions_dir, "contrato", number)
+
+    selected = scd.select_latest_sessions(scd.discover_sessions(sessions_dir), count=10)
+
+    assert [record.identity.number for record in selected] == list(range(85, 95))
+
+
+def test_select_session_range_keeps_absent_sessions_as_placeholders(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions"
+    write_session_artifact(sessions_dir, "contrato", 79, slug="range-test")
+    write_session_artifact(sessions_dir, "balance", 84, slug="range-test")
+
+    selected = scd.select_session_range(scd.discover_sessions(sessions_dir), "m04", 75, 84)
+
+    assert [record.identity.number for record in selected] == list(range(75, 85))
+    assert selected[0].slug == "sin-artefactos-locales"
+    assert selected[4].session_id == "m04-s79"
+    assert selected[-1].session_id == "m04-s84"
+
+
+def test_microcycle_filename_route_and_title_are_exact():
+    assert scd.MICRO_DIAG_DIR.as_posix().endswith("data/out/local/sessions/06_diagnoses/micro-ciclo")
+    assert scd.microcycle_filename("m04", 85, 94) == "m04-micro-ciclo-s085-s094-diagnostico.md.json"
+    assert scd.microcycle_title(85, 94) == "#### 🌀 Diagnóstico de microciclo = sesiones S85-S94"
+
+
+def test_mesocycle_filename_route_and_title_are_exact():
+    assert scd.MESO_DIAG_DIR.as_posix().endswith("data/out/local/sessions/06_diagnoses/meso-ciclo")
+    assert scd.mesocycle_filename("m04", 64, 94) == "m04-meso-ciclo-s064-s094-diagnostico.md.json"
+    assert scd.mesocycle_title(64, 94) == "#### 🌀 Diagnóstico de mesociclo = microciclos S64-S94"
+
+
+def test_routes_do_not_use_prohibited_roots_or_unhyphenated_cycle_names():
+    for path in (scd.MICRO_DIAG_DIR, scd.MESO_DIAG_DIR):
+        normalized = path.as_posix()
+        assert "data/sessions/" not in normalized
+        assert "data/out/sessions/" not in normalized
+        assert "/microciclo/" not in normalized
+        assert "/mesociclo/" not in normalized
+        assert "/micro-ciclo" in normalized or "/meso-ciclo" in normalized
+
+
+def test_write_tiddler_refuses_canon_shards():
+    with pytest.raises(ValueError, match="protected canon shard"):
+        scd.write_tiddler(
+            REPO_ROOT / "data" / "out" / "local" / "tiddlers_1.jsonl",
+            {"title": "x", "text": "x"},
+        )
+
+
+def test_build_microcycle_tiddler_has_required_format_and_sections(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions"
+    for family in scd.REQUIRED_SESSION_FAMILIES:
+        write_session_artifact(
+            sessions_dir,
+            family,
+            85,
+            text=(
+                "## Decisiones a conservar\n- conservar ruta local\n"
+                "## Hipótesis confirmadas\n- H confirmada\n"
+                "## Riesgos detectados\n- riesgo local\n"
+            ),
+        )
+    record = scd.discover_sessions(sessions_dir)[0]
+    tag_plan = scd.build_cycle_tags("m04", "micro-ciclo", 85, 85, existing_tags={"milestone:m04"})
+    tiddler = scd.build_microcycle_tiddler([record], tag_plan, [], sessions_dir, timestamp="20260505000000000")
+
+    assert tiddler["title"] == "#### 🌀 Diagnóstico de microciclo = sesiones S85-S85"
+    assert tiddler["type"] == "text/vnd.tiddlywiki"
+    for heading in (
+        "## Tipo de sesión diagnóstica",
+        "## Rango de sesiones analizadas",
+        "## Lista de sesiones incluidas",
+        "## Sesiones ausentes o incompletas",
+        "## Artefactos leídos por sesión",
+        "## Diagnósticos temáticos consultados",
+        "## Evidencia consultada desde canon",
+        "## Evidencia consultada desde repositorio",
+        "## Decisiones estabilizadas",
+        "## Hipótesis confirmadas",
+        "## Hipótesis abiertas",
+        "## Deuda técnica cerrada",
+        "## Deuda técnica persistente",
+        "## Deuda técnica nueva",
+        "## Cambios en gobernanza de rutas",
+        "## Cambios en canon/reverse",
+        "## Cambios en CI/CD",
+        "## Cambios en seguridad",
+        "## Impacto sobre agentes locales/remotos",
+        "## Patrones repetidos",
+        "## Riesgos actuales",
+        "## Señales de madurez",
+        "## Señales de deriva",
+        "## Pronóstico operativo",
+        "## Tags usados y justificación de tags nuevos",
+    ):
+        assert heading in tiddler["text"]
+
+
+def test_prognosis_uses_required_three_recommendation_shape(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions"
+    write_session_artifact(sessions_dir, "contrato", 90, valid=False)
+    record = scd.discover_sessions(sessions_dir)[0]
+    tag_plan = scd.build_cycle_tags("m04", "micro-ciclo", 90, 90)
+    text = scd.build_microcycle_markdown([record], [], tag_plan, sessions_dir)
+
+    assert "### Próxima sesión recomendada" in text
+    assert "### Segunda sesión probable" in text
+    assert "### Tercera sesión posible" in text
+    assert "- Tipo: necesidad real" in text
+    assert "- Tipo: mejora conveniente" in text
+    assert "- Tipo: tentación prematura" in text
+    assert "- Evidencia desde el microciclo:" in text
+
+
+def test_session_kind_policy_documents_pure_diagnostic_mode(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions"
+    write_session_artifact(sessions_dir, "contrato", 94)
+    record = scd.discover_sessions(sessions_dir)[0]
+    tag_plan = scd.build_cycle_tags("m04", "micro-ciclo", 94, 94)
+    text = scd.build_microcycle_markdown(
+        [record],
+        [],
+        tag_plan,
+        sessions_dir,
+        session_kind="diagnostico-puro",
+    )
+
+    assert "## Tipo de sesión diagnóstica" in text
+    assert "diagnostico-puro" in text
+    assert "debe detenerse y reportar bloqueo" in text
+    assert "sesion-mixta" in scd.SESSION_KIND_POLICIES
+    assert "sesion-practica-desarrollo" in scd.SESSION_KIND_POLICIES
+    assert "sesion-teorica-analitica" in scd.SESSION_KIND_POLICIES
+
+
+def test_mesocycle_is_controlled_output_when_microcycles_are_missing(tmp_path: Path):
+    micro_dir = tmp_path / "micro-ciclo"
+    write_microcycle(micro_dir / "m04-micro-ciclo-s085-s094-diagnostico.md.json")
+
+    status = scd.plan_mesocycle(micro_dir)
+
+    assert status.can_produce is False
+    assert status.reason == "faltan microciclos suficientes"
+    assert status.missing_ranges == [(65, 74), (75, 84)]
+    assert [item.display for item in status.available] == ["S85-S94"]
+
+
+def test_mesocycle_missing_ranges_respect_existing_previous_microcycle(tmp_path: Path):
+    micro_dir = tmp_path / "micro-ciclo"
+    write_microcycle(micro_dir / "m04-micro-ciclo-s075-s084-diagnostico.md.json")
+    write_microcycle(micro_dir / "m04-micro-ciclo-s085-s094-diagnostico.md.json")
+
+    status = scd.plan_mesocycle(micro_dir)
+
+    assert status.can_produce is False
+    assert status.missing_ranges == [(65, 74)]
+    assert [item.display for item in status.available] == ["S75-S84", "S85-S94"]
+
+
+def test_mesocycle_consumes_three_continuous_microcycles(tmp_path: Path):
+    micro_dir = tmp_path / "micro-ciclo"
+    for start, end in ((65, 74), (75, 84), (85, 94)):
+        write_microcycle(micro_dir / f"m04-micro-ciclo-s{start:03d}-s{end:03d}-diagnostico.md.json")
+
+    status = scd.plan_mesocycle(micro_dir)
+    tag_plan = scd.build_cycle_tags(
+        "m04",
+        "meso-ciclo",
+        65,
+        94,
+        source_microcycles=True,
+        diagnostic_provenance=True,
+        remote_read_root=True,
+    )
+    tiddler = scd.build_mesocycle_tiddler(status.selected, tag_plan, [], timestamp="20260505000000000")
+
+    assert status.can_produce is True
+    assert [item.display for item in status.selected] == ["S65-S74", "S75-S84", "S85-S94"]
+    assert tiddler["title"] == "#### 🌀 Diagnóstico de mesociclo = microciclos S65-S94"
+    for heading in (
+        "## Rango de microciclos analizados",
+        "## Microciclos incluidos",
+        "## Archivos de microdiagnóstico leídos",
+        "## Validez de cada microdiagnóstico",
+        "## Fuentes auxiliares consultadas",
+        "## Gobernanza de procedencia aplicada",
+        "## Completitud en staging local",
+        "## Completitud canónica",
+        "## Síntesis de S65-S74",
+        "## Síntesis de S75-S84",
+        "## Síntesis de S85-S94",
+        "## Continuidad entre microciclos",
+        "## Cambios de dirección entre microciclos",
+        "## Decisiones estabilizadas",
+        "## Hipótesis confirmadas",
+        "## Hipótesis abiertas",
+        "## Deuda técnica persistente",
+        "## Deuda técnica cerrada",
+        "## Deuda técnica nueva",
+        "## Riesgos acumulados",
+        "## Señales de madurez",
+        "## Señales de deriva",
+        "## Impacto sobre canon",
+        "## Impacto sobre reverse",
+        "## Impacto sobre CI/CD",
+        "## Impacto sobre seguridad",
+        "## Impacto sobre agente local",
+        "## Impacto sobre agente remoto",
+        "## Preparación para diagnóstico global del proyecto",
+        "## Pronóstico operativo",
+        "## Tags usados y justificación de tags nuevos",
+    ):
+        assert heading in tiddler["text"]
+    assert "[[source:micro-ciclos]]" in tiddler["tags"]
+    assert "[[governance:diagnostic-provenance]]" in tiddler["tags"]
+    assert "[[agent:remote-read-root]]" in tiddler["tags"]
+
+
+def test_mesocycle_rejects_microdiagnostic_with_wrong_title(tmp_path: Path):
+    micro_dir = tmp_path / "micro-ciclo"
+    paths = [
+        micro_dir / "m04-micro-ciclo-s065-s074-diagnostico.md.json",
+        micro_dir / "m04-micro-ciclo-s075-s084-diagnostico.md.json",
+        micro_dir / "m04-micro-ciclo-s085-s094-diagnostico.md.json",
+    ]
+    for path in paths:
+        write_microcycle(path)
+    raw = json.loads(paths[0].read_text(encoding="utf-8"))
+    raw[0]["title"] = "Diagnóstico microciclo S65-S74"
+    paths[0].write_text(json.dumps(raw, ensure_ascii=False), encoding="utf-8")
+
+    status = scd.plan_mesocycle(micro_dir)
+    tag_plan = scd.build_cycle_tags("m04", "meso-ciclo", 65, 94, source_microcycles=True)
+
+    with pytest.raises(ValueError, match="invalid microcycle diagnostics"):
+        scd.build_mesocycle_tiddler(status.selected, tag_plan, [], timestamp="20260505000000000")
+
+
+def test_thematic_diagnostics_are_auxiliary_not_primary_source(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions"
+    write_session_artifact(sessions_dir, "contrato", 94)
+    theme_path = sessions_dir / "06_diagnoses" / "tema" / "diagnostico-tematico.md.json"
+    theme_path.parent.mkdir(parents=True, exist_ok=True)
+    theme_path.write_text(json.dumps([{"title": "tema", "text": "apoyo"}]), encoding="utf-8")
+
+    records = scd.discover_sessions(sessions_dir)
+    thematic = scd.discover_thematic_diagnostics(sessions_dir)
+    tag_plan = scd.build_cycle_tags("m04", "micro-ciclo", 94, 94)
+    text = scd.build_microcycle_markdown(records, thematic, tag_plan, sessions_dir)
+
+    assert [record.session_id for record in records] == ["m04-s94"]
+    assert thematic == [theme_path]
+    assert "06_diagnoses/tema/diagnostico-tematico.md.json" in text
+
+
+def test_generate_microcycle_accepts_explicit_range_without_latest_10(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions"
+    for number in range(79, 85):
+        write_session_artifact(sessions_dir, "contrato", number, slug="explicit-range")
+
+    path, tiddler, _status = scd.generate_microcycle(
+        sessions_dir=sessions_dir,
+        start_session=75,
+        end_session=84,
+        milestone="m04",
+        session_origin="m04-s96-micro-cycle-s075-s084-diagnosis",
+    )
+
+    assert path.name == "m04-micro-ciclo-s075-s084-diagnostico.md.json"
+    assert tiddler["title"] == "#### 🌀 Diagnóstico de microciclo = sesiones S75-S84"
+    assert "- S75: sin artefactos locales" in tiddler["text"]
+    assert "## Artefactos leídos por sesión" in tiddler["text"]
+    assert "## Evidencia consultada desde canon" in tiddler["text"]
+
+
+def test_cycle_tags_prefer_existing_tags_and_justify_new_tags():
+    existing = {
+        "milestone:m04",
+        "layer:session",
+        "## 🧭🧱 Protocolo de Sesión",
+        "## 🌀🧱 Desarrollo y Evolución",
+    }
+
+    plan = scd.build_cycle_tags(
+        milestone="m04",
+        cycle_type="micro-ciclo",
+        start=85,
+        end=94,
+        existing_tags=existing,
+        session_origin="m04-s95-local-cycle-diagnostics-and-prognosis",
+    )
+
+    assert "milestone:m04" in plan.existing_tags_used
+    assert "layer:session" in plan.existing_tags_used
+    assert "diagnostic:micro-ciclo" in plan.new_tag_justifications
+    assert "range:s085-s094" in plan.new_tag_justifications
+    assert "session:m04-s95" in plan.new_tag_justifications
+    assert scd.format_tw_tags(plan.tags).count("[[diagnostic:micro-ciclo]]") == 1
+
+
+def test_no_active_legacy_cycle_route_constants():
+    assert "microciclo" not in scd.MICRO_DIAG_DIR.as_posix()
+    assert "mesociclo" not in scd.MESO_DIAG_DIR.as_posix()
+    assert "micro_ciclo" not in scd.MICRO_DIAG_DIR.as_posix()
+    assert "meso_ciclo" not in scd.MESO_DIAG_DIR.as_posix()


### PR DESCRIPTION
# PR: pipeline(security): secretless policy, CI/CodeQL greenline, micro/meso-cycle diagnostics, RULE-23 y saneamiento de tests [m04-s92..s99]

```text
Commit: feat(pipeline): secretless hardening, CI/CodeQL greenline, diagnostic infrastructure, relational chunks y legacy test cleanup [m04-s92..s99]
Meta: Es:listo|V:1|R:4|Md:estable|B:pipeline|Ctx:transversal|Pr:P1|Sz:XL|Est:13|Dr:-2|Dc:+2
Arch: Sb:Ejecución|Ea:Implementación|Cx:Orquestación segura|Lg:PYTHON, GO|Mdls:mcp_env_manager, role_contract, session_cycle_diagnostics, derive_layers, test_mcp_env_manager_security, test_session_path_governance, test_session_cycle_diagnostics, path-governance, ci-workflow
```

---

## Metadatos

| Campo | Valor |
|-------|-------|
| Estado | listo |
| Vuelta | 1 |
| Radio | 4 |
| Madurez | estable |
| Bloque | pipeline |
| ContextoCambio | transversal |
| Priority | P1 |
| Size | XL |
| Estimate | 13 |
| Delta-r | -2 |
| Delta-c | +2 |

---

## Tablero y Arquitectura

| Campo | Valor |
|-------|-------|
| StatusTablero | Ejecución |
| EstadoArquitectonico | Implementación |
| Caja | Orquestación segura |
| Lenguajes | PYTHON, GO |
| Modulos | mcp_env_manager, role_contract, session_cycle_diagnostics, derive_layers, test_mcp_env_manager_security, test_session_path_governance, test_session_cycle_diagnostics, path-governance, ci-workflow |

---

## Objetivo

Integrar el arco de 8 sesiones (m04-s92 a m04-s99) que cubre cinco frentes interdependientes:

1. **Seguridad** (s92-s93): política secretless en `mcp_env_manager.py`, suite de 29 tests de seguridad, eliminación de flujos taint CodeQL y greenline del job `Go · canon` en CI.
2. **Gobernanza de rutas** (s94): corrección del fallo estructural de `findPolicyBundleFrom` en CI y formalización de la gobernanza de rutas de sesión con documentación normativa y 16 tests.
3. **Infraestructura diagnóstica** (s95-s97): `session_cycle_diagnostics.py` con 18 tests, diagnósticos de microciclo para los rangos s065-s074, s075-s084 y s085-s094, diagnóstico de mesociclo s065-s094, y regla formal de vigencia de hallazgos diagnósticos.
4. **Pipeline relacional** (s98): propagación de `relation_targets` y `relation_count` a chunks AI, RULE-23 observable, reverse con `Rejected: 0`.
5. **Saneamiento de tests** (s99): resolución de 7 fallos legacy (s64/s65/s69), `pytest tests -q` limpio, reverse con `Rejected: 0`, sin creación de rutas prohibidas.

---

## Resultado integrado

- `mcp_env_manager.py` es secretless por construcción: `assert_not_secret_key()` bloquea toda escritura de secrets en `.env`; `_get_runtime_secret()` es la única interfaz de obtención. 29 tests de seguridad pasan.
- CodeQL no detecta flujos `SECRETS → print/logger/exception` por construcción. Job `Go · canon` pasa en CI con 530 tests Go gracias al fallback `tests/fixtures/canon_policy_bundle.json` en `findPolicyBundleFrom`.
- La gobernanza de rutas de sesión queda documentada normativamente en `docs/path-governance.md` y cubierta por 16 tests ejecutables. `data/sessions/` es ruta prohibida con guardia de test.
- La infraestructura diagnóstica de ciclos está operativa: `session_cycle_diagnostics.py` con 18 tests, tres microciclos producidos y un mesociclo completo que sintetiza decisiones de s065-s094. La regla de vigencia de hallazgos diagnósticos clasifica obligatoriamente en vivo/histórico/resuelto/dudoso.
- Los chunks AI tienen `relation_targets` y `relation_count` propagados de forma determinística. RULE-23 queda observable sin convertir el aislamiento conocido en fallo bloqueante.
- La suite `pytest tests -q` está limpia. Las deudas s64, s65 y s69 (fixture legacy `minimal_canon`, paths `data/sessions/`, `.canon-candidates.jsonl`) quedan resueltas sin crear rutas prohibidas ni artefactos históricos ficticios.

---

## Acciones realizadas

### s92 — Hardening secretless de mcp_env_manager
- Se implementó `assert_not_secret_key()` + `looks_sensitive()` como guardia centralizada en `write_env_key()`.
- Se creó `_get_runtime_secret()` con prioridad: `os.environ` → `getpass` temporal → vacío.
- Se actualizó `action_show_secret_policy()` con recomendación de rotación de `MSA_REFRESH_TOKEN` visible en opción 3 del menú.
- Se creó `tests/test_mcp_env_manager_security.py` con 29 tests como contrato ejecutable de la política. Sin dependencias externas nuevas.

### s93 — CI/CodeQL greenline
- Se eliminaron 3 flujos taint CodeQL en `mcp_env_manager.py` (rutas `SECRETS → print/logger/exception`).
- Se corrigieron 4 patrones de política de secrets residuales.
- Se amplió el trigger del workflow CI para incluir branch `m04`.
- Se validaron 530 tests Go del canon con el mismo entorno de CI; 29 tests Python de seguridad siguen pasando.

### s94 — Go·canon CI fallback y gobernanza de rutas
- Se añadió la constante `canonPolicyBundleFixtureRelPath = "tests/fixtures/canon_policy_bundle.json"` en `go/canon/role_contract.go`.
- Se extendió `findPolicyBundleFrom` con fallback al fixture tracked en el walk-up (prioridad: bundle canónico → fixture).
- Se añadió función helper `fileExists(path string) bool`.
- Se creó `tests/test_session_path_governance.py` con 16 tests que validan `DEFAULT_SESSIONS_DIR`, rutas prohibidas, fixture no vacío y `LOCAL_SYNC_SOURCE`.
- Se creó `docs/path-governance.md` con reglas explícitas, protocolo de sincronización del fixture y declaración de rutas prohibidas.

### s95 — Infraestructura diagnóstica de microciclo
- Se creó `python_scripts/session_cycle_diagnostics.py` con función `check_microcycle_readiness()` y soporte de inventario de familias por sesión.
- Se creó `tests/test_session_cycle_diagnostics.py` con 18 tests. Todos verdes.
- Se produjo el diagnóstico de microciclo s085-s094 bajo `data/out/local/sessions/06_diagnoses/micro-ciclo/`.
- Validaciones: `py_compile session_cycle_diagnostics.py` OK; 18 + 16 tests passing.

### s96 — Diagnósticos de microciclos s065-s074 y s075-s084
- Se produjeron los diagnósticos de microciclo para los rangos s065-s074 y s075-s084 bajo `data/out/local/sessions/06_diagnoses/micro-ciclo/`.
- Se habilitó el mesociclo s065-s094 al contar con los tres microciclos continuos requeridos.
- No se modificó código, scripts ni instrucciones normativas: sesión diagnóstica pura.

### s97 — Mesociclo s065-s094 y gobernanza de procedencia diagnóstica
- Se produjo el diagnóstico de mesociclo s065-s094 bajo `data/out/local/sessions/06_diagnoses/meso-ciclo/`.
- Se formalizó la regla de vigencia de hallazgos diagnósticos: clasificación obligatoria vivo/histórico/resuelto/dudoso; validación mínima contra repositorio actual antes de declarar deuda viva.
- Se documentó el caso S90 como ejemplo metodológico del patrón que la regla previene.
- Validaciones: 18 tests `session_cycle_diagnostics.py` + 16 tests `test_session_path_governance.py` passing.
- No se modificó canon, no se ejecutó remoto real, no se imprimieron secrets.

### s98 — Propagación relacional a chunks AI y RULE-23
- Se extendió la generación de chunks AI para propagar `relation_targets` y `relation_count` desde el canon.
- Se implementó RULE-23: cobertura de relaciones observable por familia, sin convertir el aislamiento conocido en fallo bloqueante.
- Se validó DT07 contra el repo vivo antes de implementar. La propagación quedó compacta y determinística.
- Reverse autoritativo con `Rejected: 0`.

### s99 — Saneamiento de tests legacy y flujo CI
- Se reprodujeron los 7 fallos legacy antes de corregir: s64 (`minimal_canon` ausente en corpus sin entidades), s65 (expectativa de contrato en `data/sessions/`), s69 (dependencia de `.canon-candidates.jsonl` legacy ausente).
- Se corrigieron expectativas de fixtures sin reabrir deuda histórica ni crear rutas prohibidas.
- `pytest tests -q` quedó limpio. Reverse autoritativo con `Rejected: 0`. S98 preservada con métricas de chunks y RULE-23.

---

## Archivos modificados / añadidos

- `python_scripts/mcp_env_manager.py`
  - s92: Guardia secretless (`assert_not_secret_key`, `looks_sensitive`, `_get_runtime_secret`), opción 3 con recomendación de rotación.
  - s93: Eliminación de flujos taint CodeQL y corrección de 4 patrones de política de secrets residuales.

- `tests/test_mcp_env_manager_security.py`
  - s92: Creado. 29 tests de seguridad. Contrato ejecutable de la política secretless.

- `.github/workflows/` (trigger CI)
  - s93: Trigger CI ampliado para incluir branch `m04`.

- `go/canon/role_contract.go`
  - s94: Constante `canonPolicyBundleFixtureRelPath`, fallback en `findPolicyBundleFrom`, función `fileExists`.

- `tests/test_session_path_governance.py`
  - s94: Creado. 16 tests de gobernanza de rutas de sesión.

- `docs/path-governance.md`
  - s94: Creado. Documento normativo de rutas: raíz activa, rutas prohibidas, protocolo de fixture.

- `python_scripts/session_cycle_diagnostics.py`
  - s95: Creado. Motor de diagnóstico de microciclo con `check_microcycle_readiness()`.

- `tests/test_session_cycle_diagnostics.py`
  - s95: Creado. 18 tests del motor diagnóstico.

- `data/out/local/sessions/06_diagnoses/micro-ciclo/m04-micro-ciclo-s085-s094-diagnostico.md.json`
  - s95: Diagnóstico de microciclo s085-s094.

- `data/out/local/sessions/06_diagnoses/micro-ciclo/m04-micro-ciclo-s065-s074-diagnostico.md.json`
  - s96: Diagnóstico de microciclo s065-s074.

- `data/out/local/sessions/06_diagnoses/micro-ciclo/m04-micro-ciclo-s075-s084-diagnostico.md.json`
  - s96: Diagnóstico de microciclo s075-s084.

- `data/out/local/sessions/06_diagnoses/meso-ciclo/` (artefacto de mesociclo s065-s094)
  - s97: Diagnóstico de mesociclo sintetizando los tres microciclos.

- `data/out/local/sessions/02_detalles_de_sesion/m04-s97-formalizacion-gobernanza-procedencia-diagnostica.md.json`
  - s97: Formalización de la regla de vigencia de hallazgos diagnósticos.

- `python_scripts/derive_layers.py` (o script de generación de chunks AI)
  - s98: Propagación de `relation_targets` y `relation_count` a chunks. RULE-23.

- `tests/fixtures/` (fixtures s64/s65/s69 corregidos)
  - s99: Corrección de expectativas legacy: `minimal_canon`, paths `data/sessions/`, `.canon-candidates.jsonl`.

- `data/out/local/sessions/04_balance_de_sesion/m04-s92..s99-*.md.json`
  - Artefactos de balance por sesión.

- `data/out/local/sessions/05_propuesta_de_sesion/m04-s92..s99-*.md.json`
  - Artefactos de propuesta por sesión (donde existan).

---

## Comprobaciones sugeridas

- Ejecutar `pytest tests/test_mcp_env_manager_security.py -v` y confirmar 29/29 passing.
- Verificar que ningún secret (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `MSA_REFRESH_TOKEN`) aparece en ninguna salida del menú MCP ni en `.env` del repo.
- Ejecutar `go test ./...` desde `go/canon/` y confirmar 530 PASS, 0 FAIL con `canonPolicyBundleFixtureRelPath` activo como fallback.
- Verificar en GitHub Actions que el job `Go · canon` pasa en branch `m04` tras el push.
- Verificar que CodeQL no reporta flujos taint en `mcp_env_manager.py` (pestaña Security de GitHub Advanced Security).
- Ejecutar `pytest tests/test_session_path_governance.py -v` y confirmar 16/16 passing.
- Verificar que `data/sessions/` no existe o está vacío (`test_data_sessions_directory_does_not_exist_or_is_empty`).
- Ejecutar `pytest tests/test_session_cycle_diagnostics.py -v` y confirmar 18/18 passing.
- Verificar que los tres diagnósticos de microciclo (s065-s074, s075-s084, s085-s094) existen bajo `data/out/local/sessions/06_diagnoses/micro-ciclo/`.
- Verificar que el diagnóstico de mesociclo s065-s094 existe bajo `data/out/local/sessions/06_diagnoses/meso-ciclo/`.
- Ejecutar `pytest tests -q` y confirmar salida limpia sin fallos legacy (s64/s65/s69 resueltos).
- Confirmar reverse autoritativo con `Rejected: 0` para los cambios de s98 y s99.
- Verificar que los enums usados pertenecen al contrato activo `estructura_de_commits_tiddly-data-converter.JSON` v2.1.0.
- Confirmar que `tests/fixtures/canon_policy_bundle.json` está trackeado en git.

---

## Notas para el revisor

Este PR integra 8 sesiones que forman dos sub-arcos distintos pero secuencialmente dependientes:

**Sub-arco 1 (s92-s94): Seguridad + CI + Gobernanza**. El hardening secretless de s92 elimina la superficie de exposición de secrets; s93 confirma el resultado en CodeQL y extiende el CI a `m04`; s94 cierra la causa raíz del fallo `Go · canon` y formaliza la gobernanza de rutas como contrato ejecutable. Este sub-arco no puede integrarse parcialmente: s93 depende del estado dejado por s92 y s94 completa el diagnóstico de CI que s93 abrió.

**Sub-arco 2 (s95-s99): Diagnóstica + Relacional + Tests**. Las sesiones s95-s97 construyen la infraestructura de diagnóstico de ciclos (micro → meso → gobernanza de procedencia). S98 extiende el pipeline relacional apoyándose en el estado estable del canon post-s94. S99 cierra la deuda de tests que impedía un `pytest tests -q` limpio, condición necesaria para que el CI Python sea honesto en el futuro.

El contrato JSON `estructura_de_commits_tiddly-data-converter.JSON` no fue modificado. Sigue siendo la fuente de verdad contractual en versión 2.1.0.

**Nota sobre s97 doble**: s97 tiene dos artefactos de balance bajo nombres distintos (`diagnostic-provenance-governance-and-meso-cycle-s065-s094` y `formalizacion-gobernanza-procedencia-diagnostica`), correspondientes a dos entregas de la misma sesión: el mesociclo y la regla de vigencia. Ambos son parte de s97.

**Nota sobre s96**: sesión de diagnóstico puro. No modificó código, scripts ni instrucciones. Su contribución son los artefactos de microciclo bajo `06_diagnoses/micro-ciclo/` que habilitan el mesociclo de s97.

La deuda pendiente más relevante: integrar `pytest` en CI ordinario requiere resolver cómo proveer `data/out/local/` en el runner o crear fixtures autocontenidos. Eso queda como frontera natural de la sesión siguiente a s99.