### PR TITLE
feat(pipeline): implementa sync bilateral gobernada OneDrive con pull remoto controlado y admisión de staging

### DIFF
--- a/estructura.txt
+++ b/estructura.txt
@@ -23,265 +23,1035 @@
 │   ├── in
 │   │   └── objeto_de_estudio_trazabilidad_y_desarrollo.html
 │   ├── out
-│   │   └── local
-│   │       ├── ai
-│   │       │   ├── chunks_ai_1.jsonl
-│   │       │   ├── chunks_ai_2.jsonl
-│   │       │   ├── chunks_ai_3.jsonl
-│   │       │   ├── manifest.json
-│   │       │   ├── reports
-│   │       │   │   ├── chunk_qc_report.json
-│   │       │   │   ├── classification_report.json
-│   │       │   │   ├── derivation_report.json
-│   │       │   │   ├── relations_qc_report.json
-│   │       │   │   └── retrieval_qc_report.json
-│   │       │   ├── tiddlers_ai_1.jsonl
-│   │       │   ├── tiddlers_ai_10.jsonl
-│   │       │   ├── tiddlers_ai_2.jsonl
-│   │       │   ├── tiddlers_ai_3.jsonl
-│   │       │   ├── tiddlers_ai_4.jsonl
-│   │       │   ├── tiddlers_ai_5.jsonl
-│   │       │   ├── tiddlers_ai_6.jsonl
-│   │       │   ├── tiddlers_ai_7.jsonl
-│   │       │   ├── tiddlers_ai_8.jsonl
-│   │       │   └── tiddlers_ai_9.jsonl
-│   │       ├── audit
-│   │       │   ├── applied_safe_fixes.json
-│   │       │   ├── audit_log.jsonl
-│   │       │   ├── compliance_report.json
-│   │       │   ├── compliance_summary.md
-│   │       │   ├── manifest.json
-│   │       │   ├── manual_review_queue.jsonl
-│   │       │   ├── pre_post_diff.json
-│   │       │   ├── proposed_fixes.json
-│   │       │   ├── s85_capa2_stale_target_classification.json
-│   │       │   ├── s85_session_admission_before_after.json
-│   │       │   └── warnings.jsonl
-│   │       ├── enriched
-│   │       │   ├── manifest.json
-│   │       │   ├── tiddlers_enriched_1.jsonl
-│   │       │   ├── tiddlers_enriched_10.jsonl
-│   │       │   ├── tiddlers_enriched_2.jsonl
-│   │       │   ├── tiddlers_enriched_3.jsonl
-│   │       │   ├── tiddlers_enriched_4.jsonl
-│   │       │   ├── tiddlers_enriched_5.jsonl
-│   │       │   ├── tiddlers_enriched_6.jsonl
-│   │       │   ├── tiddlers_enriched_7.jsonl
-│   │       │   ├── tiddlers_enriched_8.jsonl
-│   │       │   └── tiddlers_enriched_9.jsonl
-│   │       ├── export
-│   │       │   ├── s33-export-log.jsonl
-│   │       │   ├── s33-functional-tiddlers.jsonl
-│   │       │   └── s33-manifest.json
-│   │       ├── microsoft_copilot
-│   │       │   ├── artifacts.csv
-│   │       │   ├── bundles
-│   │       │   │   ├── governance_core.txt
-│   │       │   │   ├── pipeline_and_layers.txt
-│   │       │   │   └── recent_sessions.txt
-│   │       │   ├── copilot_agent
-│   │       │   │   ├── corpus.txt
-│   │       │   │   ├── entities.json
-│   │       │   │   └── relations.csv
-│   │       │   ├── coverage.csv
-│   │       │   ├── edges.csv
-│   │       │   ├── entities.json
-│   │       │   ├── manifest.json
-│   │       │   ├── navigation_index.json
-│   │       │   ├── nodes.csv
-│   │       │   ├── overview.txt
-│   │       │   ├── reading_guide.txt
-│   │       │   ├── source_arbitration_report.json
-│   │       │   ├── spec
-│   │       │   │   ├── checklist_global_s61.md
-│   │       │   │   ├── memoria_decisiones_s61.md
-│   │       │   │   ├── plan_de_implementacion_s61.md
-│   │       │   │   └── summaries
-│   │       │   │       ├── contratos-instructions.json
-│   │       │   │       ├── contratos-instructions.md
-│   │       │   │       ├── contratos-s58-s59-s60.json
-│   │       │   │       ├── contratos-s58-s59-s60.md
-│   │       │   │       ├── dependencia-y-superficie-externa.json
-│   │       │   │       ├── dependencia-y-superficie-externa.md
-│   │       │   │       ├── desarrollo-y-evolucion.json
-│   │       │   │       ├── desarrollo-y-evolucion.md
-│   │       │   │       ├── detalles-del-tema.json
-│   │       │   │       ├── detalles-del-tema.md
-│   │       │   │       ├── elementos-especificos.json
-│   │       │   │       ├── elementos-especificos.md
-│   │       │   │       ├── glosario-y-convenciones.json
-│   │       │   │       ├── glosario-y-convenciones.md
-│   │       │   │       ├── hipotesis.json
-│   │       │   │       ├── hipotesis.md
-│   │       │   │       ├── microsoft-support-formats.json
-│   │       │   │       ├── microsoft-support-formats.md
-│   │       │   │       ├── politica-de-memoria-activa.json
-│   │       │   │       ├── politica-de-memoria-activa.md
-│   │       │   │       ├── prcommits.json
-│   │       │   │       ├── prcommits.md
-│   │       │   │       ├── principios-de-gestion.json
-│   │       │   │       ├── principios-de-gestion.md
-│   │       │   │       ├── procedencia-epistemologica.json
-│   │       │   │       ├── procedencia-epistemologica.md
-│   │       │   │       ├── protocolo-de-sesion.json
-│   │       │   │       ├── protocolo-de-sesion.md
-│   │       │   │       ├── repo-y-derivados-actuales.json
-│   │       │   │       ├── repo-y-derivados-actuales.md
-│   │       │   │       ├── sesiones.json
-│   │       │   │       ├── sesiones.md
-│   │       │   │       ├── tiddlers-sesiones.json
-│   │       │   │       └── tiddlers-sesiones.md
-│   │       │   └── topics.json
-│   │       ├── pipeline
-│   │       │   ├── canon.entries.json
-│   │       │   ├── canon.jsonl
-│   │       │   ├── ingesta.tiddlers.json
-│   │       │   └── raw.tiddlers.json
-│   │       ├── reverse_html
-│   │       │   ├── reverse-report.json
-│   │       │   └── tiddly-data-converter.derived.html
-│   │       ├── sessions
-│   │       │   ├── 00_contratos
-│   │       │   │   ├── m04-s79-rust-kernel-role-vocabulary-alignment-and-semantic-contract-hardening-v0.md.json
-│   │       │   │   ├── m04-s80-unclassified-residual-mapping-and-contract-propagation-hardening-v0.md.json
-│   │       │   │   ├── m04-s81-document-context-rebaseline-hardening-and-technical-report-sync-v0.md.json
-│   │       │   │   ├── m04-s82-relation-self-reference-cleanup-and-policy-contract-path-hardening-v0.md.json
-│   │       │   │   ├── m04-s83-relation-materialization-sessions-path-migration-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s84-embedded-relations-pipeline-exposure-and-audited-downstream-propagation-v0.md.json
-│   │       │   │   ├── m04-s85-stale-layer2-target-resolution-diagnostic-admission-normalization-and-policy-loader-hardening-v0.md.json
-│   │       │   │   ├── m04-s86-local-remote-read-root-alignment-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s87-remote-mirror-and-env-contract-v0.md.json
-│   │       │   │   ├── m04-s88-remote-first-out-local-mirror-and-env-contract-formalization-v0.md.json
-│   │       │   │   ├── m04-s89-local-mcp-menu-and-env-management-integration-v0.md.json
-│   │       │   │   ├── m04-s90-mcp-menu-ux-improvements-v0.md.json
-│   │       │   │   ├── m04-s91-terminal-cat-states-ui-seed.md.json
-│   │       │   │   ├── m04-s92-hardening-mcp-env-manager-secretless-runtime-v0.md.json
-│   │       │   │   ├── m04-s93-ci-codeql-canon-greenline.md.json
-│   │       │   │   ├── policy
-│   │       │   │   │   ├── canon_policy_bundle.json
-│   │       │   │   │   └── estructura_de_commits_tiddly-data-converter.JSON
-│   │       │   │   └── projections
-│   │       │   │       └── derived_layers_registry.json
-│   │       │   ├── 01_procedencia
-│   │       │   │   ├── m04-s79-rust-kernel-role-vocabulary-alignment-and-semantic-contract-hardening-v0.md.json
-│   │       │   │   ├── m04-s80-unclassified-residual-mapping-and-contract-propagation-hardening-v0.md.json
-│   │       │   │   ├── m04-s81-document-context-rebaseline-hardening-and-technical-report-sync-v0.md.json
-│   │       │   │   ├── m04-s82-relation-self-reference-cleanup-and-policy-contract-path-hardening-v0.md.json
-│   │       │   │   ├── m04-s83-relation-materialization-sessions-path-migration-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s84-embedded-relations-pipeline-exposure-and-audited-downstream-propagation-v0.md.json
-│   │       │   │   ├── m04-s85-stale-layer2-target-resolution-diagnostic-admission-normalization-and-policy-loader-hardening-v0.md.json
-│   │       │   │   ├── m04-s86-local-remote-read-root-alignment-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s87-remote-mirror-and-env-contract-v0.md.json
-│   │       │   │   ├── m04-s88-remote-first-out-local-mirror-and-env-contract-formalization-v0.md.json
-│   │       │   │   ├── m04-s89-local-mcp-menu-and-env-management-integration-v0.md.json
-│   │       │   │   ├── m04-s90-mcp-menu-ux-improvements-v0.md.json
-│   │       │   │   ├── m04-s91-terminal-cat-states-ui-seed.md.json
-│   │       │   │   ├── m04-s92-hardening-mcp-env-manager-secretless-runtime-v0.md.json
-│   │       │   │   └── m04-s93-ci-codeql-canon-greenline.md.json
-│   │       │   ├── 02_detalles_de_sesion
-│   │       │   │   ├── m04-s79-rust-kernel-role-vocabulary-alignment-and-semantic-contract-hardening-v0.md.json
-│   │       │   │   ├── m04-s80-unclassified-residual-mapping-and-contract-propagation-hardening-v0.md.json
-│   │       │   │   ├── m04-s81-document-context-rebaseline-hardening-and-technical-report-sync-v0.md.json
-│   │       │   │   ├── m04-s82-relation-self-reference-cleanup-and-policy-contract-path-hardening-v0.md.json
-│   │       │   │   ├── m04-s83-relation-materialization-sessions-path-migration-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s84-embedded-relations-pipeline-exposure-and-audited-downstream-propagation-v0.md.json
-│   │       │   │   ├── m04-s85-stale-layer2-target-resolution-diagnostic-admission-normalization-and-policy-loader-hardening-v0.md.json
-│   │       │   │   ├── m04-s86-local-remote-read-root-alignment-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s87-remote-mirror-and-env-contract-v0.md.json
-│   │       │   │   ├── m04-s88-remote-first-out-local-mirror-and-env-contract-formalization-v0.md.json
-│   │       │   │   ├── m04-s89-local-mcp-menu-and-env-management-integration-v0.md.json
-│   │       │   │   ├── m04-s90-mcp-menu-ux-improvements-v0.md.json
-│   │       │   │   ├── m04-s91-terminal-cat-states-ui-seed.md.json
-│   │       │   │   ├── m04-s92-hardening-mcp-env-manager-secretless-runtime-v0.md.json
-│   │       │   │   └── m04-s93-ci-codeql-canon-greenline.md.json
-│   │       │   ├── 03_hipotesis
-│   │       │   │   ├── m04-s79-rust-kernel-role-vocabulary-alignment-and-semantic-contract-hardening-v0.md.json
-│   │       │   │   ├── m04-s80-unclassified-residual-mapping-and-contract-propagation-hardening-v0.md.json
-│   │       │   │   ├── m04-s81-document-context-rebaseline-hardening-and-technical-report-sync-v0.md.json
-│   │       │   │   ├── m04-s82-relation-self-reference-cleanup-and-policy-contract-path-hardening-v0.md.json
-│   │       │   │   ├── m04-s83-relation-materialization-sessions-path-migration-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s84-embedded-relations-pipeline-exposure-and-audited-downstream-propagation-v0.md.json
-│   │       │   │   ├── m04-s85-stale-layer2-target-resolution-diagnostic-admission-normalization-and-policy-loader-hardening-v0.md.json
-│   │       │   │   ├── m04-s86-local-remote-read-root-alignment-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s87-remote-mirror-and-env-contract-v0.md.json
-│   │       │   │   ├── m04-s88-remote-first-out-local-mirror-and-env-contract-formalization-v0.md.json
-│   │       │   │   ├── m04-s89-local-mcp-menu-and-env-management-integration-v0.md.json
-│   │       │   │   ├── m04-s90-mcp-menu-ux-improvements-v0.md.json
-│   │       │   │   ├── m04-s91-terminal-cat-states-ui-seed.md.json
-│   │       │   │   ├── m04-s92-hardening-mcp-env-manager-secretless-runtime-v0.md.json
-│   │       │   │   └── m04-s93-ci-codeql-canon-greenline.md.json
-│   │       │   ├── 04_balance_de_sesion
-│   │       │   │   ├── m04-s79-rust-kernel-role-vocabulary-alignment-and-semantic-contract-hardening-v0.md.json
-│   │       │   │   ├── m04-s80-unclassified-residual-mapping-and-contract-propagation-hardening-v0.md.json
-│   │       │   │   ├── m04-s81-document-context-rebaseline-hardening-and-technical-report-sync-v0.md.json
-│   │       │   │   ├── m04-s82-relation-self-reference-cleanup-and-policy-contract-path-hardening-v0.md.json
-│   │       │   │   ├── m04-s83-relation-materialization-sessions-path-migration-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s84-embedded-relations-pipeline-exposure-and-audited-downstream-propagation-v0.md.json
-│   │       │   │   ├── m04-s85-stale-layer2-target-resolution-diagnostic-admission-normalization-and-policy-loader-hardening-v0.md.json
-│   │       │   │   ├── m04-s86-local-remote-read-root-alignment-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s87-remote-mirror-and-env-contract-v0.md.json
-│   │       │   │   ├── m04-s88-remote-first-out-local-mirror-and-env-contract-formalization-v0.md.json
-│   │       │   │   ├── m04-s89-local-mcp-menu-and-env-management-integration-v0.md.json
-│   │       │   │   ├── m04-s90-mcp-menu-ux-improvements-v0.md.json
-│   │       │   │   ├── m04-s91-terminal-cat-states-ui-seed.md.json
-│   │       │   │   ├── m04-s92-hardening-mcp-env-manager-secretless-runtime-v0.md.json
-│   │       │   │   └── m04-s93-ci-codeql-canon-greenline.md.json
-│   │       │   ├── 05_propuesta_de_sesion
-│   │       │   │   ├── m04-s79-rust-kernel-role-vocabulary-alignment-and-semantic-contract-hardening-v0.md.json
-│   │       │   │   ├── m04-s80-unclassified-residual-mapping-and-contract-propagation-hardening-v0.md.json
-│   │       │   │   ├── m04-s81-document-context-rebaseline-hardening-and-technical-report-sync-v0.md.json
-│   │       │   │   ├── m04-s82-relation-self-reference-cleanup-and-policy-contract-path-hardening-v0.md.json
-│   │       │   │   ├── m04-s83-relation-materialization-sessions-path-migration-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s84-embedded-relations-pipeline-exposure-and-audited-downstream-propagation-v0.md.json
-│   │       │   │   ├── m04-s85-stale-layer2-target-resolution-diagnostic-admission-normalization-and-policy-loader-hardening-v0.md.json
-│   │       │   │   ├── m04-s86-local-remote-read-root-alignment-and-universal-session-canonization-v0.md.json
-│   │       │   │   ├── m04-s87-remote-mirror-and-env-contract-v0.md.json
-│   │       │   │   ├── m04-s88-remote-first-out-local-mirror-and-env-contract-formalization-v0.md.json
-│   │       │   │   ├── m04-s89-local-mcp-menu-and-env-management-integration-v0.md.json
-│   │       │   │   ├── m04-s90-mcp-menu-ux-improvements-v0.md.json
-│   │       │   │   ├── m04-s91-terminal-cat-states-ui-seed.md.json
-│   │       │   │   ├── m04-s92-hardening-mcp-env-manager-secretless-runtime-v0.md.json
-│   │       │   │   └── m04-s93-ci-codeql-canon-greenline.md.json
-│   │       │   └── 06_diagnoses
-│   │       │       ├── meso-ciclo
-│   │       │       ├── micro-ciclo
-│   │       │       ├── module
-│   │       │       ├── sesion
-│   │       │       │   ├── m04-s79-rust-kernel-role-vocabulary-alignment-and-semantic-contract-hardening-v0.md.json
-│   │       │       │   ├── m04-s80-unclassified-residual-mapping-and-contract-propagation-hardening-v0.md.json
-│   │       │       │   ├── m04-s81-document-context-rebaseline-hardening-and-technical-report-sync-v0.md.json
-│   │       │       │   ├── m04-s82-relation-self-reference-cleanup-and-policy-contract-path-hardening-v0.md.json
-│   │       │       │   ├── m04-s83-relation-materialization-sessions-path-migration-and-universal-session-canonization-v0.md.json
-│   │       │       │   ├── m04-s84-embedded-relations-pipeline-exposure-and-audited-downstream-propagation-v0.md.json
-│   │       │       │   ├── m04-s85-stale-layer2-target-resolution-diagnostic-admission-normalization-and-policy-loader-hardening-v0.md.json
-│   │       │       │   ├── m04-s86-local-remote-read-root-alignment-and-universal-session-canonization-v0.md.json
-│   │       │       │   ├── m04-s87-remote-mirror-and-env-contract-v0.md.json
-│   │       │       │   ├── m04-s88-remote-first-out-local-mirror-and-env-contract-formalization-v0.md.json
-│   │       │       │   ├── m04-s89-local-mcp-menu-and-env-management-integration-v0.md.json
-│   │       │       │   ├── m04-s90-mcp-menu-ux-improvements-v0.md.json
-│   │       │       │   ├── m04-s91-terminal-cat-states-ui-seed.md.json
-│   │       │       │   ├── m04-s92-hardening-mcp-env-manager-secretless-runtime-v0.md.json
-│   │       │       │   ├── m04-s93-ci-codeql-canon-greenline.md.json
-│   │       │       │   ├── s93-go-canon-test.jsonl
-│   │       │       │   └── s93-go-canon-test.log
-│   │       │       └── tema
-│   │       │           ├── diagnostico-tematico-01-alineacion-de-roles.md.json
-│   │       │           ├── diagnostico-tematico-02-histories-extraibles.md.json
-│   │       │           ├── diagnostico-tematico-03-contexto-documental.md.json
-│   │       │           ├── diagnostico-tematico-04-segmentacion-ontologica-de-unclassified.md.json
-│   │       │           ├── diagnostico-tematico-05-utilidad-de-relaciones.md.json
-│   │       │           └── diagnostico-tematico-06-utilidad-eficiencia-y-practicidad-relacional-post-s83.md.json
-│   │       ├── tiddlers_1.jsonl
-│   │       ├── tiddlers_2.jsonl
-│   │       ├── tiddlers_3.jsonl
-│   │       ├── tiddlers_4.jsonl
-│   │       ├── tiddlers_5.jsonl
-│   │       ├── tiddlers_6.jsonl
-│   │       ├── tiddlers_7.jsonl
-│   │       ├── tiddlers_8.jsonl
-│   │       └── tiddlers_9.jsonl
+│   │   ├── local
+│   │   │   ├── ai
+│   │   │   │   ├── chunks_ai_1.jsonl
+│   │   │   │   ├── chunks_ai_2.jsonl
+│   │   │   │   ├── chunks_ai_3.jsonl
+│   │   │   │   ├── chunks_ai_4.jsonl
+│   │   │   │   ├── chunks_ai_5.jsonl
+│   │   │   │   ├── manifest.json
+│   │   │   │   ├── reports
+│   │   │   │   │   ├── chunk_qc_report.json
+│   │   │   │   │   ├── classification_report.json
+│   │   │   │   │   ├── derivation_report.json
+│   │   │   │   │   ├── relations_qc_report.json
+│   │   │   │   │   └── retrieval_qc_report.json
+│   │   │   │   ├── tiddlers_ai_1.jsonl
+│   │   │   │   ├── tiddlers_ai_10.jsonl
+│   │   │   │   ├── tiddlers_ai_2.jsonl
+│   │   │   │   ├── tiddlers_ai_3.jsonl
+│   │   │   │   ├── tiddlers_ai_4.jsonl
+│   │   │   │   ├── tiddlers_ai_5.jsonl
+│   │   │   │   ├── tiddlers_ai_6.jsonl
+│   │   │   │   ├── tiddlers_ai_7.jsonl
+│   │   │   │   ├── tiddlers_ai_8.jsonl
+│   │   │   │   └── tiddlers_ai_9.jsonl
+│   │   │   ├── audit
+│   │   │   │   ├── applied_safe_fixes.json
+│   │   │   │   ├── audit_log.jsonl
+│   │   │   │   ├── compliance_report.json
+│   │   │   │   ├── compliance_summary.md
+│   │   │   │   ├── manifest.json
+│   │   │   │   ├── manual_review_queue.jsonl
+│   │   │   │   ├── pre_post_diff.json
+│   │   │   │   ├── proposed_fixes.json
+│   │   │   │   ├── s85_capa2_stale_target_classification.json
+│   │   │   │   ├── s85_session_admission_before_after.json
+│   │   │   │   └── warnings.jsonl
+│   │   │   ├── enriched
+│   │   │   │   ├── manifest.json
+│   │   │   │   ├── tiddlers_enriched_1.jsonl
+│   │   │   │   ├── tiddlers_enriched_10.jsonl
+│   │   │   │   ├── tiddlers_enriched_2.jsonl
+│   │   │   │   ├── tiddlers_enriched_3.jsonl
+│   │   │   │   ├── tiddlers_enriched_4.jsonl
+│   │   │   │   ├── tiddlers_enriched_5.jsonl
+│   │   │   │   ├── tiddlers_enriched_6.jsonl
+│   │   │   │   ├── tiddlers_enriched_7.jsonl
+│   │   │   │   ├── tiddlers_enriched_8.jsonl
+│   │   │   │   └── tiddlers_enriched_9.jsonl
+│   │   │   ├── export
+│   │   │   │   ├── s33-export-log.jsonl
+│   │   │   │   ├── s33-functional-tiddlers.jsonl
+│   │   │   │   └── s33-manifest.json
+│   │   │   ├── microsoft_copilot
+│   │   │   │   ├── artifacts.csv
+│   │   │   │   ├── bundles
+│   │   │   │   │   ├── governance_core.txt
+│   │   │   │   │   ├── pipeline_and_layers.txt
+│   │   │   │   │   └── recent_sessions.txt
+│   │   │   │   ├── copilot_agent
+│   │   │   │   │   ├── corpus.txt
+│   │   │   │   │   ├── entities.json
+│   │   │   │   │   └── relations.csv
+│   │   │   │   ├── coverage.csv
+│   │   │   │   ├── edges.csv
+│   │   │   │   ├── entities.json
+│   │   │   │   ├── manifest.json
+│   │   │   │   ├── navigation_index.json
+│   │   │   │   ├── nodes.csv
+│   │   │   │   ├── overview.txt
+│   │   │   │   ├── reading_guide.txt
+│   │   │   │   ├── source_arbitration_report.json
+│   │   │   │   ├── spec
+│   │   │   │   │   ├── checklist_global_s61.md
+│   │   │   │   │   ├── memoria_decisiones_s61.md
+│   │   │   │   │   ├── plan_de_implementacion_s61.md
+│   │   │   │   │   └── summaries
+│   │   │   │   │       ├── contratos-instructions.json
+│   │   │   │   │       ├── contratos-instructions.md
+│   │   │   │   │       ├── contratos-s58-s59-s60.json
+│   │   │   │   │       ├── contratos-s58-s59-s60.md
+│   │   │   │   │       ├── dependencia-y-superficie-externa.json
+│   │   │   │   │       ├── dependencia-y-superficie-externa.md
+│   │   │   │   │       ├── desarrollo-y-evolucion.json
+│   │   │   │   │       ├── desarrollo-y-evolucion.md
+│   │   │   │   │       ├── detalles-del-tema.json
+│   │   │   │   │       ├── detalles-del-tema.md
+│   │   │   │   │       ├── elementos-especificos.json
+│   │   │   │   │       ├── elementos-especificos.md
+│   │   │   │   │       ├── glosario-y-convenciones.json
+│   │   │   │   │       ├── glosario-y-convenciones.md
+│   │   │   │   │       ├── hipotesis.json
+│   │   │   │   │       ├── hipotesis.md
+│   │   │   │   │       ├── microsoft-support-formats.json
+│   │   │   │   │       ├── microsoft-support-formats.md
+│   │   │   │   │       ├── politica-de-memoria-activa.json
+│   │   │   │   │       ├── politica-de-memoria-activa.md
+│   │   │   │   │       ├── prcommits.json
+│   │   │   │   │       ├── prcommits.md
+│   │   │   │   │       ├── principios-de-gestion.json
+│   │   │   │   │       ├── principios-de-gestion.md
+│   │   │   │   │       ├── procedencia-epistemologica.json
+│   │   │   │   │       ├── procedencia-epistemologica.md
+│   │   │   │   │       ├── protocolo-de-sesion.json
+│   │   │   │   │       ├── protocolo-de-sesion.md
+│   │   │   │   │       ├── repo-y-derivados-actuales.json
+│   │   │   │   │       ├── repo-y-derivados-actuales.md
+│   │   │   │   │       ├── sesiones.json
+│   │   │   │   │       ├── sesiones.md
+│   │   │   │   │       ├── tiddlers-sesiones.json
+│   │   │   │   │       └── tiddlers-sesiones.md
+│   │   │   │   └── topics.json
+│   │   │   ├── pipeline
+│   │   │   ├── reverse_html
+│   │   │   │   ├── reverse-report.json
+│   │   │   │   └── tiddly-data-converter.derived.html
+│   │   │   ├── sessions
+│   │   │   │   ├── 00_contratos
+│   │   │   │   │   ├── m04-s97-diagnostic-provenance-governance-and-meso-cycle-s065-s094.md.json
+│   │   │   │   │   ├── m04-s97-formalizacion-gobernanza-procedencia-diagnostica.md.json
+│   │   │   │   │   ├── m04-s98-propagacion-relacional-chunks-ai-y-rule23.md.json
+│   │   │   │   │   ├── m04-s99-saneamiento-tests-legacy-y-flujo-ci-actual.md.json
+│   │   │   │   │   ├── policy
+│   │   │   │   │   │   ├── canon_policy_bundle.json
+│   │   │   │   │   │   └── estructura_de_commits_tiddly-data-converter.JSON
+│   │   │   │   │   └── projections
+│   │   │   │   │       └── derived_layers_registry.json
+│   │   │   │   ├── 01_procedencia
+│   │   │   │   │   ├── m04-s97-diagnostic-provenance-governance-and-meso-cycle-s065-s094.md.json
+│   │   │   │   │   ├── m04-s97-formalizacion-gobernanza-procedencia-diagnostica.md.json
+│   │   │   │   │   ├── m04-s98-propagacion-relacional-chunks-ai-y-rule23.md.json
+│   │   │   │   │   └── m04-s99-saneamiento-tests-legacy-y-flujo-ci-actual.md.json
+│   │   │   │   ├── 02_detalles_de_sesion
+│   │   │   │   │   ├── m04-s97-diagnostic-provenance-governance-and-meso-cycle-s065-s094.md.json
+│   │   │   │   │   ├── m04-s97-formalizacion-gobernanza-procedencia-diagnostica.md.json
+│   │   │   │   │   ├── m04-s98-propagacion-relacional-chunks-ai-y-rule23.md.json
+│   │   │   │   │   └── m04-s99-saneamiento-tests-legacy-y-flujo-ci-actual.md.json
+│   │   │   │   ├── 03_hipotesis
+│   │   │   │   │   ├── m04-s97-diagnostic-provenance-governance-and-meso-cycle-s065-s094.md.json
+│   │   │   │   │   ├── m04-s97-formalizacion-gobernanza-procedencia-diagnostica.md.json
+│   │   │   │   │   ├── m04-s98-propagacion-relacional-chunks-ai-y-rule23.md.json
+│   │   │   │   │   └── m04-s99-saneamiento-tests-legacy-y-flujo-ci-actual.md.json
+│   │   │   │   ├── 04_balance_de_sesion
+│   │   │   │   │   ├── m04-s97-diagnostic-provenance-governance-and-meso-cycle-s065-s094.md.json
+│   │   │   │   │   ├── m04-s97-formalizacion-gobernanza-procedencia-diagnostica.md.json
+│   │   │   │   │   ├── m04-s98-propagacion-relacional-chunks-ai-y-rule23.md.json
+│   │   │   │   │   └── m04-s99-saneamiento-tests-legacy-y-flujo-ci-actual.md.json
+│   │   │   │   ├── 05_propuesta_de_sesion
+│   │   │   │   │   ├── m04-s97-diagnostic-provenance-governance-and-meso-cycle-s065-s094.md.json
+│   │   │   │   │   ├── m04-s97-formalizacion-gobernanza-procedencia-diagnostica.md.json
+│   │   │   │   │   ├── m04-s98-propagacion-relacional-chunks-ai-y-rule23.md.json
+│   │   │   │   │   └── m04-s99-saneamiento-tests-legacy-y-flujo-ci-actual.md.json
+│   │   │   │   └── 06_diagnoses
+│   │   │   │       ├── meso-ciclo
+│   │   │   │       │   ├── m04-meso-ciclo-s005-s034-diagnostico.md.json
+│   │   │   │       │   ├── m04-meso-ciclo-s035-s064-diagnostico.md.json
+│   │   │   │       │   └── m04-meso-ciclo-s065-s094-diagnostico.md.json
+│   │   │   │       ├── micro-ciclo
+│   │   │   │       │   ├── m04-micro-ciclo-s001-s004-diagnostico.md.json
+│   │   │   │       │   ├── m04-micro-ciclo-s005-s014-diagnostico.md.json
+│   │   │   │       │   ├── m04-micro-ciclo-s015-s024-diagnostico.md.json
+│   │   │   │       │   ├── m04-micro-ciclo-s025-s034-diagnostico.md.json
+│   │   │   │       │   ├── m04-micro-ciclo-s035-s044-diagnostico.md.json
+│   │   │   │       │   ├── m04-micro-ciclo-s045-s054-diagnostico.md.json
+│   │   │   │       │   ├── m04-micro-ciclo-s055-s064-diagnostico.md.json
+│   │   │   │       │   ├── m04-micro-ciclo-s065-s074-diagnostico.md.json
+│   │   │   │       │   ├── m04-micro-ciclo-s075-s084-diagnostico.md.json
+│   │   │   │       │   └── m04-micro-ciclo-s085-s094-diagnostico.md.json
+│   │   │   │       ├── module
+│   │   │   │       ├── proyecto
+│   │   │   │       │   └── m04 diagnostico-global-proyecto-post-s097.md.json
+│   │   │   │       ├── sesion
+│   │   │   │       │   ├── m04-s97-diagnostic-provenance-governance-and-meso-cycle-s065-s094.md.json
+│   │   │   │       │   ├── m04-s97-formalizacion-gobernanza-procedencia-diagnostica.md.json
+│   │   │   │       │   ├── m04-s98-propagacion-relacional-chunks-ai-y-rule23.md.json
+│   │   │   │       │   └── m04-s99-saneamiento-tests-legacy-y-flujo-ci-actual.md.json
+│   │   │   │       └── tema
+│   │   │   │           ├── diagnostico-tematico-01-alineacion-de-roles.md.json
+│   │   │   │           ├── diagnostico-tematico-02-histories-extraibles.md.json
+│   │   │   │           ├── diagnostico-tematico-03-contexto-documental.md.json
+│   │   │   │           ├── diagnostico-tematico-04-segmentacion-ontologica-de-unclassified.md.json
+│   │   │   │           ├── diagnostico-tematico-05-utilidad-de-relaciones.md.json
+│   │   │   │           ├── diagnostico-tematico-06-utilidad-eficiencia-y-practicidad-relacional-post-s83.md.json
+│   │   │   │           └── diagnostico-tematico-07-validacion-capa2-relacional-stale-slugs-canon-vivo.md.json
+│   │   │   ├── tiddlers_1.jsonl
+│   │   │   ├── tiddlers_2.jsonl
+│   │   │   ├── tiddlers_3.jsonl
+│   │   │   ├── tiddlers_4.jsonl
+│   │   │   ├── tiddlers_5.jsonl
+│   │   │   ├── tiddlers_6.jsonl
+│   │   │   ├── tiddlers_7.jsonl
+│   │   │   ├── tiddlers_8.jsonl
+│   │   │   └── tiddlers_9.jsonl
+│   │   └── remote
 │   ├── README.md
 │   └── tmp
+│       ├── admissions
+│       │   ├── admit-20260505154934-multi-session.json
+│       │   ├── admit-20260505154952-multi-session.json
+│       │   ├── admit-20260505164144-multi-session.json
+│       │   ├── admit-20260505164204-multi-session.json
+│       │   ├── admit-20260505184842-multi-session.json
+│       │   ├── admit-20260505184909-multi-session.json
+│       │   ├── admit-20260505190857-multi-session.json
+│       │   ├── admit-20260505190913-multi-session.json
+│       │   ├── admit-20260505204019-multi-session.json
+│       │   ├── admit-20260505204050-multi-session.json
+│       │   ├── admit-20260505210412-multi-session.json
+│       │   ├── admit-20260505210443-multi-session.json
+│       │   ├── admit-20260506002535-multi-session.json
+│       │   ├── admit-20260506002548-multi-session.json
+│       │   ├── backups
+│       │   │   ├── admit-20260505154952-multi-session
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── admit-20260505164204-multi-session
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── admit-20260505184909-multi-session
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── admit-20260505190913-multi-session
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── admit-20260505204050-multi-session
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── admit-20260505210443-multi-session
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── admit-20260506002548-multi-session
+│       │   │       ├── tiddlers_1.jsonl
+│       │   │       ├── tiddlers_2.jsonl
+│       │   │       ├── tiddlers_3.jsonl
+│       │   │       ├── tiddlers_4.jsonl
+│       │   │       ├── tiddlers_5.jsonl
+│       │   │       ├── tiddlers_6.jsonl
+│       │   │       ├── tiddlers_7.jsonl
+│       │   │       ├── tiddlers_8.jsonl
+│       │   │       └── tiddlers_9.jsonl
+│       │   └── s69_unittest
+│       │       ├── admit-20260505213555-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213556-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213557-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213559-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213604-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213613-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213621-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213714-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213716-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213719-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213721-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213724-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213733-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213742-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213805-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213806-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213808-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213810-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213814-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213824-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── admit-20260505213832-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── backups
+│       │       │   ├── admit-20260505213621-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │       │   │   ├── tiddlers_1.jsonl
+│       │       │   │   ├── tiddlers_2.jsonl
+│       │       │   │   ├── tiddlers_3.jsonl
+│       │       │   │   ├── tiddlers_4.jsonl
+│       │       │   │   ├── tiddlers_5.jsonl
+│       │       │   │   ├── tiddlers_6.jsonl
+│       │       │   │   ├── tiddlers_7.jsonl
+│       │       │   │   ├── tiddlers_8.jsonl
+│       │       │   │   └── tiddlers_9.jsonl
+│       │       │   ├── admit-20260505213742-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │       │   │   ├── tiddlers_1.jsonl
+│       │       │   │   ├── tiddlers_2.jsonl
+│       │       │   │   ├── tiddlers_3.jsonl
+│       │       │   │   ├── tiddlers_4.jsonl
+│       │       │   │   ├── tiddlers_5.jsonl
+│       │       │   │   ├── tiddlers_6.jsonl
+│       │       │   │   ├── tiddlers_7.jsonl
+│       │       │   │   ├── tiddlers_8.jsonl
+│       │       │   │   └── tiddlers_9.jsonl
+│       │       │   ├── admit-20260505213832-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │       │   │   ├── tiddlers_1.jsonl
+│       │       │   │   ├── tiddlers_2.jsonl
+│       │       │   │   ├── tiddlers_3.jsonl
+│       │       │   │   ├── tiddlers_4.jsonl
+│       │       │   │   ├── tiddlers_5.jsonl
+│       │       │   │   ├── tiddlers_6.jsonl
+│       │       │   │   ├── tiddlers_7.jsonl
+│       │       │   │   ├── tiddlers_8.jsonl
+│       │       │   │   └── tiddlers_9.jsonl
+│       │       │   ├── rollback-20260505213629-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │       │   │   ├── tiddlers_1.jsonl
+│       │       │   │   ├── tiddlers_2.jsonl
+│       │       │   │   ├── tiddlers_3.jsonl
+│       │       │   │   ├── tiddlers_4.jsonl
+│       │       │   │   ├── tiddlers_5.jsonl
+│       │       │   │   ├── tiddlers_6.jsonl
+│       │       │   │   ├── tiddlers_7.jsonl
+│       │       │   │   ├── tiddlers_8.jsonl
+│       │       │   │   └── tiddlers_9.jsonl
+│       │       │   ├── rollback-20260505213752-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │       │   │   ├── tiddlers_1.jsonl
+│       │       │   │   ├── tiddlers_2.jsonl
+│       │       │   │   ├── tiddlers_3.jsonl
+│       │       │   │   ├── tiddlers_4.jsonl
+│       │       │   │   ├── tiddlers_5.jsonl
+│       │       │   │   ├── tiddlers_6.jsonl
+│       │       │   │   ├── tiddlers_7.jsonl
+│       │       │   │   ├── tiddlers_8.jsonl
+│       │       │   │   └── tiddlers_9.jsonl
+│       │       │   └── rollback-20260505213840-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │       │       ├── tiddlers_1.jsonl
+│       │       │       ├── tiddlers_2.jsonl
+│       │       │       ├── tiddlers_3.jsonl
+│       │       │       ├── tiddlers_4.jsonl
+│       │       │       ├── tiddlers_5.jsonl
+│       │       │       ├── tiddlers_6.jsonl
+│       │       │       ├── tiddlers_7.jsonl
+│       │       │       ├── tiddlers_8.jsonl
+│       │       │       └── tiddlers_9.jsonl
+│       │       ├── rollback-20260505213629-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── rollback-20260505213752-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── rollback-20260505213840-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── validate-20260505213600-missing-source-path.json
+│       │       ├── validate-20260505213612-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── validate-20260505213722-missing-source-path.json
+│       │       ├── validate-20260505213733-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │       ├── validate-20260505213812-missing-source-path.json
+│       │       └── validate-20260505213823-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       ├── canonical_quality
+│       │   └── quality-20260505185713
+│       │       ├── canonical-line-gate.json
+│       │       └── deep-node-inspect.json
+│       ├── html_export
+│       │   ├── export-20260505154840
+│       │   │   ├── tiddlers.export.log
+│       │   │   └── tiddlers.export.manifest.json
+│       │   ├── export-20260505163004
+│       │   │   ├── tiddlers.export.log
+│       │   │   └── tiddlers.export.manifest.json
+│       │   ├── export-20260505184712
+│       │   │   ├── tiddlers.export.jsonl
+│       │   │   ├── tiddlers.export.log
+│       │   │   └── tiddlers.export.manifest.json
+│       │   ├── export-20260505203845
+│       │   │   ├── tiddlers.export.log
+│       │   │   └── tiddlers.export.manifest.json
+│       │   ├── export-20260505204854
+│       │   │   ├── tiddlers.export.jsonl
+│       │   │   ├── tiddlers.export.log
+│       │   │   └── tiddlers.export.manifest.json
+│       │   └── export-20260505205508
+│       │       ├── tiddlers.export.jsonl
+│       │       ├── tiddlers.export.log
+│       │       └── tiddlers.export.manifest.json
+│       ├── reconstruction
+│       │   ├── diagnostic-20260505154831
+│       │   │   └── gate-report.json
+│       │   ├── diagnostic-20260505162948
+│       │   │   └── gate-report.json
+│       │   ├── diagnostic-20260505184708
+│       │   │   └── gate-report.json
+│       │   ├── diagnostic-20260505203841
+│       │   │   └── gate-report.json
+│       │   ├── diagnostic-20260505204850
+│       │   │   └── gate-report.json
+│       │   ├── diagnostic-20260505205505
+│       │   │   └── gate-report.json
+│       │   ├── export-20260505154840
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── export-20260505163004
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── export-20260505184712
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── export-20260505203845
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── export-20260505204854
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── export-20260505205508
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reconstruction-20260505154903
+│       │   │   ├── canon_after
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── canon_before
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reconstruction-20260505164112
+│       │   │   ├── canon_after
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── canon_before
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reconstruction-20260505184727
+│       │   │   ├── canon_after
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── canon_before
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reconstruction-20260505203914
+│       │   │   ├── canon_after
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── canon_before
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reconstruction-20260505204907
+│       │   │   ├── canon_after
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── canon_before
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reverse-20260505155050
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reverse-20260505164225
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reverse-20260505184923
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reverse-20260505204318
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reverse-20260505204420
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reverse-20260505204959
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   ├── reverse-20260505210510
+│       │   │   ├── gate-report.json
+│       │   │   └── reconstruction-report.json
+│       │   └── reverse-20260506002712
+│       │       ├── gate-report.json
+│       │       └── reconstruction-report.json
+│       ├── session_admission
+│       │   ├── admit-20260505154934-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505154934-multi-session.derived.html
+│       │   │       └── admit-20260505154934-multi-session.reverse-report.json
+│       │   ├── admit-20260505154952-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505154952-multi-session.derived.html
+│       │   │       └── admit-20260505154952-multi-session.reverse-report.json
+│       │   ├── admit-20260505164144-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505164144-multi-session.derived.html
+│       │   │       └── admit-20260505164144-multi-session.reverse-report.json
+│       │   ├── admit-20260505164204-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505164204-multi-session.derived.html
+│       │   │       └── admit-20260505164204-multi-session.reverse-report.json
+│       │   ├── admit-20260505184842-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505184842-multi-session.derived.html
+│       │   │       └── admit-20260505184842-multi-session.reverse-report.json
+│       │   ├── admit-20260505184909-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505184909-multi-session.derived.html
+│       │   │       └── admit-20260505184909-multi-session.reverse-report.json
+│       │   ├── admit-20260505190857-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505190857-multi-session.derived.html
+│       │   │       └── admit-20260505190857-multi-session.reverse-report.json
+│       │   ├── admit-20260505190913-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505190913-multi-session.derived.html
+│       │   │       └── admit-20260505190913-multi-session.reverse-report.json
+│       │   ├── admit-20260505204019-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505204019-multi-session.derived.html
+│       │   │       └── admit-20260505204019-multi-session.reverse-report.json
+│       │   ├── admit-20260505204050-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505204050-multi-session.derived.html
+│       │   │       └── admit-20260505204050-multi-session.reverse-report.json
+│       │   ├── admit-20260505210412-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505210412-multi-session.derived.html
+│       │   │       └── admit-20260505210412-multi-session.reverse-report.json
+│       │   ├── admit-20260505210443-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505210443-multi-session.derived.html
+│       │   │       └── admit-20260505210443-multi-session.reverse-report.json
+│       │   ├── admit-20260506002535-multi-session
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260506002535-multi-session.derived.html
+│       │   │       └── admit-20260506002535-multi-session.reverse-report.json
+│       │   └── admit-20260506002548-multi-session
+│       │       ├── admission_lines.normalized.jsonl
+│       │       ├── admission_lines.raw.jsonl
+│       │       ├── canon
+│       │       │   ├── tiddlers_1.jsonl
+│       │       │   ├── tiddlers_2.jsonl
+│       │       │   ├── tiddlers_3.jsonl
+│       │       │   ├── tiddlers_4.jsonl
+│       │       │   ├── tiddlers_5.jsonl
+│       │       │   ├── tiddlers_6.jsonl
+│       │       │   ├── tiddlers_7.jsonl
+│       │       │   ├── tiddlers_8.jsonl
+│       │       │   └── tiddlers_9.jsonl
+│       │       └── reverse_html
+│       │           ├── admit-20260506002548-multi-session.derived.html
+│       │           └── admit-20260506002548-multi-session.reverse-report.json
+│       ├── session_admission_s69_unittest
+│       │   ├── admit-20260505213604-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505213604-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260505213604-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260505213613-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505213613-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260505213613-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260505213621-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505213621-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260505213621-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260505213724-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505213724-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260505213724-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260505213733-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505213733-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260505213733-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260505213742-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505213742-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260505213742-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260505213814-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505213814-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260505213814-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260505213824-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505213824-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260505213824-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260505213832-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260505213832-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260505213832-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── rollback-20260505213629-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260505213629-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── rollback-20260505213629-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── rollback-20260505213752-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260505213752-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── rollback-20260505213752-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   └── rollback-20260505213840-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │       ├── canon
+│       │       │   ├── tiddlers_1.jsonl
+│       │       │   ├── tiddlers_2.jsonl
+│       │       │   ├── tiddlers_3.jsonl
+│       │       │   ├── tiddlers_4.jsonl
+│       │       │   ├── tiddlers_5.jsonl
+│       │       │   ├── tiddlers_6.jsonl
+│       │       │   ├── tiddlers_7.jsonl
+│       │       │   ├── tiddlers_8.jsonl
+│       │       │   └── tiddlers_9.jsonl
+│       │       └── reverse_html
+│       │           ├── rollback-20260505213840-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │           └── rollback-20260505213840-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       └── session_sync
+│           ├── sync-20260505154929
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260505164140
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260505184750
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260505190831
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260505204010
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   ├── replacement-candidates.canon-candidates.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── sync-20260505210408
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           └── sync-20260506002530
+│               ├── inventory.json
+│               ├── missing-candidates.canon-candidates.jsonl
+│               ├── normalize
+│               │   ├── admission_lines.normalized.jsonl
+│               │   └── admission_lines.raw.jsonl
+│               └── sync-candidates.canon-candidates.jsonl
 ├── docs
 │   ├── Informe_Tecnico_de_Tiddler (Esp).md
 │   ├── refs
@@ -307,9 +1077,7 @@
 │   │   ├── 07. Nested learning, the illusion of deep learnin arch.docx
 │   │   ├── 07. Nested learning, the illusion of deep learnin arch.pdf
 │   │   └── 07. Nested learning, the illusion of deep learnin arch.txt
-│   ├── Technical_Report_Tiddler_Sys_(Eng).md
-│   └── ui
-│       └── terminal-cat-states-v0.md
+│   └── Technical_Report_Tiddler_Sys_(Eng).md
 ├── esquemas
 │   ├── canon
 │   │   ├── canon_guarded_session_rules.md
@@ -440,6 +1208,7 @@
 │   ├── path_governance.py
 │   ├── remote_mirror_out_local.py
 │   ├── s45_derive_layers.py
+│   ├── session_cycle_diagnostics.py
 │   ├── session_sync.py
 │   ├── stage_modal_delta.py
 │   ├── tdc_cat.py
@@ -592,11 +1361,19 @@
 │   ├── smoke
 │   │   └── test_pipeline_smoke.sh
 │   ├── test.txt
-│   └── test_mcp_env_manager_security.py
-└── tools
-    └── accumulator
-        ├── README.md
-        └── spec.md
+│   ├── test_mcp_env_manager_security.py
+│   ├── test_rule23_relational_coverage.py
+│   ├── test_session_cycle_diagnostics.py
+│   └── test_session_path_governance.py
+├── tools
+│   └── accumulator
+│       ├── README.md
+│       └── spec.md
+└── ux
+    ├── assets
+    │   └── Open eyes.PNG
+    └── ui
+        └── terminal-cat-states-v0.md
 
 # Nota: se han excluido de esta vista los artefactos de build (target/),
 # caches (__pycache__), metadatos de Windows (*:Zone.Identifier),

--- a/python_scripts/mcp_env_manager.py
+++ b/python_scripts/mcp_env_manager.py
@@ -578,17 +578,132 @@ def action_reset_key() -> None:
 # Submenu
 # ---------------------------------------------------------------------------
 
+def action_preview_pull() -> None:
+    """Show what would be pulled from OneDrive _remote_outbox/sessions/ (dry-run, no auth)."""
+    print("  Preview pull remoto \u2192 local staging (SYNC_DRY_RUN=true)\n")
+    print("  Origen remoto : OneDrive approot:/<project>/_remote_outbox/sessions/")
+    print("  Destino local : data/tmp/remote_inbox/  (staging \u2014 NO canon)")
+    print("  Admision      : python_scripts/admit_session_candidates.py")
+    print("  Canon write   : NUNCA \u2014 AGENT_DIRECT_CANON_WRITE=false")
+    print()
+    env = _build_mirror_env("true")
+    import subprocess as _sp
+    _sp.run(
+        [sys.executable, str(SCRIPT_DIR / "remote_pull_sessions.py")],
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+
+def action_pull_and_admit() -> None:
+    """Pull from _remote_outbox/sessions/ to staging then run admission gate (live)."""
+    print()
+    print("  PULL REMOTO \u2192 LOCAL + ADMISION")
+    print()
+    print("  Este flujo descarga candidatos de:")
+    print("    OneDrive approot:/<project>/_remote_outbox/sessions/")
+    print("  hacia el staging local:")
+    print("    data/tmp/remote_inbox/")
+    print()
+    print("  El pull NO sobrescribe canon ni derivados base.")
+    print("  Solo archivos de sesion con nombre mXX-sNN-<slug>.md.json son aceptados.")
+    print()
+    print("  Credenciales de autenticacion Microsoft: runtime only \u2014 no se guardan en .env.")
+    print()
+    client_id = _get_runtime_secret("AZURE_CLIENT_ID", "ID de aplicacion Azure AD")
+    if not client_id:
+        print("  Credencial de autenticacion Azure no disponible. Pull cancelado.")
+        return
+    refresh_token = _get_runtime_secret("MSA_REFRESH_TOKEN", "token de actualizacion Microsoft")
+    if not refresh_token:
+        print("  Token de actualizacion Microsoft no disponible. Pull cancelado.")
+        client_id = ""
+        return
+
+    confirm = _prompt("  Ejecutar pull real? [s/N] ").strip().lower()
+    if confirm not in ("s", "si", "y", "yes"):
+        print("  Cancelado.")
+        client_id = refresh_token = ""
+        return
+
+    env = _build_mirror_env("false")
+    env["AZURE_CLIENT_ID"] = client_id
+    env["MSA_REFRESH_TOKEN"] = refresh_token
+
+    import subprocess as _sp
+    print(flush=True)
+    _sp.run(
+        [sys.executable, str(SCRIPT_DIR / "remote_pull_sessions.py")],
+        cwd=REPO_ROOT,
+        env=env,
+    )
+    client_id = refresh_token = ""
+
+    print()
+    inbox = REPO_ROOT / "data" / "tmp" / "remote_inbox"
+    candidates = list(inbox.glob("*.md.json")) if inbox.exists() else []
+    if candidates:
+        print(f"  {len(candidates)} candidato(s) en staging. Ejecutar admision?")
+        print("  Comando: python3 python_scripts/admit_session_candidates.py dry-run --all-contracts")
+        run_admit = _prompt("  Ejecutar dry-run de admision? [s/N] ").strip().lower()
+        if run_admit in ("s", "si", "y", "yes"):
+            _sp.run(
+                [sys.executable, str(SCRIPT_DIR / "admit_session_candidates.py"), "dry-run", "--all-contracts"],
+                cwd=REPO_ROOT,
+                env=os.environ.copy(),
+            )
+    else:
+        print("  data/tmp/remote_inbox/ no tiene candidatos .md.json todavia.")
+
+
+def action_show_last_sync() -> None:
+    """Show the last sync/pull summary from data/tmp/ if available."""
+    import glob as _glob
+    reports_dir = REPO_ROOT / "data" / "tmp" / "admissions"
+    pattern = str(reports_dir / "*.json")
+    matches = sorted(_glob.glob(pattern), reverse=True)
+    if not matches:
+        print("  No hay reportes de admision en data/tmp/admissions/.")
+        print("  Los reportes de sync de mirror no se persisten localmente por defecto.")
+        inbox = REPO_ROOT / "data" / "tmp" / "remote_inbox"
+        if inbox.exists():
+            candidates = list(inbox.glob("*.md.json"))
+            print(f"  Candidatos actuales en staging: {len(candidates)}")
+            for c in candidates[:10]:
+                print(f"    {c.name}")
+        return
+    latest = matches[0]
+    print(f"  Ultimo reporte: {latest}")
+    try:
+        import json as _json
+        with open(latest, encoding="utf-8") as fh:
+            data = _json.load(fh)
+        print(f"  mode     : {data.get('mode', '?')}")
+        print(f"  status   : {data.get('status', '?')}")
+        print(f"  session  : {data.get('session_id', '?')}")
+        print(f"  timestamp: {data.get('timestamp', '?')}")
+        admitted = data.get('admitted_count', 0)
+        rejected = len(data.get('rejected_candidates', []))
+        print(f"  admitted : {admitted}")
+        print(f"  rejected : {rejected}")
+    except Exception as exc:
+        print(f"  No se pudo leer el reporte: {exc}")
+
+
 _MENU_BODY = (
-    "1) Inicializar .env\n"
-    "2) Editar variable operativa\n"
-    "3) Politica de secrets (runtime only)\n"
-    "4) Ver estado de configuracion\n"
-    "5) Probar autenticacion Azure\n"
-    "6) Probar acceso a App Folder\n"
-    "7) Preview mirror local \u2192 remoto (dry-run)\n"
-    "8) Sync manual (mirror real a OneDrive)\n"
-    "9) Resetear variable a vacio\n"
-    "0) Volver"
+    "1)  Inicializar variables operativas locales\n"
+    "2)  Editar variable operativa\n"
+    "3)  Politica de secrets (runtime only)\n"
+    "4)  Ver estado de configuracion\n"
+    "5)  Probar autenticacion Azure\n"
+    "6)  Probar acceso a App Folder\n"
+    "7)  Preview mirror local \u2192 remoto (dry-run)\n"
+    "8)  Sync manual local \u2192 remoto (mirror real)\n"
+    "9)  Preview pull remoto \u2192 local staging (dry-run)\n"
+    "10) Pull remoto \u2192 staging + admision\n"
+    "11) Ver ultimo reporte de sync/admision\n"
+    "12) Resetear variable operativa a vacio\n"
+    "0)  Volver"
 )
 
 _ACTIONS = {
@@ -600,7 +715,10 @@ _ACTIONS = {
     "6": action_test_appfolder,
     "7": action_preview,
     "8": action_sync_manual,
-    "9": action_reset_key,
+    "9": action_preview_pull,
+    "10": action_pull_and_admit,
+    "11": action_show_last_sync,
+    "12": action_reset_key,
 }
 
 

--- a/python_scripts/remote_mirror_out_local.py
+++ b/python_scripts/remote_mirror_out_local.py
@@ -37,11 +37,13 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import quote
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
@@ -60,6 +62,21 @@ TOKEN_URL_TMPL = "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
 # Files up to this size use a single PUT; larger files use an upload session.
 SIMPLE_UPLOAD_LIMIT = 4 * 1024 * 1024   # 4 MB
 CHUNK_SIZE = 10 * 1024 * 1024            # 10 MB per chunk in upload sessions
+
+# HTTP status codes that warrant a retry with exponential backoff.
+TRANSIENT_HTTP_CODES: frozenset[int] = frozenset({408, 429, 500, 502, 503, 504})
+MAX_RETRIES = 4
+BASE_BACKOFF_SECONDS = 2
+
+# Remote path prefixes that must NEVER be pruned even with REMOTE_DELETE_EXTRANEOUS=true.
+PROTECTED_REMOTE_PREFIXES: tuple[str, ...] = (
+    "_remote_outbox",
+)
+
+# Files whose names match these patterns are excluded from sync with a reason.
+_EXCLUSION_CHECKS: list[tuple[str, str]] = [
+    # (reason_key, description) — checked in order
+]
 
 
 # ---------------------------------------------------------------------------
@@ -144,7 +161,103 @@ class MirrorStats:
     uploaded: int = 0
     skipped: int = 0
     deleted: int = 0
+    protected: int = 0
+    excluded: int = 0
+    excluded_reasons: dict[str, int] = field(default_factory=dict)
+    errors_by_type: dict[str, int] = field(default_factory=dict)
     errors: list[str] = field(default_factory=list)
+
+    def add_error(self, error_type: str, message: str) -> None:
+        self.errors_by_type[error_type] = self.errors_by_type.get(error_type, 0) + 1
+        self.errors.append(message)
+
+    def add_excluded(self, reason: str) -> None:
+        self.excluded += 1
+        self.excluded_reasons[reason] = self.excluded_reasons.get(reason, 0) + 1
+
+
+# ---------------------------------------------------------------------------
+# Syncable file iterator with exclusions
+# ---------------------------------------------------------------------------
+
+def _exclusion_reason(path: Path) -> str | None:
+    """Return an exclusion reason key if this file should not be synced, else None."""
+    name = path.name
+
+    # Windows Alternate Data Streams (Zone.Identifier and similar ADS files)
+    if ":" in name:
+        return "windows_ads_zone_identifier"
+
+    # Dotenv files — never sync credentials
+    if name == ".env" or name.startswith(".env."):
+        return "dotenv_credentials"
+
+    # macOS metadata
+    if name == ".DS_Store":
+        return "macos_metadata"
+
+    # Windows metadata
+    if name in ("Thumbs.db", "desktop.ini"):
+        return "windows_metadata"
+
+    # Temporary / lock files
+    lower = name.lower()
+    if lower.endswith((".tmp", ".lock", ".swp", ".bak")):
+        return "temporary_file"
+
+    # Python / tool caches — check any path segment, not just the filename
+    for part in path.parts:
+        if part in ("__pycache__", ".pytest_cache", ".mypy_cache", "node_modules", ".venv", ".git"):
+            return "cache_or_vcs_directory"
+
+    return None
+
+
+def iter_syncable_files(
+    source: Path,
+    stats: MirrorStats | None = None,
+    verbose: bool = False,
+) -> list[tuple[str, Path]]:
+    """Return (rel_path, abs_path) pairs for all syncable files under source.
+
+    Files failing the exclusion check are logged and counted in stats but
+    not returned.  This is the single source of truth for what gets synced.
+    """
+    result: list[tuple[str, Path]] = []
+    for p in sorted(source.rglob("*")):
+        if not p.is_file():
+            continue
+        reason = _exclusion_reason(p)
+        if reason:
+            rel = str(p.relative_to(source)).replace("\\", "/")
+            if stats is not None:
+                stats.add_excluded(reason)
+            if verbose:
+                print(f"  excluded: {rel}  reason={reason}")
+            continue
+        rel = str(p.relative_to(source)).replace("\\", "/")
+        result.append((rel, p))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Graph path encoding
+# ---------------------------------------------------------------------------
+
+def encode_graph_path_segment(segment: str) -> str:
+    """URL-encode a single Microsoft Graph path segment (no slashes encoded)."""
+    return quote(segment, safe="")
+
+
+def encode_graph_rel_path(rel: str) -> str:
+    """URL-encode each segment of a relative path for Microsoft Graph URLs.
+
+    Example:
+      'sessions/06_diagnoses/m04 diag.md.json'
+      -> 'sessions/06_diagnoses/m04%20diag.md.json'
+    """
+    segments = rel.replace("\\", "/").split("/")
+    return "/".join(encode_graph_path_segment(seg) for seg in segments)
 
 
 # ---------------------------------------------------------------------------
@@ -219,7 +332,7 @@ def resolve_project_folder(cfg: MirrorConfig, token: str) -> str:
     if not cfg.project_root_name:
         return root
 
-    folder_check_url = f"{root}:/{cfg.project_root_name}"
+    folder_check_url = f"{root}:/{encode_graph_path_segment(cfg.project_root_name)}"
     try:
         _http_json(folder_check_url, headers=_auth(token))
     except urllib.error.HTTPError as exc:
@@ -237,16 +350,17 @@ def resolve_project_folder(cfg: MirrorConfig, token: str) -> str:
         else:
             raise
 
-    return f"{root}:/{cfg.project_root_name}"
+    return f"{root}:/{encode_graph_path_segment(cfg.project_root_name)}"
 
 
 def upload_file(remote_prefix: str, rel: str, path: Path, token: str) -> None:
-    rel = rel.replace("\\", "/")
+    """Upload a local file to OneDrive using an encoded Graph URL."""
+    encoded_rel = encode_graph_rel_path(rel)
     size = path.stat().st_size
 
     if size <= SIMPLE_UPLOAD_LIMIT:
         _http_put_raw(
-            f"{remote_prefix}/{rel}:/content",
+            f"{remote_prefix}/{encoded_rel}:/content",
             path.read_bytes(),
             {**_auth(token), "Content-Type": "application/octet-stream"},
         )
@@ -254,7 +368,7 @@ def upload_file(remote_prefix: str, rel: str, path: Path, token: str) -> None:
 
     # Large file — upload session with chunked PUT
     session = _http_json(
-        f"{remote_prefix}/{rel}:/createUploadSession",
+        f"{remote_prefix}/{encoded_rel}:/createUploadSession",
         method="POST",
         data=json.dumps({
             "item": {"@microsoft.graph.conflictBehavior": "replace"}
@@ -273,6 +387,40 @@ def upload_file(remote_prefix: str, rel: str, path: Path, token: str) -> None:
             with urllib.request.urlopen(req):
                 pass
             offset += len(chunk)
+
+
+def _upload_with_retry(
+    remote_prefix: str,
+    rel: str,
+    path: Path,
+    token: str,
+    stats: MirrorStats,
+    verbose: bool = False,
+) -> None:
+    """Upload with exponential backoff on transient Graph errors."""
+    last_exc: Exception | None = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            upload_file(remote_prefix, rel, path, token)
+            return
+        except urllib.error.HTTPError as exc:
+            last_exc = exc
+            if exc.code in TRANSIENT_HTTP_CODES and attempt < MAX_RETRIES:
+                retry_after = 0
+                try:
+                    retry_after = int(exc.headers.get("Retry-After", 0) or 0)
+                except (TypeError, ValueError):
+                    pass
+                wait = max(retry_after, BASE_BACKOFF_SECONDS ** attempt)
+                print(f"  upload retry {attempt}/{MAX_RETRIES - 1}: {rel} — HTTP {exc.code}")
+                time.sleep(wait)
+            else:
+                raise
+        except Exception as exc:
+            last_exc = exc
+            raise
+    if last_exc is not None:
+        raise last_exc
 
 
 def list_remote_files(remote_prefix: str, token: str, folder_rel: str = "") -> set[str]:
@@ -299,43 +447,54 @@ def list_remote_files(remote_prefix: str, token: str, folder_rel: str = "") -> s
     return result
 
 
+def _is_protected_remote_path(rel: str) -> bool:
+    """Return True if this remote path is under a protected prefix (e.g. _remote_outbox)."""
+    normalized = rel.replace("\\", "/").lstrip("/")
+    for prefix in PROTECTED_REMOTE_PREFIXES:
+        if normalized == prefix or normalized.startswith(prefix + "/"):
+            return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Mirror orchestration
 # ---------------------------------------------------------------------------
 
-def collect_local_files(source: Path) -> list[tuple[str, Path]]:
-    return [
-        (str(p.relative_to(source)).replace("\\", "/"), p)
-        for p in sorted(source.rglob("*"))
-        if p.is_file()
-    ]
-
-
-def run_dry_run(cfg: MirrorConfig, local_files: list[tuple[str, Path]]) -> MirrorStats:
-    stats = MirrorStats()
+def run_dry_run(cfg: MirrorConfig, local_files: list[tuple[str, Path]], stats: MirrorStats) -> None:
     for rel, path in local_files:
         size_kb = path.stat().st_size // 1024
         print(f"  [dry-run] upload  {rel}  ({size_kb} KB)")
         stats.uploaded += 1
     if cfg.delete_extraneous:
         print("  [dry-run] delete-extraneous: remote listing skipped in dry-run")
-    return stats
 
 
-def run_live(cfg: MirrorConfig, local_files: list[tuple[str, Path]]) -> MirrorStats:
-    stats = MirrorStats()
-
+def run_live(cfg: MirrorConfig, local_files: list[tuple[str, Path]], stats: MirrorStats) -> None:
     print("Authenticating via MSA refresh token...")
-    token = exchange_refresh_token(cfg)
+    try:
+        token = exchange_refresh_token(cfg)
+    except Exception as exc:
+        stats.add_error("AUTH_ERROR", f"auth failed: {exc}")
+        print(f"  error AUTH_ERROR: {exc}", file=sys.stderr)
+        return
 
     print(f"Resolving project folder '{cfg.project_root_name}' under {cfg.root_mode}...")
-    remote_prefix = resolve_project_folder(cfg, token)
+    try:
+        remote_prefix = resolve_project_folder(cfg, token)
+    except urllib.error.HTTPError as exc:
+        if exc.code in (401, 403):
+            stats.add_error("PERMISSION_ERROR", f"cannot resolve project folder: HTTP {exc.code}")
+        else:
+            stats.add_error("TRANSIENT_GRAPH_ERROR", f"cannot resolve project folder: HTTP {exc.code}")
+        print(f"  error: cannot resolve project folder: HTTP {exc.code}", file=sys.stderr)
+        return
 
     for rel, path in local_files:
         try:
             if cfg.conflict_behavior == "skip":
+                encoded_rel = encode_graph_rel_path(rel)
                 try:
-                    _http_json(f"{remote_prefix}/{rel}", headers=_auth(token))
+                    _http_json(f"{remote_prefix}/{encoded_rel}", headers=_auth(token))
                     if cfg.verbose:
                         print(f"  skip    {rel}")
                     stats.skipped += 1
@@ -344,23 +503,45 @@ def run_live(cfg: MirrorConfig, local_files: list[tuple[str, Path]]) -> MirrorSt
                     if exc.code != 404:
                         raise
 
-            upload_file(remote_prefix, rel, path, token)
+            _upload_with_retry(remote_prefix, rel, path, token, stats, cfg.verbose)
             if cfg.verbose:
                 print(f"  upload  {rel}")
             stats.uploaded += 1
-        except Exception as exc:  # noqa: BLE001
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                error_type = "AUTH_ERROR" if exc.code == 401 else "PERMISSION_ERROR"
+            elif exc.code in TRANSIENT_HTTP_CODES:
+                error_type = "TRANSIENT_GRAPH_ERROR"
+            else:
+                # Likely a path encoding or bad request issue
+                error_type = "PATH_ENCODING_ERROR" if exc.code == 400 else "TRANSIENT_GRAPH_ERROR"
+            msg = f"{rel}: HTTP {exc.code}"
+            stats.add_error(error_type, msg)
+            print(f"  error {error_type}: {msg}", file=sys.stderr)
+        except Exception as exc:
             msg = f"{rel}: {exc}"
-            stats.errors.append(msg)
+            stats.add_error("TRANSIENT_GRAPH_ERROR", msg)
             print(f"  error   {msg}", file=sys.stderr)
 
     if cfg.delete_extraneous:
         print("Listing remote files for prune...")
-        remote_files = list_remote_files(remote_prefix, token)
+        try:
+            remote_files = list_remote_files(remote_prefix, token)
+        except Exception as exc:
+            stats.add_error("REMOTE_PRUNE_ERROR", f"list remote failed: {exc}")
+            print(f"  error REMOTE_PRUNE_ERROR: listing failed: {exc}", file=sys.stderr)
+            return
+
         local_rels = {rel for rel, _ in local_files}
         for rel in sorted(remote_files - local_rels):
+            if _is_protected_remote_path(rel):
+                print(f"  protected  {rel}  (skipping prune)")
+                stats.protected += 1
+                continue
             try:
+                encoded_rel = encode_graph_rel_path(rel)
                 req = urllib.request.Request(
-                    f"{remote_prefix}/{rel}", method="DELETE"
+                    f"{remote_prefix}/{encoded_rel}", method="DELETE"
                 )
                 req.add_header("Authorization", f"Bearer {token}")
                 with urllib.request.urlopen(req):
@@ -368,12 +549,10 @@ def run_live(cfg: MirrorConfig, local_files: list[tuple[str, Path]]) -> MirrorSt
                 if cfg.verbose:
                     print(f"  delete  {rel}")
                 stats.deleted += 1
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 msg = f"delete {rel}: {exc}"
-                stats.errors.append(msg)
-                print(f"  error   {msg}", file=sys.stderr)
-
-    return stats
+                stats.add_error("REMOTE_PRUNE_ERROR", msg)
+                print(f"  error REMOTE_PRUNE_ERROR: {msg}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -408,18 +587,34 @@ def main() -> int:
             print("error: MSA_REFRESH_TOKEN is required for live mode", file=sys.stderr)
             return 1
 
-    local_files = collect_local_files(cfg.source)
-    print(f"  {len(local_files)} file(s) in source\n")
+    stats = MirrorStats()
+    local_files = iter_syncable_files(cfg.source, stats=stats, verbose=cfg.verbose)
+    total_seen = len(local_files) + stats.excluded
+    print(f"  {total_seen} file(s) seen — {len(local_files)} syncable — {stats.excluded} excluded\n")
 
-    stats = run_dry_run(cfg, local_files) if cfg.dry_run else run_live(cfg, local_files)
+    if stats.excluded_reasons and cfg.verbose:
+        for reason, count in sorted(stats.excluded_reasons.items()):
+            print(f"  excluded by reason: {reason}={count}")
+        print()
+
+    if cfg.dry_run:
+        run_dry_run(cfg, local_files, stats)
+    else:
+        run_live(cfg, local_files, stats)
 
     summary = {
         "source": as_display_path(cfg.source),
         "project_root": cfg.project_root_name,
         "dry_run": cfg.dry_run,
+        "total_seen": total_seen,
+        "syncable": len(local_files),
         "uploaded": stats.uploaded,
         "skipped": stats.skipped,
         "deleted": stats.deleted,
+        "protected": stats.protected,
+        "excluded": stats.excluded,
+        "excluded_reasons": stats.excluded_reasons,
+        "errors_by_type": stats.errors_by_type,
         "errors": stats.errors,
     }
     print()

--- a/python_scripts/remote_pull_sessions.py
+++ b/python_scripts/remote_pull_sessions.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Pull session candidates from the OneDrive remote outbox to local staging.
+
+Architecture (bilateral, NOT symmetric):
+  LOCAL data/out/local/  →  push mirror  →  OneDrive approot:/tiddly-data-converter/
+  OneDrive _remote_outbox/sessions/  →  pull (this script)  →  data/tmp/remote_inbox/
+  data/tmp/remote_inbox/  →  admission gate  →  data/out/local/sessions/
+
+Rules:
+- Only files under _remote_outbox/sessions/ on OneDrive are pulled.
+- Files are staged in data/tmp/remote_inbox/ — never written directly to canon.
+- The allowlist prevents pulling tiddlers_*.jsonl or any non-session artifact.
+- AGENT_DIRECT_CANON_WRITE must remain false.
+- Secrets (AZURE_CLIENT_ID, MSA_REFRESH_TOKEN) are runtime only — never .env.
+
+Env vars (non-sensitive, loadable from .env):
+  MSA_TENANT                  consumers | common | <tenant-id>
+  ONEDRIVE_PROJECT_ROOT_NAME  subfolder under approot (default: tiddly-data-converter)
+  ONEDRIVE_ROOT_MODE          approot | drive (default: approot)
+  REMOTE_INBOX_DIR            local staging dir (default: data/tmp/remote_inbox)
+  SYNC_DRY_RUN                true | false (default: true)
+
+Secrets (runtime only):
+  AZURE_CLIENT_ID
+  MSA_REFRESH_TOKEN
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import quote
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from path_governance import (  # noqa: E402
+    REPO_ROOT,
+    as_display_path,
+    resolve_repo_path,
+)
+
+GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+TOKEN_URL_TMPL = "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
+
+# Only pull from this remote prefix (relative to the project root folder).
+REMOTE_OUTBOX_PREFIX = "_remote_outbox/sessions"
+
+# Default local staging directory for pulled candidates.
+DEFAULT_REMOTE_INBOX = REPO_ROOT / "data" / "tmp" / "remote_inbox"
+
+# Allowlist: only files matching these patterns may be pulled from the outbox.
+_ALLOWED_FILENAME_RE = re.compile(
+    r"^m\d+-s\d+[a-z]?-.+\.md\.json$",
+    re.IGNORECASE,
+)
+
+# Denylist: these filename patterns are always rejected regardless of path.
+_CANON_SHARD_RE = re.compile(r"^tiddlers_\d+\.jsonl$")
+
+# Protected local paths — pulled files must never overwrite these.
+_PROTECTED_LOCAL_PREFIXES: tuple[str, ...] = (
+    "tiddlers_",
+    "enriched",
+    "ai",
+    "microsoft_copilot",
+    "reverse_html",
+    "audit",
+)
+
+
+# ---------------------------------------------------------------------------
+# .env loader
+# ---------------------------------------------------------------------------
+
+def _load_dotenv(path: Path) -> None:
+    if not path.is_file():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if key and key not in os.environ:
+            os.environ[key] = value.strip()
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PullConfig:
+    tenant: str
+    client_id: str
+    refresh_token: str
+    project_root_name: str
+    root_mode: str
+    inbox_dir: Path
+    dry_run: bool
+
+
+def _env(key: str, default: str = "") -> str:
+    val = os.environ.get(key, "").strip()
+    return val or default
+
+
+def _bool_env(key: str, default: bool) -> bool:
+    val = _env(key).lower()
+    if val in ("true", "1", "yes"):
+        return True
+    if val in ("false", "0", "no"):
+        return False
+    return default
+
+
+def load_config() -> PullConfig:
+    _load_dotenv(REPO_ROOT / ".env")
+    inbox_val = _env("REMOTE_INBOX_DIR") or None
+    inbox_dir = resolve_repo_path(inbox_val, DEFAULT_REMOTE_INBOX)
+    return PullConfig(
+        tenant=_env("MSA_TENANT", "consumers"),
+        client_id=_env("AZURE_CLIENT_ID"),
+        refresh_token=_env("MSA_REFRESH_TOKEN"),
+        project_root_name=_env("ONEDRIVE_PROJECT_ROOT_NAME", "tiddly-data-converter"),
+        root_mode=_env("ONEDRIVE_ROOT_MODE", "approot"),
+        inbox_dir=inbox_dir,
+        dry_run=_bool_env("SYNC_DRY_RUN", True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PullStats:
+    listed: int = 0
+    pulled: int = 0
+    skipped_allowlist: int = 0
+    skipped_denylist: int = 0
+    skipped_already_present: int = 0
+    errors: list[str] = field(default_factory=list)
+    errors_by_type: dict[str, int] = field(default_factory=dict)
+
+    def add_error(self, error_type: str, message: str) -> None:
+        self.errors_by_type[error_type] = self.errors_by_type.get(error_type, 0) + 1
+        self.errors.append(message)
+
+
+# ---------------------------------------------------------------------------
+# Graph path encoding (shared logic)
+# ---------------------------------------------------------------------------
+
+def _encode_segment(segment: str) -> str:
+    return quote(segment, safe="")
+
+
+def _encode_rel(rel: str) -> str:
+    return "/".join(_encode_segment(s) for s in rel.replace("\\", "/").split("/"))
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _http_json(
+    url: str,
+    *,
+    method: str = "GET",
+    data: bytes | None = None,
+    headers: dict[str, str] | None = None,
+) -> dict:
+    req = urllib.request.Request(url, data=data, method=method)
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def _http_get_bytes(url: str, headers: dict[str, str]) -> bytes:
+    req = urllib.request.Request(url)
+    for k, v in headers.items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req) as resp:
+        return resp.read()
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+def exchange_refresh_token(cfg: PullConfig) -> str:
+    token_url = TOKEN_URL_TMPL.format(tenant=cfg.tenant)
+    body = urllib.parse.urlencode({
+        "grant_type": "refresh_token",
+        "client_id": cfg.client_id,
+        "refresh_token": cfg.refresh_token,
+        "scope": "Files.ReadWrite.AppFolder offline_access",
+    }).encode()
+    result = _http_json(
+        token_url,
+        method="POST",
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    if "access_token" not in result:
+        raise RuntimeError(
+            f"Token exchange failed: {result.get('error_description', result)}"
+        )
+    return result["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Allowlist / denylist checks
+# ---------------------------------------------------------------------------
+
+def _is_allowed_outbox_file(filename: str) -> tuple[bool, str]:
+    """Return (allowed, reason) for a candidate remote filename.
+
+    Only session artifacts following the project naming convention are allowed.
+    Canon shards, env files, and non-session artifacts are explicitly rejected.
+    """
+    # Reject canon shards unconditionally
+    if _CANON_SHARD_RE.match(filename):
+        return False, "denylist_canon_shard"
+
+    # Reject .env and credential files
+    if filename == ".env" or filename.startswith(".env."):
+        return False, "denylist_credentials"
+
+    # Reject Windows ADS files
+    if ":" in filename:
+        return False, "denylist_ads_zone_identifier"
+
+    # Must match session artifact naming convention
+    if not _ALLOWED_FILENAME_RE.match(filename):
+        return False, "allowlist_not_session_artifact"
+
+    return True, ""
+
+
+def _is_protected_local_path(local_path: Path, inbox_dir: Path) -> bool:
+    """Return True if the file would overwrite a protected local area."""
+    try:
+        rel = str(local_path.relative_to(inbox_dir)).replace("\\", "/")
+    except ValueError:
+        return True  # outside inbox — reject
+    for prefix in _PROTECTED_LOCAL_PREFIXES:
+        if rel.startswith(prefix):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Remote listing
+# ---------------------------------------------------------------------------
+
+def _list_outbox_files(root_base: str, project_name: str, token: str) -> list[dict]:
+    """List files under _remote_outbox/sessions/ on OneDrive.
+
+    Returns a list of Graph item dicts (name, id, @microsoft.graph.downloadUrl, size).
+    """
+    encoded_project = _encode_segment(project_name)
+    encoded_outbox = _encode_rel(REMOTE_OUTBOX_PREFIX)
+    url = f"{root_base}:/{encoded_project}/{encoded_outbox}:/children"
+    try:
+        page = _http_json(url, headers=_auth(token))
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return []  # outbox does not exist yet — not an error
+        raise
+
+    items: list[dict] = []
+    while True:
+        for item in page.get("value", []):
+            if "folder" not in item:  # files only
+                items.append(item)
+        next_link = page.get("@odata.nextLink")
+        if not next_link:
+            break
+        page = _http_json(next_link, headers=_auth(token))
+    return items
+
+
+def _root_base(cfg: PullConfig) -> str:
+    if cfg.root_mode == "drive":
+        return f"{GRAPH_BASE}/me/drive/root"
+    return f"{GRAPH_BASE}/me/drive/special/approot"
+
+
+# ---------------------------------------------------------------------------
+# Pull orchestration
+# ---------------------------------------------------------------------------
+
+def run_dry_run(cfg: PullConfig, items: list[dict], stats: PullStats) -> None:
+    for item in items:
+        name = item.get("name", "")
+        size = item.get("size", 0)
+        allowed, reason = _is_allowed_outbox_file(name)
+        if not allowed:
+            print(f"  [dry-run] skip   {name}  reason={reason}")
+            if reason.startswith("denylist"):
+                stats.skipped_denylist += 1
+            else:
+                stats.skipped_allowlist += 1
+            continue
+        dest = cfg.inbox_dir / name
+        if dest.exists():
+            print(f"  [dry-run] exists {name}  ({size} B) — already in inbox")
+            stats.skipped_already_present += 1
+        else:
+            print(f"  [dry-run] pull   {name}  ({size} B) → {as_display_path(cfg.inbox_dir)}/")
+            stats.pulled += 1
+
+
+def run_live(cfg: PullConfig, items: list[dict], token: str, stats: PullStats) -> None:
+    cfg.inbox_dir.mkdir(parents=True, exist_ok=True)
+    for item in items:
+        name = item.get("name", "")
+        size = item.get("size", 0)
+        allowed, reason = _is_allowed_outbox_file(name)
+        if not allowed:
+            print(f"  skip     {name}  reason={reason}")
+            if reason.startswith("denylist"):
+                stats.skipped_denylist += 1
+            else:
+                stats.skipped_allowlist += 1
+            continue
+
+        dest = cfg.inbox_dir / name
+        if _is_protected_local_path(dest, cfg.inbox_dir):
+            print(f"  reject   {name}  reason=protected_local_path")
+            stats.add_error("LOCAL_SAFETY_ERROR", f"{name}: would write outside allowed inbox area")
+            continue
+
+        if dest.exists():
+            print(f"  exists   {name}  ({size} B) — skipping (already staged)")
+            stats.skipped_already_present += 1
+            continue
+
+        # Prefer direct download URL if provided by Graph listing
+        download_url = item.get("@microsoft.graph.downloadUrl")
+        if not download_url:
+            # Construct from item id
+            item_id = item.get("id", "")
+            download_url = f"{GRAPH_BASE}/me/drive/items/{_encode_segment(item_id)}/content"
+
+        try:
+            content = _http_get_bytes(download_url, _auth(token))
+            dest.write_bytes(content)
+            print(f"  pulled   {name}  ({len(content)} B)")
+            stats.pulled += 1
+        except urllib.error.HTTPError as exc:
+            error_type = "AUTH_ERROR" if exc.code in (401, 403) else "TRANSIENT_GRAPH_ERROR"
+            stats.add_error(error_type, f"{name}: HTTP {exc.code}")
+            print(f"  error {error_type}: {name}: HTTP {exc.code}", file=sys.stderr)
+        except Exception as exc:
+            stats.add_error("TRANSIENT_GRAPH_ERROR", f"{name}: {exc}")
+            print(f"  error   {name}: {exc}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    cfg = load_config()
+
+    print(f"remote_outbox : {REMOTE_OUTBOX_PREFIX}")
+    print(f"project       : {cfg.project_root_name}")
+    print(f"root_mode     : {cfg.root_mode}")
+    print(f"inbox_dir     : {as_display_path(cfg.inbox_dir)}")
+    print(f"dry_run       : {cfg.dry_run}")
+    print()
+    print("NOTE: This pull is NOT symmetric. It only fetches from _remote_outbox/sessions/")
+    print("      and stages files in data/tmp/remote_inbox/ — canon is never overwritten.")
+    print()
+
+    if not cfg.dry_run:
+        if not cfg.client_id:
+            print("error: AZURE_CLIENT_ID is required for live mode", file=sys.stderr)
+            return 1
+        if not cfg.refresh_token:
+            print("error: MSA_REFRESH_TOKEN is required for live mode", file=sys.stderr)
+            return 1
+
+    stats = PullStats()
+
+    if cfg.dry_run:
+        # In dry-run we can't list remote files without auth; show policy and exit.
+        print("  [dry-run] Would list files under:")
+        print(f"            OneDrive approot:/{cfg.project_root_name}/{REMOTE_OUTBOX_PREFIX}/")
+        print(f"  [dry-run] Allowed files matching: mXX-sNN-<slug>.md.json")
+        print(f"  [dry-run] Staging target: {as_display_path(cfg.inbox_dir)}/")
+        print(f"  [dry-run] Admission gate: AGENT_ADMISSION_SCRIPT")
+        print(f"  [dry-run] Canon overwrite: NEVER (AGENT_DIRECT_CANON_WRITE=false)")
+        stats.listed = 0
+        summary = {
+            "dry_run": True,
+            "remote_outbox": REMOTE_OUTBOX_PREFIX,
+            "inbox_dir": as_display_path(cfg.inbox_dir),
+            "listed": 0,
+            "pulled": 0,
+            "skipped_allowlist": 0,
+            "skipped_denylist": 0,
+            "skipped_already_present": 0,
+            "errors_by_type": {},
+            "errors": [],
+        }
+        print()
+        print(json.dumps(summary, indent=2))
+        return 0
+
+    print("Authenticating via MSA refresh token...")
+    try:
+        token = exchange_refresh_token(cfg)
+    except Exception as exc:
+        stats.add_error("AUTH_ERROR", f"auth failed: {exc}")
+        print(f"  error AUTH_ERROR: {exc}", file=sys.stderr)
+        print(json.dumps({"status": "fail", "errors_by_type": stats.errors_by_type}, indent=2))
+        return 1
+
+    root_base = _root_base(cfg)
+    print(f"Listing {REMOTE_OUTBOX_PREFIX}...")
+    try:
+        items = _list_outbox_files(root_base, cfg.project_root_name, token)
+    except urllib.error.HTTPError as exc:
+        error_type = "AUTH_ERROR" if exc.code in (401, 403) else "TRANSIENT_GRAPH_ERROR"
+        stats.add_error(error_type, f"listing failed: HTTP {exc.code}")
+        print(f"  error {error_type}: listing failed: HTTP {exc.code}", file=sys.stderr)
+        print(json.dumps({"status": "fail", "errors_by_type": stats.errors_by_type}, indent=2))
+        return 1
+    except Exception as exc:
+        stats.add_error("TRANSIENT_GRAPH_ERROR", f"listing failed: {exc}")
+        print(f"  error: listing failed: {exc}", file=sys.stderr)
+        print(json.dumps({"status": "fail", "errors_by_type": stats.errors_by_type}, indent=2))
+        return 1
+
+    stats.listed = len(items)
+    print(f"  {stats.listed} file(s) found in remote outbox\n")
+
+    run_live(cfg, items, token, stats)
+
+    summary = {
+        "remote_outbox": REMOTE_OUTBOX_PREFIX,
+        "inbox_dir": as_display_path(cfg.inbox_dir),
+        "dry_run": cfg.dry_run,
+        "listed": stats.listed,
+        "pulled": stats.pulled,
+        "skipped_allowlist": stats.skipped_allowlist,
+        "skipped_denylist": stats.skipped_denylist,
+        "skipped_already_present": stats.skipped_already_present,
+        "errors_by_type": stats.errors_by_type,
+        "errors": stats.errors,
+    }
+    print()
+    print(json.dumps(summary, indent=2))
+
+    return 1 if stats.errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_remote_mirror_out_local.py
+++ b/tests/test_remote_mirror_out_local.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Tests for remote_mirror_out_local.py — S100 bilateral sync governance.
+
+Validates:
+1. Path encoding: spaces and special chars are properly percent-encoded in Graph URLs.
+2. Zone.Identifier exclusion: ADS files with ':' in name are excluded before upload.
+3. Prune protection: _remote_outbox/ paths are never deleted by REMOTE_DELETE_EXTRANEOUS.
+4. Pull allowlist: remote_pull_sessions only accepts mXX-sNN-*.md.json files.
+5. Pull denylist: tiddlers_*.jsonl and .env files are rejected from pull.
+6. Retry on 504: upload_with_retry retries on transient errors.
+7. Secrets not printed: no token/auth-header leak in error paths.
+8. No legacy data/sessions/ creation.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+import urllib.error
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_DIR = REPO_ROOT / "python_scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import remote_mirror_out_local as mirror
+import remote_pull_sessions as pull
+
+
+# ---------------------------------------------------------------------------
+# 1. Path encoding
+# ---------------------------------------------------------------------------
+
+class TestPathEncoding(unittest.TestCase):
+
+    def test_encode_segment_encodes_spaces(self):
+        encoded = mirror.encode_graph_path_segment("m04 diagnostico-global.md.json")
+        self.assertNotIn(" ", encoded)
+        self.assertIn("%20", encoded)
+
+    def test_encode_segment_encodes_special_chars(self):
+        encoded = mirror.encode_graph_path_segment("file (v2).json")
+        self.assertNotIn("(", encoded)
+        self.assertNotIn(")", encoded)
+        self.assertNotIn(" ", encoded)
+
+    def test_encode_rel_path_encodes_each_segment(self):
+        rel = "sessions/06_diagnoses/proyecto/m04 diagnostico-global-proyecto-post-s097.md.json"
+        encoded = mirror.encode_graph_rel_path(rel)
+        self.assertNotIn(" ", encoded)
+        self.assertIn("sessions/06_diagnoses/proyecto/", encoded)
+        self.assertIn("m04%20diagnostico", encoded)
+
+    def test_encode_rel_path_does_not_encode_separators(self):
+        rel = "sessions/sub/file.json"
+        encoded = mirror.encode_graph_rel_path(rel)
+        self.assertEqual(encoded, "sessions/sub/file.json")
+
+    def test_encode_segment_safe_name(self):
+        # A slug-safe name should be unchanged
+        encoded = mirror.encode_graph_path_segment("m04-s100-sync-bilateral.md.json")
+        self.assertEqual(encoded, "m04-s100-sync-bilateral.md.json")
+
+
+# ---------------------------------------------------------------------------
+# 2. Zone.Identifier / ADS exclusion
+# ---------------------------------------------------------------------------
+
+class TestZoneIdentifierExclusion(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _make_file(self, name: str, content: bytes = b"x") -> Path:
+        p = self.root / name
+        p.write_bytes(content)
+        return p
+
+    def test_zone_identifier_excluded(self):
+        ads = self._make_file("tiddlers_1.jsonl:Zone.Identifier")
+        reason = mirror._exclusion_reason(ads)
+        self.assertEqual(reason, "windows_ads_zone_identifier")
+
+    def test_colon_in_name_excluded(self):
+        p = self._make_file("some:file.txt")
+        reason = mirror._exclusion_reason(p)
+        self.assertEqual(reason, "windows_ads_zone_identifier")
+
+    def test_dotenv_excluded(self):
+        p = self._make_file(".env")
+        reason = mirror._exclusion_reason(p)
+        self.assertEqual(reason, "dotenv_credentials")
+
+    def test_dotenv_local_excluded(self):
+        p = self._make_file(".env.local")
+        reason = mirror._exclusion_reason(p)
+        self.assertEqual(reason, "dotenv_credentials")
+
+    def test_ds_store_excluded(self):
+        p = self._make_file(".DS_Store")
+        reason = mirror._exclusion_reason(p)
+        self.assertEqual(reason, "macos_metadata")
+
+    def test_tmp_file_excluded(self):
+        p = self._make_file("session.tmp")
+        reason = mirror._exclusion_reason(p)
+        self.assertEqual(reason, "temporary_file")
+
+    def test_lock_file_excluded(self):
+        p = self._make_file("session.lock")
+        reason = mirror._exclusion_reason(p)
+        self.assertEqual(reason, "temporary_file")
+
+    def test_pycache_excluded(self):
+        cache_dir = self.root / "__pycache__"
+        cache_dir.mkdir()
+        p = cache_dir / "module.cpython-311.pyc"
+        p.write_bytes(b"x")
+        reason = mirror._exclusion_reason(p)
+        self.assertEqual(reason, "cache_or_vcs_directory")
+
+    def test_normal_file_not_excluded(self):
+        p = self._make_file("m04-s100-sync-bilateral.md.json")
+        reason = mirror._exclusion_reason(p)
+        self.assertIsNone(reason)
+
+    def test_iter_syncable_files_excludes_ads(self):
+        good = self._make_file("good.md.json", b"good")
+        ads = self._make_file("tiddlers_1.jsonl:Zone.Identifier", b"ads")
+        stats = mirror.MirrorStats()
+        result = mirror.iter_syncable_files(self.root, stats=stats)
+        names = [Path(p).name for _, p in result]
+        self.assertIn("good.md.json", names)
+        self.assertNotIn("tiddlers_1.jsonl:Zone.Identifier", names)
+        self.assertEqual(stats.excluded, 1)
+        self.assertEqual(stats.excluded_reasons.get("windows_ads_zone_identifier"), 1)
+
+    def test_iter_syncable_files_counts_all_exclusion_types(self):
+        self._make_file("good.json", b"good")
+        self._make_file("bad:ads.json", b"bad")
+        self._make_file(".env", b"secret")
+        stats = mirror.MirrorStats()
+        result = mirror.iter_syncable_files(self.root, stats=stats)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(stats.excluded, 2)
+
+
+# ---------------------------------------------------------------------------
+# 3. Prune protection: _remote_outbox/ never deleted
+# ---------------------------------------------------------------------------
+
+class TestPruneProtection(unittest.TestCase):
+
+    def test_outbox_root_is_protected(self):
+        self.assertTrue(mirror._is_protected_remote_path("_remote_outbox"))
+
+    def test_outbox_sessions_is_protected(self):
+        self.assertTrue(mirror._is_protected_remote_path("_remote_outbox/sessions"))
+
+    def test_outbox_file_is_protected(self):
+        self.assertTrue(mirror._is_protected_remote_path("_remote_outbox/sessions/m04-s100-test.md.json"))
+
+    def test_non_outbox_is_not_protected(self):
+        self.assertFalse(mirror._is_protected_remote_path("sessions/06_diagnoses/test.md.json"))
+
+    def test_outbox_prefix_with_leading_slash(self):
+        self.assertTrue(mirror._is_protected_remote_path("/_remote_outbox/sessions/file.md.json"))
+
+    def test_prune_skips_outbox(self):
+        """run_live must not delete _remote_outbox/ files even with delete_extraneous=true."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            local_file = root / "local.json"
+            local_file.write_bytes(b"local")
+
+            cfg = mirror.MirrorConfig(
+                source=root,
+                tenant="consumers",
+                client_id="fake",
+                refresh_token="fake",
+                project_root_name="test",
+                root_mode="approot",
+                create_dirs=True,
+                conflict_behavior="replace",
+                delete_extraneous=True,
+                dry_run=False,
+                sync_mode="local_primary",
+            )
+            stats = mirror.MirrorStats()
+            local_files = [("local.json", local_file)]
+
+            # Patch network calls
+            with patch.object(mirror, "exchange_refresh_token", return_value="tok"), \
+                 patch.object(mirror, "resolve_project_folder", return_value="https://fake/prefix"), \
+                 patch.object(mirror, "upload_file", return_value=None), \
+                 patch.object(mirror, "list_remote_files", return_value={
+                     "local.json",
+                     "_remote_outbox/sessions/m04-s100-remote-candidate.md.json",
+                 }):
+                mirror.run_live(cfg, local_files, stats)
+
+            # _remote_outbox file must NOT be deleted
+            self.assertEqual(stats.deleted, 0)
+            self.assertEqual(stats.protected, 1)
+            self.assertEqual(stats.errors, [])
+
+
+# ---------------------------------------------------------------------------
+# 4 & 5. Pull allowlist / denylist
+# ---------------------------------------------------------------------------
+
+class TestPullAllowlist(unittest.TestCase):
+
+    def _check(self, filename: str) -> tuple[bool, str]:
+        return pull._is_allowed_outbox_file(filename)
+
+    def test_valid_session_artifact_allowed(self):
+        allowed, reason = self._check("m04-s100-sync-bilateral-onedrive.md.json")
+        self.assertTrue(allowed)
+        self.assertEqual(reason, "")
+
+    def test_valid_session_with_letter_suffix_allowed(self):
+        allowed, reason = self._check("m04-s100a-addendum.md.json")
+        self.assertTrue(allowed)
+
+    def test_canon_shard_denied(self):
+        allowed, reason = self._check("tiddlers_1.jsonl")
+        self.assertFalse(allowed)
+        self.assertEqual(reason, "denylist_canon_shard")
+
+    def test_canon_shard_any_number_denied(self):
+        allowed, reason = self._check("tiddlers_99.jsonl")
+        self.assertFalse(allowed)
+        self.assertEqual(reason, "denylist_canon_shard")
+
+    def test_dotenv_denied(self):
+        allowed, reason = self._check(".env")
+        self.assertFalse(allowed)
+        self.assertEqual(reason, "denylist_credentials")
+
+    def test_ads_zone_identifier_denied(self):
+        allowed, reason = self._check("tiddlers_1.jsonl:Zone.Identifier")
+        self.assertFalse(allowed)
+        self.assertEqual(reason, "denylist_ads_zone_identifier")
+
+    def test_generic_json_file_not_allowed(self):
+        allowed, reason = self._check("output.json")
+        self.assertFalse(allowed)
+        self.assertEqual(reason, "allowlist_not_session_artifact")
+
+    def test_wrong_prefix_not_allowed(self):
+        allowed, reason = self._check("session-100-sync.md.json")
+        self.assertFalse(allowed)
+
+    def test_pull_live_rejects_canon_shard(self):
+        """run_live must not download tiddlers_*.jsonl to local inbox."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inbox = Path(tmp) / "remote_inbox"
+            cfg = pull.PullConfig(
+                tenant="consumers",
+                client_id="fake",
+                refresh_token="fake",
+                project_root_name="test",
+                root_mode="approot",
+                inbox_dir=inbox,
+                dry_run=False,
+            )
+            stats = pull.PullStats()
+            items = [{"name": "tiddlers_1.jsonl", "size": 100}]
+            pull.run_live(cfg, items, "tok", stats)
+            self.assertEqual(stats.pulled, 0)
+            self.assertEqual(stats.skipped_denylist, 1)
+            self.assertFalse((inbox / "tiddlers_1.jsonl").exists())
+
+    def test_pull_live_accepts_valid_session_artifact(self):
+        """run_live must stage mXX-sNN-*.md.json files into inbox."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inbox = Path(tmp) / "remote_inbox"
+            cfg = pull.PullConfig(
+                tenant="consumers",
+                client_id="fake",
+                refresh_token="fake",
+                project_root_name="test",
+                root_mode="approot",
+                inbox_dir=inbox,
+                dry_run=False,
+            )
+            stats = pull.PullStats()
+            items = [{
+                "name": "m04-s100-sync-bilateral.md.json",
+                "size": 50,
+                "@microsoft.graph.downloadUrl": "https://fake/download",
+            }]
+            with patch.object(pull, "_http_get_bytes", return_value=b'{"title": "test"}'):
+                pull.run_live(cfg, items, "tok", stats)
+            self.assertEqual(stats.pulled, 1)
+            self.assertTrue((inbox / "m04-s100-sync-bilateral.md.json").exists())
+
+
+# ---------------------------------------------------------------------------
+# 6. Retry on transient errors (504)
+# ---------------------------------------------------------------------------
+
+class TestRetryBackoff(unittest.TestCase):
+
+    def test_upload_succeeds_after_retry(self):
+        """_upload_with_retry should retry on 504 and succeed on second attempt."""
+        call_count = {"n": 0}
+
+        def _fake_upload(remote_prefix, rel, path, token):
+            call_count["n"] += 1
+            if call_count["n"] < 2:
+                raise urllib.error.HTTPError(
+                    url="", code=504, msg="Gateway Timeout",
+                    hdrs=MagicMock(get=lambda k, d=None: None),
+                    fp=None,
+                )
+
+        stats = mirror.MirrorStats()
+        with patch.object(mirror, "upload_file", side_effect=_fake_upload), \
+             patch("time.sleep"):
+            mirror._upload_with_retry("prefix", "rel/file.json", Path("/tmp/x"), "tok", stats)
+        self.assertEqual(call_count["n"], 2)
+        self.assertEqual(stats.errors, [])
+
+    def test_upload_fails_after_max_retries(self):
+        """_upload_with_retry should classify TRANSIENT_GRAPH_ERROR after exhausting retries."""
+        def _always_504(*args, **kwargs):
+            raise urllib.error.HTTPError(
+                url="", code=504, msg="Gateway Timeout",
+                hdrs=MagicMock(get=lambda k, d=None: None),
+                fp=None,
+            )
+
+        stats = mirror.MirrorStats()
+        with patch.object(mirror, "upload_file", side_effect=_always_504), \
+             patch("time.sleep"):
+            with self.assertRaises(urllib.error.HTTPError):
+                mirror._upload_with_retry("prefix", "rel/file.json", Path("/tmp/x"), "tok", stats)
+
+    def test_transient_codes_defined(self):
+        self.assertIn(504, mirror.TRANSIENT_HTTP_CODES)
+        self.assertIn(429, mirror.TRANSIENT_HTTP_CODES)
+        self.assertIn(408, mirror.TRANSIENT_HTTP_CODES)
+        self.assertIn(503, mirror.TRANSIENT_HTTP_CODES)
+
+
+# ---------------------------------------------------------------------------
+# 7. Secrets not printed or persisted
+# ---------------------------------------------------------------------------
+
+class TestSecretsNotLeaked(unittest.TestCase):
+
+    def test_error_message_does_not_contain_token(self):
+        """When upload fails, the error message must not contain the token string."""
+        stats = mirror.MirrorStats()
+        SECRET_TOKEN = "super-secret-refresh-token-12345"
+
+        def _fail(*args, **kwargs):
+            raise urllib.error.HTTPError(
+                url="", code=401, msg="Unauthorized",
+                hdrs=MagicMock(get=lambda k, d=None: None),
+                fp=None,
+            )
+
+        with patch.object(mirror, "exchange_refresh_token", return_value=SECRET_TOKEN), \
+             patch.object(mirror, "resolve_project_folder", return_value="https://fake/prefix"), \
+             patch.object(mirror, "_upload_with_retry", side_effect=_fail):
+            cfg = mirror.MirrorConfig(
+                source=Path("/tmp"),
+                tenant="consumers",
+                client_id="client-id",
+                refresh_token=SECRET_TOKEN,
+                project_root_name="test",
+                root_mode="approot",
+                create_dirs=True,
+                conflict_behavior="replace",
+                delete_extraneous=False,
+                dry_run=False,
+                sync_mode="local_primary",
+            )
+            with tempfile.TemporaryDirectory() as tmp:
+                p = Path(tmp) / "file.json"
+                p.write_bytes(b"content")
+                mirror.run_live(cfg, [("file.json", p)], stats)
+
+        for err in stats.errors:
+            self.assertNotIn(SECRET_TOKEN, err, "Refresh token must not appear in error messages")
+
+    def test_no_legacy_data_sessions_path(self):
+        """Verify that neither script references data/sessions/ as an output path."""
+        mirror_src = (REPO_ROOT / "python_scripts" / "remote_mirror_out_local.py").read_text()
+        pull_src = (REPO_ROOT / "python_scripts" / "remote_pull_sessions.py").read_text()
+        # The path data/sessions/ must not appear as a write target — only data/out/local/sessions/
+        # Allow it in migration_equivalent checks (path_governance references are OK)
+        for line in mirror_src.splitlines():
+            if "data/sessions/" in line and "migration" not in line.lower() and "#" not in line:
+                self.fail(f"remote_mirror_out_local.py references legacy data/sessions/ path: {line!r}")
+        for line in pull_src.splitlines():
+            if "data/sessions/" in line and "#" not in line:
+                self.fail(f"remote_pull_sessions.py references legacy data/sessions/ path: {line!r}")
+
+
+# ---------------------------------------------------------------------------
+# 8. Stats error classification
+# ---------------------------------------------------------------------------
+
+class TestStatsErrorClassification(unittest.TestCase):
+
+    def test_add_error_classifies_by_type(self):
+        stats = mirror.MirrorStats()
+        stats.add_error("AUTH_ERROR", "auth failed")
+        stats.add_error("TRANSIENT_GRAPH_ERROR", "504")
+        stats.add_error("TRANSIENT_GRAPH_ERROR", "503")
+        self.assertEqual(stats.errors_by_type["AUTH_ERROR"], 1)
+        self.assertEqual(stats.errors_by_type["TRANSIENT_GRAPH_ERROR"], 2)
+        self.assertEqual(len(stats.errors), 3)
+
+    def test_add_excluded_counts_by_reason(self):
+        stats = mirror.MirrorStats()
+        stats.add_excluded("windows_ads_zone_identifier")
+        stats.add_excluded("windows_ads_zone_identifier")
+        stats.add_excluded("dotenv_credentials")
+        self.assertEqual(stats.excluded, 3)
+        self.assertEqual(stats.excluded_reasons["windows_ads_zone_identifier"], 2)
+        self.assertEqual(stats.excluded_reasons["dotenv_credentials"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR: pipeline(pipeline): sync bilateral OneDrive — mirror local→remoto y pull remoto→staging gobernado con allowlist y admission gate

```text
Commit: feat(pipeline): implementa sync bilateral gobernada OneDrive con pull remoto controlado y admisión de staging
Meta: Es:listo|V:1|R:3|Md:estable|B:pipeline|Ctx:runtime|Pr:P1|Sz:L|Est:8|Dr:-1|Dc:+2
Arch: Sb:Ejecución|Ea:Implementación|Cx:Orquestación segura|Lg:PYTHON|Mdls:remote_mirror_out_local,remote_pull_sessions,mcp_env_manager,test_remote_mirror_out_local,remote_inbox
```

---

## Metadatos

| Campo | Valor |
|-------|-------|
| Estado | listo |
| Vuelta | 1 |
| Radio | 3 |
| Madurez | estable |
| Bloque | pipeline |
| ContextoCambio | runtime |
| Priority | P1 |
| Size | L |
| Estimate | 8 |
| Delta-r | -1 |
| Delta-c | +2 |

---

## Tablero y Arquitectura

| Campo | Valor |
|-------|-------|
| StatusTablero | Ejecución |
| EstadoArquitectonico | Implementación |
| Caja | Orquestación segura |
| Lenguajes | PYTHON |
| Modulos | remote_mirror_out_local, remote_pull_sessions, mcp_env_manager, test_remote_mirror_out_local, remote_inbox |

---

## Objetivo

Implementar y dejar gobernada la sincronización bilateral entre el entorno local y OneDrive remoto, completando la arquitectura asimétrica del sistema: `LOCAL→REMOTO` como mirror gobernado (ya existente pero reforzado), `REMOTO→LOCAL` como pull controlado con staging y admission gate (nuevo en S100).

El objetivo operativo es que ningún candidato remoto llegue directamente al canon: todo pasa por `data/tmp/remote_inbox/` como zona de cuarentena, con allowlist de nombres validada antes de escritura local.

---

## Resultado integrado

El repositorio queda con una arquitectura de sync bilateral funcional, secretless y auditada:

- `remote_mirror_out_local.py` queda reforzado con exclusiones tipadas, URL-encoding seguro por segmento, retry/backoff exponencial y protección de rutas remotas críticas contra prune.
- `remote_pull_sessions.py` es un nuevo módulo que implementa el flujo inverso REMOTO→LOCAL con allowlist estricta, denylist defensiva y staging en `data/tmp/remote_inbox/`.
- `mcp_env_manager.py` queda actualizado con opciones 9-12 que exponen el nuevo flujo bilateral al operador.
- `tests/test_remote_mirror_out_local.py` cubre 39 casos nuevos incluyendo path encoding, Zone.Identifier, prune protection, pull allowlist/denylist, retry 504 y no-secrets-leaked.
- 156 tests pasan. Los 2 fallos preexistentes son de S55/S65, no introducidos en S100.

---

## Acciones realizadas

- Se añadió `iter_syncable_files()` a `remote_mirror_out_local.py` con exclusiones explícitas: `Zone.Identifier`, `.env`, `.DS_Store`, `Thumbs.db`, `desktop.ini`, `*.tmp`, `*.lock`, `*.swp`, `*.bak`, `__pycache__/`, `.pytest_cache/`, `.mypy_cache/`, `.git/`.
- Se añadieron `encode_graph_path_segment()` y `encode_graph_rel_path()` para URL-encoding seguro por segmento en Graph API.
- Se añadió `_upload_with_retry()` con backoff exponencial para códigos `408/429/500/502/503/504`.
- Se añadió `_is_protected_remote_path()` para proteger `_remote_outbox/` del prune.
- Se extendió `MirrorStats` con campos tipados: `excluded`, `excluded_reasons`, `protected`, `errors_by_type`.
- Se actualizaron `run_dry_run` y `run_live` para consumir las nuevas funciones. El resumen JSON del sync incluye los nuevos campos.
- Se creó `remote_pull_sessions.py` con flujo completo REMOTO→LOCAL: allowlist `mXX-sNN-[a-z]?-*.md.json`, denylist `tiddlers_*.jsonl / .env / ADS`, staging en `data/tmp/remote_inbox/`, config vía env (`REMOTE_INBOX_DIR`, `SYNC_DRY_RUN`, `MSA_TENANT`, `ONEDRIVE_PROJECT_ROOT_NAME`), secrets runtime-only, clasificación de errores tipada (`AUTH_ERROR`, `PERMISSION_ERROR`, `TRANSIENT_GRAPH_ERROR`, `LOCAL_SAFETY_ERROR`).
- Se creó `data/tmp/remote_inbox/` con `.gitkeep` para persistir la zona de staging en git.
- Se actualizó `mcp_env_manager.py`: opción 9 preview pull dry-run, opción 10 pull live con confirmación, opción 11 ver último reporte, opción 12 resetear variable operativa (era opción 9), etiquetas de opciones 1 y 8 actualizadas.
- Se creó `tests/test_remote_mirror_out_local.py` con 39 tests cubriendo path encoding, exclusión Zone.Identifier, prune protection, allowlist/denylist del pull, retry 504 y verificación de no-leak de secrets.

---

## Archivos modificados / añadidos

- `python_scripts/remote_mirror_out_local.py`
  - Modificado. Refuerzo de exclusiones, URL-encoding, retry/backoff, prune protection, `MirrorStats` extendido.

- `python_scripts/remote_pull_sessions.py`
  - Creado. Módulo nuevo para el flujo REMOTO→LOCAL con allowlist, denylist y staging.

- `python_scripts/mcp_env_manager.py`
  - Modificado. Opciones 9-12 para pull bilateral; etiquetas de opciones 1 y 8 actualizadas.

- `data/tmp/remote_inbox/.gitkeep`
  - Creado. Persiste la zona de staging en git para candidatos remotos.

- `tests/test_remote_mirror_out_local.py`
  - Creado. 39 tests cubriendo superficies de seguridad y comportamiento del sync bilateral.

- `data/out/local/sessions/00_contratos/m04-s100-sync-bilateral-gobernada-onedrive-admission-gated.md.json`
  - Creado. Contrato de sesión S100 bajo familia operativa de contratos.

- `data/out/local/sessions/02_detalles_de_sesion/m04-s100-sync-bilateral-gobernada-onedrive-admission-gated.md.json`
  - Creado. Detalles técnicos y validaciones ejecutadas de la sesión.

---

## Comprobaciones sugeridas

- Verificar que `python3 -m py_compile` pasa para `remote_mirror_out_local.py`, `remote_pull_sessions.py` y `mcp_env_manager.py`.
- Verificar que `python3 -m pytest tests/ -q` reporta 156 passed con los mismos 2 fallos preexistentes de S55/S65 y ningún fallo nuevo.
- Verificar que `remote_pull_sessions.py` en dry-run no escribe ningún archivo en `data/tmp/remote_inbox/`.
- Verificar que `_is_protected_remote_path()` bloquea rutas que contengan `_remote_outbox/`.
- Verificar que ningún test ni ningún script imprime `MSA_REFRESH_TOKEN`, `AZURE_CLIENT_ID` ni cabeceras `Authorization`.
- Verificar que `data/tmp/remote_inbox/` existe en git vía `.gitkeep`.
- Verificar que el contrato de sesión `.md.json` existe bajo `data/out/local/sessions/00_contratos/`.
- Verificar que el cambio no afecta canon directamente (`AGENT_DIRECT_CANON_WRITE=false` es el valor operativo activo).
- Verificar que no se introdujeron rutas `data/sessions/` (ruta deprecada desde S94).

---

## Notas para el revisor

S100 cierra la arquitectura bilateral de sync: el flujo `LOCAL→REMOTO` ya existía; esta sesión añade `REMOTO→LOCAL` con staging controlado y admission gate, sin escritura directa al canon.

Los secrets (`MSA_REFRESH_TOKEN`, `AZURE_CLIENT_ID`) son runtime-only. No hay credenciales hardcodeadas ni en tests.

Los 2 fallos preexistentes en pytest corresponden a S55/S65 y son conocidos. No fueron introducidos en S100 ni son bloqueantes para esta integración.

El sync real (live `LOCAL→REMOTO` y live `REMOTO→LOCAL`) no fue ejecutado en S100. Requiere confirmación humana explícita y credenciales runtime activas. Esta restricción es contractual y se mantiene.

El contrato de sesión `.md.json` existe bajo `data/out/local/sessions/00_contratos/`. La admisión canónica no se ejecutó porque no hay candidatos externos nuevos en esta sesión.
```