### PR TITLE
feat(pipeline): implementa flujo de admisión de metadatos de repositorio

### DIFF
--- a/estructura.txt
+++ b/estructura.txt
@@ -220,6 +220,13 @@
 │   │   │   │   ├── canon.entries.json
 │   │   │   │   ├── canon.jsonl
 │   │   │   │   ├── ingesta.tiddlers.json
+│   │   │   │   ├── menu_refactor
+│   │   │   │   │   └── s0150
+│   │   │   │   │       ├── s0150_menu_after.txt
+│   │   │   │   │       ├── s0150_menu_before.txt
+│   │   │   │   │       ├── s0150_menu_compatibility_report.md
+│   │   │   │   │       ├── s0150_menu_mapping.json
+│   │   │   │   │       └── s0150_menu_operator_guide.md
 │   │   │   │   ├── raw.tiddlers.json
 │   │   │   │   ├── relation_admissibility
 │   │   │   │   │   └── s0132
@@ -335,6 +342,73 @@
 │   │   │   │   │       ├── unresolved_candidates.jsonl
 │   │   │   │   │       ├── valid_candidates.jsonl
 │   │   │   │   │       └── validation_report.json
+│   │   │   │   ├── repo_artifacts
+│   │   │   │   │   └── s0146
+│   │   │   │   │       ├── s0146_generated_output_candidates.jsonl
+│   │   │   │   │       ├── s0146_moved_candidates.jsonl
+│   │   │   │   │       ├── s0146_narrative_code_reference_candidates.jsonl
+│   │   │   │   │       ├── s0146_repo_artifact_classification.jsonl
+│   │   │   │   │       ├── s0146_repo_artifact_grouped_summary.json
+│   │   │   │   │       ├── s0146_repo_artifact_grouped_summary.md
+│   │   │   │   │       ├── s0146_repo_artifact_mapping_preview.json
+│   │   │   │   │       ├── s0146_repo_artifact_metadata_contract.md
+│   │   │   │   │       ├── s0146_repo_artifact_relation_opportunities.jsonl
+│   │   │   │   │       ├── s0146_repo_artifact_review.csv
+│   │   │   │   │       ├── s0146_repo_artifact_rules.json
+│   │   │   │   │       ├── s0146_repo_artifact_samples.md
+│   │   │   │   │       ├── s0146_repo_lifecycle_report.json
+│   │   │   │   │       ├── s0146_repo_lifecycle_report.md
+│   │   │   │   │       ├── s0146_repo_path_mismatch_report.json
+│   │   │   │   │       └── s0146_technical_tiddler_inventory.json
+│   │   │   │   ├── repo_metadata_admission
+│   │   │   │   │   ├── s0149
+│   │   │   │   │   │   ├── s0149_metadata_admission_audit_log.jsonl
+│   │   │   │   │   │   ├── s0149_metadata_admission_blocked.jsonl
+│   │   │   │   │   │   ├── s0149_metadata_admission_dry_run_report.json
+│   │   │   │   │   │   ├── s0149_metadata_admission_patch_preview.jsonl
+│   │   │   │   │   │   ├── s0149_metadata_admission_ready.jsonl
+│   │   │   │   │   │   ├── s0149_metadata_admission_review.csv
+│   │   │   │   │   │   ├── s0149_metadata_admission_summary.md
+│   │   │   │   │   │   ├── s0149_metadata_apply_report.json
+│   │   │   │   │   │   ├── s0149_metadata_operator_flow_report.md
+│   │   │   │   │   │   └── s0149_selected_batches.json
+│   │   │   │   │   └── s0150
+│   │   │   │   │       ├── s0150_metadata_patch_hashes_refreshed.json
+│   │   │   │   │       ├── s0150_metadata_patch_preview_refreshed.jsonl
+│   │   │   │   │       ├── s0150_metadata_refresh_blocked.jsonl
+│   │   │   │   │       ├── s0150_metadata_refresh_report.json
+│   │   │   │   │       ├── s0150_metadata_refresh_review.csv
+│   │   │   │   │       ├── s0150_metadata_refresh_summary.md
+│   │   │   │   │       └── s0150_metadata_review_batches_refreshed.json
+│   │   │   │   ├── repo_metadata_review
+│   │   │   │   │   ├── s0147
+│   │   │   │   │   │   ├── s0147_relation_opportunities_context.md
+│   │   │   │   │   │   ├── s0147_repo_metadata_dry_run_report.json
+│   │   │   │   │   │   ├── s0147_repo_metadata_excluded_records.jsonl
+│   │   │   │   │   │   ├── s0147_repo_metadata_menu_contract.md
+│   │   │   │   │   │   ├── s0147_repo_metadata_operator_instructions.md
+│   │   │   │   │   │   ├── s0147_repo_metadata_patch_hashes.json
+│   │   │   │   │   │   ├── s0147_repo_metadata_patch_preview.jsonl
+│   │   │   │   │   │   ├── s0147_repo_metadata_patch_summary.json
+│   │   │   │   │   │   ├── s0147_repo_metadata_patch_summary.md
+│   │   │   │   │   │   ├── s0147_repo_metadata_review.csv
+│   │   │   │   │   │   ├── s0147_repo_metadata_review_batches.json
+│   │   │   │   │   │   ├── s0147_repo_metadata_review_queue.jsonl
+│   │   │   │   │   │   ├── s0147_repo_metadata_risk_report.json
+│   │   │   │   │   │   ├── s0147_repo_metadata_risk_report.md
+│   │   │   │   │   │   └── s0147_repo_metadata_validation_report.json
+│   │   │   │   │   └── s0148
+│   │   │   │   │       ├── s0148_repo_metadata_admission_ready_dry_run.jsonl
+│   │   │   │   │       ├── s0148_repo_metadata_batch_approvals.json
+│   │   │   │   │       ├── s0148_repo_metadata_blocked_records.jsonl
+│   │   │   │   │       ├── s0148_repo_metadata_gate_report.json
+│   │   │   │   │       ├── s0148_repo_metadata_hash_verification.json
+│   │   │   │   │       ├── s0148_repo_metadata_human_decisions.json
+│   │   │   │   │       ├── s0148_repo_metadata_next_apply_plan.md
+│   │   │   │   │       ├── s0148_repo_metadata_operator_summary.md
+│   │   │   │   │       ├── s0148_repo_metadata_rejected_or_deferred_batches.json
+│   │   │   │   │       ├── s0148_repo_metadata_risk_verification.json
+│   │   │   │   │       └── s0148_repo_metadata_terminal_audit.jsonl
 │   │   │   │   ├── reversible_metadata
 │   │   │   │   │   ├── s0134
 │   │   │   │   │   │   ├── s0134_reversible_metadata_matrix.json
@@ -354,81 +428,101 @@
 │   │   │   │   │       ├── s0144_semantic_text_profiles.json
 │   │   │   │   │       ├── s0144_semantic_text_records.jsonl
 │   │   │   │   │       └── s0144_semantic_text_review.csv
-│   │   │   │   └── source_fields
-│   │   │   │       └── s0133
-│   │   │   │           ├── s0133_source_fields_contract_report.json
-│   │   │   │           ├── s0133_source_fields_review.csv
-│   │   │   │           └── s0133_source_fields_summary.md
+│   │   │   │   ├── semantic_text_authority
+│   │   │   │   │   └── s0149
+│   │   │   │   │       ├── s0149_semantic_text_authority_coverage_report.json
+│   │   │   │   │       ├── s0149_semantic_text_authority_hashes.json
+│   │   │   │   │       ├── s0149_semantic_text_authority_index.json
+│   │   │   │   │       ├── s0149_semantic_text_authority_records.jsonl
+│   │   │   │   │       ├── s0149_semantic_text_authority_review.csv
+│   │   │   │   │       └── s0149_semantic_text_authority_summary.md
+│   │   │   │   ├── source_fields
+│   │   │   │   │   └── s0133
+│   │   │   │   │       ├── s0133_source_fields_contract_report.json
+│   │   │   │   │       ├── s0133_source_fields_review.csv
+│   │   │   │   │       └── s0133_source_fields_summary.md
+│   │   │   │   ├── test_saneamiento
+│   │   │   │   │   └── s0150
+│   │   │   │   │       ├── s0150_legacy_test_classification.json
+│   │   │   │   │       ├── s0150_legacy_test_classification.md
+│   │   │   │   │       ├── s0150_pytest_full.log
+│   │   │   │   │       └── s0150_test_update_plan.md
+│   │   │   │   └── unknown_artifact_family
+│   │   │   │       └── s0145
+│   │   │   │           ├── s0145_artifact_family_mapping_preview.json
+│   │   │   │           ├── s0145_artifact_family_proposal.md
+│   │   │   │           ├── s0145_unknown_classification_candidates.jsonl
+│   │   │   │           ├── s0145_unknown_classification_rules.json
+│   │   │   │           ├── s0145_unknown_grouped_summary.json
+│   │   │   │           ├── s0145_unknown_grouped_summary.md
+│   │   │   │           ├── s0145_unknown_inventory.json
+│   │   │   │           ├── s0145_unknown_review.csv
+│   │   │   │           └── s0145_unknown_samples.md
 │   │   │   ├── reverse_html
 │   │   │   │   ├── reverse-report.json
 │   │   │   │   └── tiddly-data-converter.derived.html
 │   │   │   ├── sessions
 │   │   │   │   ├── 00_contratos
-│   │   │   │   │   ├── m04-s0138-contrato-integracion-exportador-repositorio-menu-principal.md.json
-│   │   │   │   │   ├── m04-s0139-contrato-decision-gobernada-tipos-relacionales-historicos.md.json
-│   │   │   │   │   ├── m04-s0140-contrato-primer-ciclo-real-human-review-aprobado-dry-run.md.json
-│   │   │   │   │   ├── m04-s0141-contrato-integracion-operativa-human-review-menu-relacional-visualizacion-resultados-dry-run.md.json
-│   │   │   │   │   ├── m04-s0142-contrato-aprobacion-batch-gobernada-human-review-relacional-terminal.md.json
-│   │   │   │   │   ├── m04-s0143-contrato-simplificacion-operativa-menu-relacional-batch-dry-run.md.json
-│   │   │   │   │   ├── m04-s0144-contrato-semantic-text-deterministico-por-artifact-family.md.json
+│   │   │   │   │   ├── m04-s0145-contrato-caracterizacion-registros-unknown-propuesta-artifact-family-referencias-especificas.md.json
+│   │   │   │   │   ├── m04-s0146-contrato-caracterizacion-gobernada-tiddlers-tecnicos-matriz-repo-artifact-antes-metadata-canonica.md.json
+│   │   │   │   │   ├── m04-s0147-contrato-patch-preview-metadata-tecnica-estratificada-menu-revision-local.md.json
+│   │   │   │   │   ├── m04-s0148-contrato-aprobacion-batch-metadata-tecnica-terminal-compuerta-admision-dry-run.md.json
+│   │   │   │   │   ├── m04-s0149-contrato-menu-gobernado-admision-metadata-tecnica-semantic-text-authority-aware.md.json
+│   │   │   │   │   ├── m04-s0150-contrato-centralizacion-menu-canonico-refresh-metadata-saneamiento-tests-legacy.md.json
 │   │   │   │   │   ├── policy
 │   │   │   │   │   │   ├── canon_policy_bundle.json
 │   │   │   │   │   │   └── estructura_de_commits_tiddly-data-converter.JSON
 │   │   │   │   │   └── projections
 │   │   │   │   │       └── derived_layers_registry.json
 │   │   │   │   ├── 01_procedencia
-│   │   │   │   │   ├── m04-s0138-procedencia-integracion-exportador-repositorio-menu-principal.md.json
-│   │   │   │   │   ├── m04-s0139-procedencia-decision-gobernada-tipos-relacionales-historicos.md.json
-│   │   │   │   │   ├── m04-s0140-procedencia-primer-ciclo-real-human-review-aprobado-dry-run.md.json
-│   │   │   │   │   ├── m04-s0141-procedencia-integracion-operativa-human-review-menu-relacional-visualizacion-resultados-dry-run.md.json
-│   │   │   │   │   ├── m04-s0142-procedencia-aprobacion-batch-gobernada-human-review-relacional-terminal.md.json
-│   │   │   │   │   ├── m04-s0143-procedencia-simplificacion-operativa-menu-relacional-batch-dry-run.md.json
-│   │   │   │   │   └── m04-s0144-procedencia-semantic-text-deterministico-por-artifact-family.md.json
+│   │   │   │   │   ├── m04-s0145-procedencia-caracterizacion-registros-unknown-propuesta-artifact-family-referencias-especificas.md.json
+│   │   │   │   │   ├── m04-s0146-procedencia-caracterizacion-gobernada-tiddlers-tecnicos-matriz-repo-artifact-antes-metadata-canonica.md.json
+│   │   │   │   │   ├── m04-s0147-procedencia-patch-preview-metadata-tecnica-estratificada-menu-revision-local.md.json
+│   │   │   │   │   ├── m04-s0148-procedencia-aprobacion-batch-metadata-tecnica-terminal-compuerta-admision-dry-run.md.json
+│   │   │   │   │   ├── m04-s0149-procedencia-menu-gobernado-admision-metadata-tecnica-semantic-text-authority-aware.md.json
+│   │   │   │   │   └── m04-s0150-procedencia-centralizacion-menu-canonico-refresh-metadata-saneamiento-tests-legacy.md.json
 │   │   │   │   ├── 02_detalles_de_sesion
-│   │   │   │   │   ├── m04-s0139-decision-gobernada-tipos-relacionales-historicos.md.json
-│   │   │   │   │   ├── m04-s0140-primer-ciclo-real-human-review-aprobado-dry-run.md.json
-│   │   │   │   │   ├── m04-s0141-integracion-operativa-human-review-menu-relacional-visualizacion-resultados-dry-run.md.json
-│   │   │   │   │   ├── m04-s0142-aprobacion-batch-gobernada-human-review-relacional-terminal.md.json
-│   │   │   │   │   ├── m04-s0143-simplificacion-operativa-menu-relacional-batch-dry-run.md.json
-│   │   │   │   │   └── m04-s0144-semantic-text-deterministico-por-artifact-family.md.json
+│   │   │   │   │   ├── m04-s0145-caracterizacion-registros-unknown-propuesta-artifact-family-referencias-especificas.md.json
+│   │   │   │   │   ├── m04-s0146-caracterizacion-gobernada-tiddlers-tecnicos-matriz-repo-artifact-antes-metadata-canonica.md.json
+│   │   │   │   │   ├── m04-s0147-patch-preview-metadata-tecnica-estratificada-menu-revision-local.md.json
+│   │   │   │   │   ├── m04-s0148-aprobacion-batch-metadata-tecnica-terminal-compuerta-admision-dry-run.md.json
+│   │   │   │   │   ├── m04-s0149-menu-gobernado-admision-metadata-tecnica-semantic-text-authority-aware.md.json
+│   │   │   │   │   └── m04-s0150-centralizacion-menu-canonico-refresh-metadata-saneamiento-tests-legacy.md.json
 │   │   │   │   ├── 03_hipotesis
-│   │   │   │   │   ├── m04-s0138-hipotesis-integracion-exportador-repositorio-menu-principal.md.json
-│   │   │   │   │   ├── m04-s0139-hipotesis-decision-gobernada-tipos-relacionales-historicos.md.json
-│   │   │   │   │   ├── m04-s0140-hipotesis-primer-ciclo-real-human-review-aprobado-dry-run.md.json
-│   │   │   │   │   ├── m04-s0141-hipotesis-integracion-operativa-human-review-menu-relacional-visualizacion-resultados-dry-run.md.json
-│   │   │   │   │   ├── m04-s0142-hipotesis-aprobacion-batch-gobernada-human-review-relacional-terminal.md.json
-│   │   │   │   │   ├── m04-s0143-hipotesis-simplificacion-operativa-menu-relacional-batch-dry-run.md.json
-│   │   │   │   │   └── m04-s0144-hipotesis-semantic-text-deterministico-por-artifact-family.md.json
+│   │   │   │   │   ├── m04-s0145-hipotesis-caracterizacion-registros-unknown-propuesta-artifact-family-referencias-especificas.md.json
+│   │   │   │   │   ├── m04-s0146-hipotesis-caracterizacion-gobernada-tiddlers-tecnicos-matriz-repo-artifact-antes-metadata-canonica.md.json
+│   │   │   │   │   ├── m04-s0147-hipotesis-patch-preview-metadata-tecnica-estratificada-menu-revision-local.md.json
+│   │   │   │   │   ├── m04-s0148-hipotesis-aprobacion-batch-metadata-tecnica-terminal-compuerta-admision-dry-run.md.json
+│   │   │   │   │   ├── m04-s0149-hipotesis-menu-gobernado-admision-metadata-tecnica-semantic-text-authority-aware.md.json
+│   │   │   │   │   └── m04-s0150-hipotesis-centralizacion-menu-canonico-refresh-metadata-saneamiento-tests-legacy.md.json
 │   │   │   │   ├── 04_balance_de_sesion
-│   │   │   │   │   ├── m04-s0138-balance-integracion-exportador-repositorio-menu-principal.md.json
-│   │   │   │   │   ├── m04-s0139-balance-decision-gobernada-tipos-relacionales-historicos.md.json
-│   │   │   │   │   ├── m04-s0140-balance-primer-ciclo-real-human-review-aprobado-dry-run.md.json
-│   │   │   │   │   ├── m04-s0141-balance-integracion-operativa-human-review-menu-relacional-visualizacion-resultados-dry-run.md.json
-│   │   │   │   │   ├── m04-s0142-balance-aprobacion-batch-gobernada-human-review-relacional-terminal.md.json
-│   │   │   │   │   ├── m04-s0143-balance-simplificacion-operativa-menu-relacional-batch-dry-run.md.json
-│   │   │   │   │   └── m04-s0144-balance-semantic-text-deterministico-por-artifact-family.md.json
+│   │   │   │   │   ├── m04-s0145-balance-caracterizacion-registros-unknown-propuesta-artifact-family-referencias-especificas.md.json
+│   │   │   │   │   ├── m04-s0146-balance-caracterizacion-gobernada-tiddlers-tecnicos-matriz-repo-artifact-antes-metadata-canonica.md.json
+│   │   │   │   │   ├── m04-s0147-balance-patch-preview-metadata-tecnica-estratificada-menu-revision-local.md.json
+│   │   │   │   │   ├── m04-s0148-balance-aprobacion-batch-metadata-tecnica-terminal-compuerta-admision-dry-run.md.json
+│   │   │   │   │   ├── m04-s0149-balance-menu-gobernado-admision-metadata-tecnica-semantic-text-authority-aware.md.json
+│   │   │   │   │   └── m04-s0150-balance-centralizacion-menu-canonico-refresh-metadata-saneamiento-tests-legacy.md.json
 │   │   │   │   ├── 05_propuesta_de_sesion
-│   │   │   │   │   ├── m04-s0138-propuesta-integracion-exportador-repositorio-menu-principal.md.json
-│   │   │   │   │   ├── m04-s0139-propuesta-decision-gobernada-tipos-relacionales-historicos.md.json
-│   │   │   │   │   ├── m04-s0140-propuesta-primer-ciclo-real-human-review-aprobado-dry-run.md.json
-│   │   │   │   │   ├── m04-s0141-propuesta-integracion-operativa-human-review-menu-relacional-visualizacion-resultados-dry-run.md.json
-│   │   │   │   │   ├── m04-s0142-propuesta-aprobacion-batch-gobernada-human-review-relacional-terminal.md.json
-│   │   │   │   │   ├── m04-s0143-propuesta-simplificacion-operativa-menu-relacional-batch-dry-run.md.json
-│   │   │   │   │   └── m04-s0144-propuesta-semantic-text-deterministico-por-artifact-family.md.json
+│   │   │   │   │   ├── m04-s0145-propuesta-caracterizacion-registros-unknown-propuesta-artifact-family-referencias-especificas.md.json
+│   │   │   │   │   ├── m04-s0146-propuesta-caracterizacion-gobernada-tiddlers-tecnicos-matriz-repo-artifact-antes-metadata-canonica.md.json
+│   │   │   │   │   ├── m04-s0147-propuesta-patch-preview-metadata-tecnica-estratificada-menu-revision-local.md.json
+│   │   │   │   │   ├── m04-s0148-propuesta-aprobacion-batch-metadata-tecnica-terminal-compuerta-admision-dry-run.md.json
+│   │   │   │   │   ├── m04-s0149-propuesta-menu-gobernado-admision-metadata-tecnica-semantic-text-authority-aware.md.json
+│   │   │   │   │   └── m04-s0150-propuesta-centralizacion-menu-canonico-refresh-metadata-saneamiento-tests-legacy.md.json
 │   │   │   │   └── 06_diagnoses
 │   │   │   │       ├── meso-ciclo
 │   │   │   │       ├── micro-ciclo
 │   │   │   │       ├── module
 │   │   │   │       ├── proyecto
 │   │   │   │       ├── sesion
-│   │   │   │       │   ├── diagnostico-sesion-s0138-integracion-exportador-repositorio-menu-principal.md.json
-│   │   │   │       │   ├── diagnostico-sesion-s0139-decision-gobernada-tipos-relacionales-historicos.md.json
-│   │   │   │       │   ├── diagnostico-sesion-s0140-primer-ciclo-real-human-review-aprobado-dry-run.md.json
-│   │   │   │       │   ├── diagnostico-sesion-s0141-integracion-operativa-human-review-menu-relacional-visualizacion-resultados-dry-run.md.json
-│   │   │   │       │   ├── diagnostico-sesion-s0142-aprobacion-batch-gobernada-human-review-relacional-terminal.md.json
-│   │   │   │       │   ├── diagnostico-sesion-s0143-simplificacion-operativa-menu-relacional-batch-dry-run.md.json
-│   │   │   │       │   └── diagnostico-sesion-s0144-semantic-text-deterministico-por-artifact-family.md.json
+│   │   │   │       │   ├── diagnostico-sesion-s0145-caracterizacion-registros-unknown-propuesta-artifact-family-referencias-especificas.md.json
+│   │   │   │       │   ├── diagnostico-sesion-s0146-caracterizacion-gobernada-tiddlers-tecnicos-matriz-repo-artifact-antes-metadata-canonica.md.json
+│   │   │   │       │   ├── diagnostico-sesion-s0147-patch-preview-metadata-tecnica-estratificada-menu-revision-local.md.json
+│   │   │   │       │   ├── diagnostico-sesion-s0148-aprobacion-batch-metadata-tecnica-terminal-compuerta-admision-dry-run.md.json
+│   │   │   │       │   ├── diagnostico-sesion-s0149-menu-gobernado-admision-metadata-tecnica-semantic-text-authority-aware.md.json
+│   │   │   │       │   └── diagnostico-sesion-s0150-centralizacion-menu-canonico-refresh-metadata-saneamiento-tests-legacy.md.json
 │   │   │   │       └── tema
+│   │   │   │           └── diagnostico-tematico-037-gobernanza-tiddlers-tecnicos-vigencia-codigo-relaciones-repo-artifact.md.json
 │   │   │   ├── tiddlers-export
 │   │   │   │   └── hashes_rep_export
 │   │   │   ├── tiddlers_1.jsonl
@@ -451,38 +545,455 @@
 │   ├── README.md
 │   └── tmp
 │       ├── admissions
-│       │   ├── admit-20260611215419-multi-session.json
-│       │   ├── admit-20260611215440-multi-session.json
-│       │   └── backups
-│       │       └── admit-20260611215440-multi-session
-│       │           ├── tiddlers_1.jsonl
-│       │           ├── tiddlers_10.jsonl
-│       │           ├── tiddlers_11.jsonl
-│       │           ├── tiddlers_12.jsonl
-│       │           ├── tiddlers_13.jsonl
-│       │           ├── tiddlers_14.jsonl
-│       │           ├── tiddlers_15.jsonl
-│       │           ├── tiddlers_16.jsonl
-│       │           ├── tiddlers_2.jsonl
-│       │           ├── tiddlers_3.jsonl
-│       │           ├── tiddlers_4.jsonl
-│       │           ├── tiddlers_5.jsonl
-│       │           ├── tiddlers_6.jsonl
-│       │           ├── tiddlers_7.jsonl
-│       │           ├── tiddlers_8.jsonl
-│       │           └── tiddlers_9.jsonl
+│       │   ├── admit-20260612191455-multi-session.json
+│       │   ├── admit-20260612191512-multi-session.json
+│       │   ├── backups
+│       │   │   └── admit-20260612191512-multi-session
+│       │   │       ├── tiddlers_1.jsonl
+│       │   │       ├── tiddlers_10.jsonl
+│       │   │       ├── tiddlers_11.jsonl
+│       │   │       ├── tiddlers_12.jsonl
+│       │   │       ├── tiddlers_13.jsonl
+│       │   │       ├── tiddlers_14.jsonl
+│       │   │       ├── tiddlers_15.jsonl
+│       │   │       ├── tiddlers_16.jsonl
+│       │   │       ├── tiddlers_2.jsonl
+│       │   │       ├── tiddlers_3.jsonl
+│       │   │       ├── tiddlers_4.jsonl
+│       │   │       ├── tiddlers_5.jsonl
+│       │   │       ├── tiddlers_6.jsonl
+│       │   │       ├── tiddlers_7.jsonl
+│       │   │       ├── tiddlers_8.jsonl
+│       │   │       └── tiddlers_9.jsonl
+│       │   ├── s69_unittest
+│       │   │   ├── admit-20260612023459-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612023500-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612023502-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612023503-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612023506-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612023514-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612023521-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612143857-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612143858-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612143859-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612143901-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612143904-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612143913-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612143919-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612165915-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612165916-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612165918-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612165920-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612165923-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612165933-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612165941-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612183619-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612183620-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612183622-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612183623-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612183626-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612183635-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612183645-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195201-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195202-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195204-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195206-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195210-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195222-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195230-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195350-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195351-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195353-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195355-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195359-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195412-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612195420-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612203638-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612203639-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612203640-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612203642-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612203645-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612203653-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612203702-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204529-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204530-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204532-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204533-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204536-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204543-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204550-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204736-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204737-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204738-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204740-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204742-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204752-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── admit-20260612204758-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── backups
+│       │   │   │   ├── admit-20260612023521-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── admit-20260612143919-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── admit-20260612165941-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── admit-20260612183645-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── admit-20260612195230-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── admit-20260612195420-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── admit-20260612203702-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── admit-20260612204550-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── admit-20260612204758-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── rollback-20260612023532-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── rollback-20260612143926-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── rollback-20260612165951-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── rollback-20260612183653-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── rollback-20260612195239-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── rollback-20260612195429-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── rollback-20260612203710-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   ├── rollback-20260612204557-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │   │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   │   └── tiddlers_9.jsonl
+│       │   │   │   └── rollback-20260612204805-m04-s98-propagacion-relacional-chunks-ai-y-rule23-pre
+│       │   │   │       ├── tiddlers_1.jsonl
+│       │   │   │       ├── tiddlers_10.jsonl
+│       │   │   │       ├── tiddlers_11.jsonl
+│       │   │   │       ├── tiddlers_12.jsonl
+│       │   │   │       ├── tiddlers_13.jsonl
+│       │   │   │       ├── tiddlers_14.jsonl
+│       │   │   │       ├── tiddlers_15.jsonl
+│       │   │   │       ├── tiddlers_16.jsonl
+│       │   │   │       ├── tiddlers_2.jsonl
+│       │   │   │       ├── tiddlers_3.jsonl
+│       │   │   │       ├── tiddlers_4.jsonl
+│       │   │   │       ├── tiddlers_5.jsonl
+│       │   │   │       ├── tiddlers_6.jsonl
+│       │   │   │       ├── tiddlers_7.jsonl
+│       │   │   │       ├── tiddlers_8.jsonl
+│       │   │   │       └── tiddlers_9.jsonl
+│       │   │   ├── rollback-20260612023532-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── rollback-20260612143926-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── rollback-20260612165951-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── rollback-20260612183653-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── rollback-20260612195239-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── rollback-20260612195429-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── rollback-20260612203710-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── rollback-20260612204557-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── rollback-20260612204805-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── validate-20260612023504-missing-source-path.json
+│       │   │   ├── validate-20260612023514-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── validate-20260612143902-missing-source-path.json
+│       │   │   ├── validate-20260612143912-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── validate-20260612165922-missing-source-path.json
+│       │   │   ├── validate-20260612165932-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── validate-20260612183625-missing-source-path.json
+│       │   │   ├── validate-20260612183634-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── validate-20260612195208-missing-source-path.json
+│       │   │   ├── validate-20260612195221-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── validate-20260612195357-missing-source-path.json
+│       │   │   ├── validate-20260612195411-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── validate-20260612203644-missing-source-path.json
+│       │   │   ├── validate-20260612203653-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── validate-20260612204535-missing-source-path.json
+│       │   │   ├── validate-20260612204543-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   │   ├── validate-20260612204741-missing-source-path.json
+│       │   │   └── validate-20260612204751-m04-s98-propagacion-relacional-chunks-ai-y-rule23.json
+│       │   ├── validate-20260612024926-multi-session.json
+│       │   ├── validate-20260612024941-multi-session.json
+│       │   ├── validate-20260612025104-multi-session.json
+│       │   ├── validate-20260612135757-multi-session.json
+│       │   ├── validate-20260612135933-multi-session.json
+│       │   ├── validate-20260612135934-multi-session.json
+│       │   ├── validate-20260612144226-multi-session.json
+│       │   ├── validate-20260612144227-multi-session.json
+│       │   ├── validate-20260612144316-multi-session.json
+│       │   ├── validate-20260612165846-multi-session.json
+│       │   ├── validate-20260612170101-multi-session.json
+│       │   ├── validate-20260612183611-multi-session.json
+│       │   ├── validate-20260612183805-multi-session.json
+│       │   ├── validate-20260612195750-multi-session.json
+│       │   └── validate-20260612205103-multi-session.json
+│       ├── canonical_quality
+│       │   └── quality-20260612191616
+│       │       ├── canonical-line-gate.json
+│       │       └── deep-node-inspect.json
 │       ├── html_export
-│       │   └── export-20260611215336
+│       │   └── export-20260612191419
 │       │       ├── tiddlers.export.jsonl
 │       │       ├── tiddlers.export.log
 │       │       └── tiddlers.export.manifest.json
 │       ├── reconstruction
-│       │   ├── diagnostic-20260611215331
+│       │   ├── diagnostic-20260612191416
 │       │   │   └── gate-report.json
-│       │   ├── export-20260611215336
+│       │   ├── export-20260612191419
 │       │   │   ├── gate-report.json
 │       │   │   └── reconstruction-report.json
-│       │   ├── reconstruction-20260611215346
+│       │   ├── reconstruction-20260612191431
 │       │   │   ├── canon_after
 │       │   │   │   ├── tiddlers_1.jsonl
 │       │   │   │   ├── tiddlers_10.jsonl
@@ -519,11 +1030,32 @@
 │       │   │   │   └── tiddlers_9.jsonl
 │       │   │   ├── gate-report.json
 │       │   │   └── reconstruction-report.json
-│       │   └── reverse-20260611215540
+│       │   └── reverse-20260612191557
 │       │       ├── gate-report.json
 │       │       └── reconstruction-report.json
+│       ├── sanitation
+│       │   ├── backup-20260612023538
+│       │   │   └── tiddlers_1.jsonl
+│       │   ├── backup-20260612143932
+│       │   │   └── tiddlers_1.jsonl
+│       │   ├── backup-20260612165958
+│       │   │   └── tiddlers_1.jsonl
+│       │   ├── backup-20260612183659
+│       │   │   └── tiddlers_1.jsonl
+│       │   ├── backup-20260612183700
+│       │   │   └── tiddlers_1.jsonl
+│       │   ├── backup-20260612195247
+│       │   │   └── tiddlers_1.jsonl
+│       │   ├── backup-20260612195438
+│       │   │   └── tiddlers_1.jsonl
+│       │   ├── backup-20260612203717
+│       │   │   └── tiddlers_1.jsonl
+│       │   ├── backup-20260612204605
+│       │   │   └── tiddlers_1.jsonl
+│       │   └── backup-20260612204812
+│       │       └── tiddlers_1.jsonl
 │       ├── session_admission
-│       │   ├── admit-20260611215419-multi-session
+│       │   ├── admit-20260612191455-multi-session
 │       │   │   ├── admission_lines.normalized.jsonl
 │       │   │   ├── admission_lines.raw.jsonl
 │       │   │   ├── canon
@@ -544,9 +1076,9 @@
 │       │   │   │   ├── tiddlers_8.jsonl
 │       │   │   │   └── tiddlers_9.jsonl
 │       │   │   └── reverse_html
-│       │   │       ├── admit-20260611215419-multi-session.derived.html
-│       │   │       └── admit-20260611215419-multi-session.reverse-report.json
-│       │   └── admit-20260611215440-multi-session
+│       │   │       ├── admit-20260612191455-multi-session.derived.html
+│       │   │       └── admit-20260612191455-multi-session.reverse-report.json
+│       │   └── admit-20260612191512-multi-session
 │       │       ├── admission_lines.normalized.jsonl
 │       │       ├── admission_lines.raw.jsonl
 │       │       ├── canon
@@ -567,10 +1099,886 @@
 │       │       │   ├── tiddlers_8.jsonl
 │       │       │   └── tiddlers_9.jsonl
 │       │       └── reverse_html
-│       │           ├── admit-20260611215440-multi-session.derived.html
-│       │           └── admit-20260611215440-multi-session.reverse-report.json
+│       │           ├── admit-20260612191512-multi-session.derived.html
+│       │           └── admit-20260612191512-multi-session.reverse-report.json
+│       ├── session_admission_s69_unittest
+│       │   ├── admit-20260612023506-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612023506-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612023506-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612023514-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612023514-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612023514-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612023521-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612023521-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612023521-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612143904-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612143904-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612143904-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612143913-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612143913-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612143913-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612143919-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612143919-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612143919-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612165923-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612165923-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612165923-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612165933-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612165933-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612165933-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612165941-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612165941-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612165941-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612183626-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612183626-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612183626-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612183635-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612183635-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612183635-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612183645-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612183645-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612183645-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612195210-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612195210-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612195210-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612195222-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612195222-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612195222-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612195230-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612195230-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612195230-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612195359-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612195359-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612195359-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612195412-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612195412-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612195412-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612195420-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612195420-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612195420-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612203645-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612203645-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612203645-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612203653-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612203653-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612203653-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612203702-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612203702-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612203702-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612204536-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612204536-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612204536-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612204543-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       └── admit-20260612204543-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612204550-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612204550-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612204550-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612204742-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612204742-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612204742-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612204752-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612204752-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612204752-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── admit-20260612204758-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── admission_lines.normalized.jsonl
+│       │   │   ├── admission_lines.raw.jsonl
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── admit-20260612204758-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── admit-20260612204758-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── rollback-20260612023532-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260612023532-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── rollback-20260612023532-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── rollback-20260612143926-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260612143926-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── rollback-20260612143926-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── rollback-20260612165951-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260612165951-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── rollback-20260612165951-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── rollback-20260612183653-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260612183653-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── rollback-20260612183653-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── rollback-20260612195239-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260612195239-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── rollback-20260612195239-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── rollback-20260612195429-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260612195429-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── rollback-20260612195429-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── rollback-20260612203710-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260612203710-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── rollback-20260612203710-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   ├── rollback-20260612204557-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │   │   ├── canon
+│       │   │   │   ├── tiddlers_1.jsonl
+│       │   │   │   ├── tiddlers_10.jsonl
+│       │   │   │   ├── tiddlers_11.jsonl
+│       │   │   │   ├── tiddlers_12.jsonl
+│       │   │   │   ├── tiddlers_13.jsonl
+│       │   │   │   ├── tiddlers_14.jsonl
+│       │   │   │   ├── tiddlers_15.jsonl
+│       │   │   │   ├── tiddlers_16.jsonl
+│       │   │   │   ├── tiddlers_2.jsonl
+│       │   │   │   ├── tiddlers_3.jsonl
+│       │   │   │   ├── tiddlers_4.jsonl
+│       │   │   │   ├── tiddlers_5.jsonl
+│       │   │   │   ├── tiddlers_6.jsonl
+│       │   │   │   ├── tiddlers_7.jsonl
+│       │   │   │   ├── tiddlers_8.jsonl
+│       │   │   │   └── tiddlers_9.jsonl
+│       │   │   └── reverse_html
+│       │   │       ├── rollback-20260612204557-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │   │       └── rollback-20260612204557-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
+│       │   └── rollback-20260612204805-m04-s98-propagacion-relacional-chunks-ai-y-rule23
+│       │       ├── canon
+│       │       │   ├── tiddlers_1.jsonl
+│       │       │   ├── tiddlers_10.jsonl
+│       │       │   ├── tiddlers_11.jsonl
+│       │       │   ├── tiddlers_12.jsonl
+│       │       │   ├── tiddlers_13.jsonl
+│       │       │   ├── tiddlers_14.jsonl
+│       │       │   ├── tiddlers_15.jsonl
+│       │       │   ├── tiddlers_16.jsonl
+│       │       │   ├── tiddlers_2.jsonl
+│       │       │   ├── tiddlers_3.jsonl
+│       │       │   ├── tiddlers_4.jsonl
+│       │       │   ├── tiddlers_5.jsonl
+│       │       │   ├── tiddlers_6.jsonl
+│       │       │   ├── tiddlers_7.jsonl
+│       │       │   ├── tiddlers_8.jsonl
+│       │       │   └── tiddlers_9.jsonl
+│       │       └── reverse_html
+│       │           ├── rollback-20260612204805-m04-s98-propagacion-relacional-chunks-ai-y-rule23.derived.html
+│       │           └── rollback-20260612204805-m04-s98-propagacion-relacional-chunks-ai-y-rule23.reverse-report.json
 │       └── session_sync
-│           └── sync-20260611215410
+│           ├── local-diagnostic-dt037-final-20260612085932
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── local-diagnostic-dt037-preflight-20260612085750
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s0145-session-final-20260612025019
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s0145-session-preflight-20260612023346
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s0146-session-final-20260612094315
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s0146-session-preflight-20260612094225
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s0147-session-final-20260612170000
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s0147-session-final-20260612170500
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s0148-session-final-20260612184000
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s0148-session-final-20260612184500
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s0149-session-preflight-202606121956
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           ├── s0150-session-preflight-202606122050
+│           │   ├── inventory.json
+│           │   ├── missing-candidates.canon-candidates.jsonl
+│           │   ├── normalize
+│           │   │   ├── admission_lines.normalized.jsonl
+│           │   │   └── admission_lines.raw.jsonl
+│           │   └── sync-candidates.canon-candidates.jsonl
+│           └── sync-20260612191448
 │               ├── inventory.json
 │               ├── missing-candidates.canon-candidates.jsonl
 │               ├── normalize
@@ -735,10 +2143,14 @@
 │   ├── build_minimal_reversible_metadata.py
 │   ├── build_relation_admission_plan.py
 │   ├── build_relation_correspondence_matrix.py
+│   ├── build_repo_metadata_patch_preview.py
 │   ├── build_reversible_metadata_normalization.py
 │   ├── build_semantic_text.py
+│   ├── build_semantic_text_authority_aware.py
 │   ├── canon_proposal.py
 │   ├── canon_sanitation.py
+│   ├── characterize_repo_artifacts.py
+│   ├── characterize_unknown_artifact_family.py
 │   ├── chunking.py
 │   ├── classification.py
 │   ├── corpus_governance.py
@@ -747,6 +2159,7 @@
 │   ├── enrichment.py
 │   ├── evaluate_relation_admissibility.py
 │   ├── generate_session_deliverables.py
+│   ├── legacy_test_classifier.py
 │   ├── mcp_env_manager.py
 │   ├── normalize_session_titles.py
 │   ├── operator_menu.py
@@ -778,6 +2191,9 @@
 │   │   │   └── verify_export_unix.py
 │   │   ├── tag_mapper_UNIX.py
 │   │   └── tiddler_exporter_UNIX.py
+│   ├── repo_metadata_admission_gate.py
+│   ├── repo_metadata_refresh_patch.py
+│   ├── repo_metadata_review_menu.py
 │   ├── s45_derive_layers.py
 │   ├── semantic_text_builder.py
 │   ├── session_artifact_governance.py
@@ -787,6 +2203,7 @@
 │   ├── source_fields_contract.py
 │   ├── stage_modal_delta.py
 │   ├── tdc_cat.py
+│   ├── tdc_menu_registry.py
 │   ├── text_utils.py
 │   ├── tiddlers_to_jsonl.py
 │   ├── validate_corpus_governance.py
@@ -962,6 +2379,7 @@
 │   ├── test_diagnostic_artifact_governance.py
 │   ├── test_field_equivalence_characterization.py
 │   ├── test_historical_relation_type_governance.py
+│   ├── test_legacy_test_classifier.py
 │   ├── test_mcp_env_manager_security.py
 │   ├── test_minimal_reversible_metadata.py
 │   ├── test_normalize_session_titles.py
@@ -983,9 +2401,19 @@
 │   ├── test_remote_mirror_out_local.py
 │   ├── test_remote_publish_diagnostic.py
 │   ├── test_remote_pull_canon_p0.py
+│   ├── test_repo_artifact_characterization.py
+│   ├── test_repo_metadata_admission_gate.py
+│   ├── test_repo_metadata_apply_gate.py
+│   ├── test_repo_metadata_menu_integration.py
+│   ├── test_repo_metadata_multi_batch_selection.py
+│   ├── test_repo_metadata_patch_preview.py
+│   ├── test_repo_metadata_refresh_patch.py
+│   ├── test_repo_metadata_review_menu.py
+│   ├── test_repo_metadata_terminal_approval.py
 │   ├── test_reverse_contract.py
 │   ├── test_reversible_metadata_normalization.py
 │   ├── test_rule23_relational_coverage.py
+│   ├── test_semantic_text_authority_aware.py
 │   ├── test_semantic_text_builder.py
 │   ├── test_session_artifact_governance.py
 │   ├── test_session_cycle_diagnostics.py
@@ -993,7 +2421,10 @@
 │   ├── test_session_sync_scan_p0.py
 │   ├── test_session_title_policy.py
 │   ├── test_source_fields_contract.py
+│   ├── test_tdc_menu_compatibility_aliases.py
+│   ├── test_tdc_menu_governed_admission.py
 │   ├── test_text_utils.py
+│   ├── test_unknown_artifact_family_characterization.py
 │   ├── test_validate_relation_candidates.py
 │   └── test_write_sharded_dry_run.py
 ├── tools
@@ -1004,6 +2435,7 @@
     ├── assets
     │   └── Open eyes.PNG
     ├── blinked.png
+    ├── cat terminal.txt
     ├── Closed eyes.png
     ├── Graphi design (mockup).png
     ├── Graphic design (status).png

--- a/python_scripts/build_repo_metadata_patch_preview.py
+++ b/python_scripts/build_repo_metadata_patch_preview.py
@@ -1,0 +1,850 @@
+#!/usr/bin/env python3
+"""Build S0147 dry-run repo metadata patch preview.
+
+Consumes the S0146 repo-artifact classification matrix and emits a reversible
+metadata preview plus human-review batches. This module never writes canon
+shards and never records human approval.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import hashlib
+import json
+import re
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+
+DEFAULT_CLASSIFICATION = (
+    REPO_ROOT
+    / "data"
+    / "out"
+    / "local"
+    / "pipeline"
+    / "repo_artifacts"
+    / "s0146"
+    / "s0146_repo_artifact_classification.jsonl"
+)
+DEFAULT_METADATA_CONTRACT = (
+    REPO_ROOT
+    / "data"
+    / "out"
+    / "local"
+    / "pipeline"
+    / "repo_artifacts"
+    / "s0146"
+    / "s0146_repo_artifact_metadata_contract.md"
+)
+DEFAULT_CANON_GLOB = str(REPO_ROOT / "data" / "out" / "local" / "tiddlers_*.jsonl")
+DEFAULT_OUT_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "repo_metadata_review" / "s0147"
+
+PATCH_REVIEW_COLUMNS = [
+    "op_id",
+    "batch_id",
+    "target_id",
+    "target_title",
+    "patch_lane",
+    "current_artifact_family",
+    "fields_preview",
+    "risk_level",
+    "requires_human_review",
+    "human_approved",
+    "applied_to_canon",
+    "dry_run",
+    "reason",
+]
+
+LANE_BATCHES = {
+    "lane_a_current_verified": "batch_current_verified",
+    "lane_b_historical_review": "batch_historical_review",
+    "lane_c_generated_derivative": "batch_generated_derivative",
+    "lane_d_embedded_code": "batch_embedded_code",
+    "lane_e_narrative_reference": "batch_narrative_reference",
+    "lane_f_excluded_review_required": "batch_excluded_review_required",
+}
+
+BATCH_LABELS = {
+    "batch_current_verified": "Carril A - codigo vigente verificado",
+    "batch_historical_review": "Carril B - historico, divergente, missing o moved",
+    "batch_generated_derivative": "Carril C - outputs generados",
+    "batch_embedded_code": "Carril D - bloques de codigo embebidos",
+    "batch_narrative_reference": "Carril E - sesiones o diagnosticos narrativos",
+    "batch_excluded_review_required": "Carril F - excluidos por revision/riesgo",
+}
+
+TECHNICAL_CANON_FAMILY_VALUES = {"", "unknown", "tiddler_tecnico"}
+HISTORICAL_CATEGORIES = {
+    "repo_snapshot_drifted",
+    "repo_snapshot_missing",
+    "moved_candidate",
+    "deleted_historical_candidate",
+}
+EMBEDDED_CATEGORIES = {"embedded_code_block", "documentation_with_code_example"}
+NARRATIVE_CATEGORIES = {"session_or_diagnostic_narrative", "narrative_code_reference"}
+
+
+def stable_json(value: Any, *, indent: int | None = None) -> str:
+    if indent is None:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=indent)
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    return sha256_bytes(text.encode("utf-8"))
+
+
+def file_sha256(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def tree_sha256(glob_pattern: str) -> str:
+    digest = hashlib.sha256()
+    for path_str in sorted(glob.glob(glob_pattern)):
+        path = Path(path_str)
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.exists():
+        return rows
+    with path.open(encoding="utf-8") as handle:
+        for line_no, raw in enumerate(handle, start=1):
+            if not raw.strip():
+                continue
+            item = json.loads(raw)
+            if isinstance(item, dict):
+                item["_source_line"] = line_no
+                rows.append(item)
+    return rows
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(stable_json(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(stable_json(row) + "\n" for row in rows), encoding="utf-8")
+
+
+def write_csv(path: Path, operations: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=PATCH_REVIEW_COLUMNS)
+        writer.writeheader()
+        for op in operations:
+            writer.writerow(
+                {
+                    "op_id": op["op_id"],
+                    "batch_id": op["batch_id"],
+                    "target_id": op["target_id"],
+                    "target_title": op["target_title"],
+                    "patch_lane": op["patch_lane"],
+                    "current_artifact_family": op["current_artifact_family"],
+                    "fields_preview": stable_json(op["fields_preview"]),
+                    "risk_level": op["source_risk_level"],
+                    "requires_human_review": op["requires_human_review"],
+                    "human_approved": op["human_approved"],
+                    "applied_to_canon": op["applied_to_canon"],
+                    "dry_run": op["dry_run"],
+                    "reason": op["reason"],
+                }
+            )
+
+
+def slugify(text: str) -> str:
+    value = text.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = re.sub(r"-+", "-", value).strip("-")
+    return value[:120]
+
+
+def current_family(record: dict[str, Any] | None) -> str:
+    if not record:
+        return "unknown"
+    source_fields = record.get("source_fields") if isinstance(record.get("source_fields"), dict) else {}
+    raw = source_fields.get("artifact_family") or record.get("artifact_family") or record.get("family") or ""
+    value = str(raw).strip()
+    return value or "unknown"
+
+
+def load_canon_index(canon_glob: str) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for path_str in sorted(glob.glob(canon_glob)):
+        for row in read_jsonl(Path(path_str)):
+            row_id = str(row.get("id") or "")
+            if row_id:
+                index[row_id] = row
+    return index
+
+
+def lane_for(row: dict[str, Any]) -> str:
+    category = str(row.get("diagnostic_category") or "")
+    authority = str(row.get("candidate_authority_level") or "")
+    is_current = str(row.get("candidate_is_current_repo_artifact") or "").lower()
+    risk = str(row.get("risk_level") or "")
+    confidence = str(row.get("confidence") or "")
+    if category == "review_required" or risk == "critical" or confidence == "requires_human_review":
+        return "lane_f_excluded_review_required"
+    if (
+        category == "repo_snapshot_current"
+        and authority == "current_verified"
+        and is_current == "true"
+    ):
+        return "lane_a_current_verified"
+    if category in HISTORICAL_CATEGORIES:
+        return "lane_b_historical_review"
+    if category == "generated_output":
+        return "lane_c_generated_derivative"
+    if category in EMBEDDED_CATEGORIES:
+        return "lane_d_embedded_code"
+    if category in NARRATIVE_CATEGORIES:
+        return "lane_e_narrative_reference"
+    return "lane_f_excluded_review_required"
+
+
+def may_set_repo_artifact_family(row: dict[str, Any], family: str, *, require_current: bool) -> bool:
+    if family not in TECHNICAL_CANON_FAMILY_VALUES:
+        return False
+    if str(row.get("candidate_artifact_family") or "") != "artefacto_repositorio":
+        return False
+    if require_current:
+        return (
+            row.get("diagnostic_category") == "repo_snapshot_current"
+            and row.get("candidate_authority_level") == "current_verified"
+            and str(row.get("candidate_is_current_repo_artifact")).lower() == "true"
+            and row.get("risk_level") != "critical"
+        )
+    return True
+
+
+def fields_for_lane(row: dict[str, Any], lane: str, family: str) -> dict[str, str]:
+    if lane == "lane_a_current_verified":
+        fields = {
+            "repo_path": str(row.get("candidate_repo_path") or ""),
+            "repo_directory": str(row.get("candidate_repo_directory") or ""),
+            "repo_extension": str(row.get("candidate_repo_extension") or ""),
+            "repo_artifact_kind": str(row.get("candidate_repo_artifact_kind") or ""),
+            "content_sha256": str(row.get("candidate_content_sha256") or row.get("canon_content_sha256") or ""),
+            "repo_lifecycle_state": "current_repo_artifact",
+            "is_current_repo_artifact": "true",
+            "authority_level": "current_verified",
+        }
+        if may_set_repo_artifact_family(row, family, require_current=True):
+            fields = {"artifact_family": "artefacto_repositorio", **fields}
+        return fields
+    if lane == "lane_b_historical_review":
+        lifecycle = str(row.get("candidate_repo_lifecycle_state") or "historical_snapshot")
+        fields = {
+            "repo_path": str(row.get("candidate_repo_path") or ""),
+            "repo_directory": str(row.get("candidate_repo_directory") or ""),
+            "repo_extension": str(row.get("candidate_repo_extension") or ""),
+            "repo_artifact_kind": str(row.get("candidate_repo_artifact_kind") or ""),
+            "repo_lifecycle_state": lifecycle,
+            "is_current_repo_artifact": "false",
+            "authority_level": "historical_snapshot",
+        }
+        moved_to = str(row.get("moved_to_candidate") or "")
+        if moved_to:
+            fields["moved_to_candidate"] = moved_to
+        return fields
+    if lane == "lane_c_generated_derivative":
+        return {
+            "technical_content_role": "generated_output",
+            "authority_level": "generated_derivative",
+            "is_current_repo_artifact": "false",
+        }
+    if lane == "lane_d_embedded_code":
+        return {
+            "contains_code": "true",
+            "technical_content_role": "embedded_code_block",
+            "authority_level": "narrative_reference",
+        }
+    if lane == "lane_e_narrative_reference":
+        return {
+            "contains_repo_references": "true",
+            "technical_content_role": "session_or_diagnostic_narrative",
+            "authority_level": "narrative_reference",
+        }
+    return {}
+
+
+def op_id_for(row: dict[str, Any], lane: str, fields: dict[str, str]) -> str:
+    source = {
+        "session": "S0147",
+        "target_id": row.get("id", ""),
+        "lane": lane,
+        "fields": fields,
+    }
+    return "s0147_" + sha256_text(stable_json(source))[:24]
+
+
+def operation_for(row: dict[str, Any], lane: str, canon_row: dict[str, Any] | None) -> dict[str, Any]:
+    family = current_family(canon_row)
+    fields = fields_for_lane(row, lane, family)
+    return {
+        "op_id": op_id_for(row, lane, fields),
+        "session": "S0147",
+        "target_id": str(row.get("id") or ""),
+        "target_title": str(row.get("title") or ""),
+        "target_slug": slugify(str(row.get("title") or "")),
+        "current_artifact_family": family,
+        "patch_lane": lane,
+        "batch_id": LANE_BATCHES[lane],
+        "operation": "metadata_preview",
+        "fields_preview": fields,
+        "source_classification_id": str(row.get("id") or ""),
+        "source_diagnostic_category": str(row.get("diagnostic_category") or ""),
+        "source_authority_level": str(row.get("candidate_authority_level") or ""),
+        "source_risk_level": str(row.get("risk_level") or ""),
+        "evidence": [
+            f"diagnostic_category={row.get('diagnostic_category')}",
+            f"authority_level={row.get('candidate_authority_level')}",
+            f"content_comparison={row.get('content_comparison')}",
+            f"repo_path={row.get('candidate_repo_path') or ''}",
+        ],
+        "reason": reason_for_lane(row, lane, family, fields),
+        "requires_human_review": True,
+        "human_approved": False,
+        "applied_to_canon": False,
+        "dry_run": True,
+    }
+
+
+def reason_for_lane(row: dict[str, Any], lane: str, family: str, fields: dict[str, str]) -> str:
+    if lane == "lane_a_current_verified":
+        if fields.get("artifact_family") == "artefacto_repositorio":
+            return "Current verified repo snapshot; eligible for future human-reviewed metadata patch."
+        return f"Current verified repo snapshot, but existing artifact_family {family!r} is preserved."
+    if lane == "lane_b_historical_review":
+        return "Historical, drifted, missing or moved repo snapshot; separated from current verified batch."
+    if lane == "lane_c_generated_derivative":
+        return "Generated output receives derivative role metadata only; no repo source authority."
+    if lane == "lane_d_embedded_code":
+        return "Embedded code block receives auxiliary technical-content metadata only."
+    if lane == "lane_e_narrative_reference":
+        return "Session/diagnostic narrative receives repo-reference metadata only."
+    return "Excluded from patch preview pending human review."
+
+
+def excluded_record(row: dict[str, Any], lane: str, canon_row: dict[str, Any] | None) -> dict[str, Any]:
+    return {
+        "session": "S0147",
+        "target_id": str(row.get("id") or ""),
+        "target_title": str(row.get("title") or ""),
+        "current_artifact_family": current_family(canon_row),
+        "patch_lane": lane,
+        "excluded_reason": excluded_reason(row),
+        "source_diagnostic_category": str(row.get("diagnostic_category") or ""),
+        "source_risk_level": str(row.get("risk_level") or ""),
+        "source_confidence": str(row.get("confidence") or ""),
+        "human_approved": False,
+        "applied_to_canon": False,
+        "dry_run": True,
+    }
+
+
+def excluded_reason(row: dict[str, Any]) -> str:
+    category = str(row.get("diagnostic_category") or "")
+    if category == "review_required":
+        return "review_required"
+    if str(row.get("risk_level") or "") == "critical":
+        return "critical_risk"
+    if str(row.get("confidence") or "") == "requires_human_review":
+        return "requires_human_review"
+    return "insufficient_metadata_rule"
+
+
+def review_item_from_operation(op: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "review_id": "review_" + op["op_id"],
+        "batch_id": op["batch_id"],
+        "target_id": op["target_id"],
+        "target_title": op["target_title"],
+        "patch_lane": op["patch_lane"],
+        "summary": op["reason"],
+        "risk_level": op["source_risk_level"],
+        "recommended_action": "review_metadata_preview",
+        "status": "pending_review",
+        "human_decision": "not_recorded",
+        "human_approved": False,
+    }
+
+
+def review_item_from_excluded(item: dict[str, Any]) -> dict[str, Any]:
+    review_id = "review_excluded_" + sha256_text(stable_json(item))[:24]
+    return {
+        "review_id": review_id,
+        "batch_id": LANE_BATCHES["lane_f_excluded_review_required"],
+        "target_id": item["target_id"],
+        "target_title": item["target_title"],
+        "patch_lane": item["patch_lane"],
+        "summary": item["excluded_reason"],
+        "risk_level": item["source_risk_level"],
+        "recommended_action": "defer_or_review_manually",
+        "status": "pending_review",
+        "human_decision": "not_recorded",
+        "human_approved": False,
+    }
+
+
+def subset_sha(rows: list[dict[str, Any]]) -> str:
+    return sha256_text("".join(stable_json(row) + "\n" for row in rows))
+
+
+def build_batches(
+    operations: list[dict[str, Any]],
+    excluded: list[dict[str, Any]],
+    *,
+    classification_sha: str,
+    canon_sha: str,
+) -> dict[str, Any]:
+    rows_by_batch: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for op in operations:
+        rows_by_batch[op["batch_id"]].append(op)
+    rows_by_batch[LANE_BATCHES["lane_f_excluded_review_required"]].extend(excluded)
+
+    batches: dict[str, Any] = {
+        "schema": "repo-metadata-review-batches/v1",
+        "session": "S0147",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "human_approved": False,
+        "batches": {},
+    }
+    for lane, batch_id in LANE_BATCHES.items():
+        rows = sorted(rows_by_batch.get(batch_id, []), key=lambda row: stable_json(row))
+        risk_profile = dict(sorted(Counter(str(row.get("source_risk_level") or row.get("risk_level") or "") for row in rows).items()))
+        batches["batches"][batch_id] = {
+            "batch_id": batch_id,
+            "batch_label": BATCH_LABELS[batch_id],
+            "patch_lane": lane,
+            "record_count": len(rows),
+            "patch_sha256": subset_sha(rows),
+            "source_classification_sha256": classification_sha,
+            "canon_before_sha256": canon_sha,
+            "risk_profile": risk_profile,
+            "recommended_for_future_approval": batch_id == "batch_current_verified" and bool(rows),
+            "human_approved": False,
+            "approval_disabled_in_s0147": True,
+            "applied_to_canon": False,
+        }
+    return batches
+
+
+def build_summary(
+    classification_rows: list[dict[str, Any]],
+    operations: list[dict[str, Any]],
+    excluded: list[dict[str, Any]],
+    batches: dict[str, Any],
+) -> dict[str, Any]:
+    lane_counts = dict(sorted(Counter(op["patch_lane"] for op in operations).items()))
+    lane_counts["lane_f_excluded_review_required"] = len(excluded)
+    return {
+        "schema": "repo-metadata-patch-summary/v1",
+        "session": "S0147",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "human_approved": False,
+        "classification_records_read": len(classification_rows),
+        "patch_operations_generated": len(operations),
+        "excluded_records": len(excluded),
+        "patch_lane_counts": lane_counts,
+        "diagnostic_category_counts": dict(sorted(Counter(row.get("source_diagnostic_category") for row in operations).items())),
+        "authority_level_counts": dict(sorted(Counter(row.get("source_authority_level") for row in operations).items())),
+        "risk_level_counts": dict(sorted(Counter(row.get("source_risk_level") for row in operations).items())),
+        "preserve_artifact_family_count": sum(1 for op in operations if "artifact_family" not in op["fields_preview"]),
+        "future_artefacto_repositorio_count": sum(1 for op in operations if op["fields_preview"].get("artifact_family") == "artefacto_repositorio"),
+        "batch_count": len(batches["batches"]),
+        "relations_generated": False,
+        "candidate_relations_generated": False,
+        "formal_relation_candidates_generated": False,
+    }
+
+
+def summary_markdown(summary: dict[str, Any], hashes: dict[str, str] | None = None) -> str:
+    hashes = hashes or {}
+    lines = [
+        "# S0147 repo metadata patch summary",
+        "",
+        f"- Registros S0146 leidos: {summary['classification_records_read']}",
+        f"- Operaciones de patch preview: {summary['patch_operations_generated']}",
+        f"- Excluidos carril F: {summary['excluded_records']}",
+        f"- Preservan artifact_family original: {summary['preserve_artifact_family_count']}",
+        f"- Podrian recibir artefacto_repositorio en futuro: {summary['future_artefacto_repositorio_count']}",
+        f"- Batches creados: {summary['batch_count']}",
+        f"- Relaciones formales generadas: {summary['formal_relation_candidates_generated']}",
+        "",
+        "## Carriles",
+    ]
+    for lane, count in summary["patch_lane_counts"].items():
+        lines.append(f"- {lane}: {count}")
+    if hashes:
+        lines.extend(
+            [
+                "",
+                "## Hashes",
+                f"- patch_preview_sha256: `{hashes.get('patch_preview_sha256', '')}`",
+                f"- s0146_classification_sha256: `{hashes.get('s0146_classification_sha256', '')}`",
+                f"- canon_before_sha256: `{hashes.get('canon_before_sha256', '')}`",
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "## Estado",
+            "- `human_approved`: false en todos los registros y batches.",
+            "- `applied_to_canon`: false en todos los registros y batches.",
+            "- `dry_run`: true.",
+            "- El menu de S0147 permite inspeccion, no aprobacion.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def risk_report(operations: list[dict[str, Any]], excluded: list[dict[str, Any]]) -> dict[str, Any]:
+    risky_ops = [op for op in operations if op["source_risk_level"] in {"high", "critical"}]
+    return {
+        "schema": "repo-metadata-risk-report/v1",
+        "session": "S0147",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "human_approved": False,
+        "high_or_critical_operations": len(risky_ops),
+        "excluded_records": len(excluded),
+        "risk_counts": dict(sorted(Counter(op["source_risk_level"] for op in operations).items())),
+        "excluded_reason_counts": dict(sorted(Counter(item["excluded_reason"] for item in excluded).items())),
+        "items": [
+            {
+                "target_id": op["target_id"],
+                "target_title": op["target_title"],
+                "patch_lane": op["patch_lane"],
+                "risk_level": op["source_risk_level"],
+                "reason": op["reason"],
+            }
+            for op in risky_ops[:200]
+        ],
+    }
+
+
+def risk_report_md(report: dict[str, Any]) -> str:
+    lines = [
+        "# S0147 repo metadata risk report",
+        "",
+        f"- High/critical patch operations: {report['high_or_critical_operations']}",
+        f"- Excluded records: {report['excluded_records']}",
+        "",
+        "## Risk counts",
+    ]
+    for risk, count in report["risk_counts"].items():
+        lines.append(f"- {risk}: {count}")
+    lines.append("")
+    lines.append("## Excluded reasons")
+    for reason, count in report["excluded_reason_counts"].items():
+        lines.append(f"- {reason}: {count}")
+    return "\n".join(lines) + "\n"
+
+
+def dry_run_report(
+    summary: dict[str, Any],
+    excluded: list[dict[str, Any]],
+    queue: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema": "repo-metadata-dry-run-report/v1",
+        "session": "S0147",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "human_approved": False,
+        "approval_required_for_future_apply": True,
+        "metadata_patch_preview_generated": True,
+        "menu_review_prepared": True,
+        "relations_generated": False,
+        "candidate_relations_generated": False,
+        "formal_relation_candidates_generated": False,
+        "counts": {
+            "patch_lane": summary["patch_lane_counts"],
+            "diagnostic_category": summary["diagnostic_category_counts"],
+            "authority_level": summary["authority_level_counts"],
+            "risk_level": summary["risk_level_counts"],
+            "recommended_action": dict(sorted(Counter(item["recommended_action"] for item in queue).items())),
+            "excluded_reason": dict(sorted(Counter(item["excluded_reason"] for item in excluded).items())),
+        },
+    }
+
+
+def menu_contract_md() -> str:
+    return """# S0147 repo metadata review menu contract
+
+## Purpose
+The menu exposes S0147 metadata patch preview artifacts for local inspection.
+It does not approve batches and does not apply metadata.
+
+## Commands
+- `--summary`
+- `--list-batches`
+- `--show-batch <batch_id>`
+- `--show-excluded`
+- `--show-risks`
+- `--validate-dry-run`
+- `--export-csv`
+
+## Approval policy
+Approval is disabled in S0147. Any approval-oriented command must return
+`approval_disabled_in_s0147`. S0148 is responsible for terminal approval and
+dry-run gates.
+"""
+
+
+def operator_instructions_md(batches: dict[str, Any]) -> str:
+    batch_lines = [
+        f"- `{batch_id}`: {payload['batch_label']} ({payload['record_count']} registros)"
+        for batch_id, payload in batches["batches"].items()
+    ]
+    return "\n".join(
+        [
+            "# S0147 operator instructions",
+            "",
+            "## Que genero S0147",
+            "Patch preview reversible de metadata tecnica estratificada, cola de revision, batches, hashes y menu local de inspeccion.",
+            "",
+            "## Que puede revisar el operador",
+            "- Resumen del patch.",
+            "- Lotes disponibles.",
+            "- Detalle de lote.",
+            "- Registros excluidos.",
+            "- Riesgos alto/critico.",
+            "- Hashes y manifiesto.",
+            "- CSV de revision.",
+            "",
+            "## No permitido todavia",
+            "- Aprobar lotes.",
+            "- Aplicar metadata.",
+            "- Modificar canon.",
+            "- Generar relaciones formales.",
+            "",
+            "## Batches",
+            *batch_lines,
+            "",
+            "## Batch mas seguro",
+            "`batch_current_verified` es el lote mas seguro para revision futura, pero no queda aprobado en S0147.",
+            "",
+            "## Comando de menu",
+            "`python3 python_scripts/repo_metadata_review_menu.py --summary`",
+            "",
+            "## Responsabilidad de S0148",
+            "Registrar aprobacion humana por terminal, verificar hashes y correr compuerta dry-run. En S0147 no se aprueba ningun lote.",
+            "",
+        ]
+    )
+
+
+def relation_context_md(classification_path: Path) -> str:
+    relation_path = classification_path.parent / "s0146_repo_artifact_relation_opportunities.jsonl"
+    count = len(read_jsonl(relation_path)) if relation_path.exists() else 0
+    return "\n".join(
+        [
+            "# S0147 relation opportunities context",
+            "",
+            f"- S0146 relation opportunities observed: {count}",
+            "- relations_generated: false",
+            "- candidate_relations_generated: false",
+            "- formal_relation_candidates_generated: false",
+            "- admissible_in_s0147: false",
+            "",
+            "```json",
+            stable_json(
+                {
+                    "relations_generated": False,
+                    "candidate_relations_generated": False,
+                    "formal_relation_candidates_generated": False,
+                    "admissible_in_s0147": False,
+                },
+                indent=2,
+            ),
+            "```",
+            "",
+            "S0147 only notes that metadata can improve future evidence. It does not create candidate_relations.",
+            "",
+        ]
+    )
+
+
+def validation_report(
+    operations: list[dict[str, Any]],
+    excluded: list[dict[str, Any]],
+    batches: dict[str, Any],
+) -> dict[str, Any]:
+    patch_violations = [
+        op["op_id"]
+        for op in operations
+        if op.get("dry_run") is not True
+        or op.get("applied_to_canon") is not False
+        or op.get("human_approved") is not False
+    ]
+    batch_violations = [
+        batch_id
+        for batch_id, batch in batches["batches"].items()
+        if batch.get("human_approved") is not False
+        or batch.get("approval_disabled_in_s0147") is not True
+        or batch.get("applied_to_canon") is not False
+    ]
+    return {
+        "schema": "repo-metadata-validation-report/v1",
+        "session": "S0147",
+        "dry_run": True,
+        "patch_records": len(operations),
+        "excluded_records": len(excluded),
+        "batch_count": len(batches["batches"]),
+        "patch_violations": patch_violations,
+        "batch_violations": batch_violations,
+        "relations_generated": False,
+        "candidate_relations_generated": False,
+        "formal_relation_candidates_generated": False,
+        "valid": not patch_violations and not batch_violations,
+    }
+
+
+def build_repo_metadata_patch_preview(
+    *,
+    classification: Path = DEFAULT_CLASSIFICATION,
+    metadata_contract: Path = DEFAULT_METADATA_CONTRACT,
+    canon_glob: str = DEFAULT_CANON_GLOB,
+    out_dir: Path = DEFAULT_OUT_DIR,
+    session: str = "S0147",
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    if not dry_run:
+        raise ValueError("S0147 only supports dry_run=true")
+    if session != "S0147":
+        raise ValueError("this builder is scoped to S0147")
+    if not classification.exists():
+        raise FileNotFoundError(classification)
+    if not metadata_contract.exists():
+        raise FileNotFoundError(metadata_contract)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    classification_rows = read_jsonl(classification)
+    canon_index = load_canon_index(canon_glob)
+    classification_sha = file_sha256(classification)
+    canon_sha = tree_sha256(canon_glob)
+
+    operations: list[dict[str, Any]] = []
+    excluded: list[dict[str, Any]] = []
+    for row in sorted(classification_rows, key=lambda item: (str(item.get("title") or ""), str(item.get("id") or ""))):
+        lane = lane_for(row)
+        canon_row = canon_index.get(str(row.get("id") or ""))
+        if lane == "lane_f_excluded_review_required":
+            excluded.append(excluded_record(row, lane, canon_row))
+            continue
+        operations.append(operation_for(row, lane, canon_row))
+    operations = sorted(operations, key=lambda op: op["op_id"])
+    excluded = sorted(excluded, key=lambda item: (item["target_title"], item["target_id"]))
+    queue = [review_item_from_operation(op) for op in operations] + [review_item_from_excluded(item) for item in excluded]
+    queue = sorted(queue, key=lambda item: item["review_id"])
+    batches = build_batches(operations, excluded, classification_sha=classification_sha, canon_sha=canon_sha)
+    summary = build_summary(classification_rows, operations, excluded, batches)
+    risks = risk_report(operations, excluded)
+    dry_report = dry_run_report(summary, excluded, queue)
+    validation = validation_report(operations, excluded, batches)
+
+    paths = {
+        "patch_preview": out_dir / "s0147_repo_metadata_patch_preview.jsonl",
+        "summary_json": out_dir / "s0147_repo_metadata_patch_summary.json",
+        "summary_md": out_dir / "s0147_repo_metadata_patch_summary.md",
+        "review_queue": out_dir / "s0147_repo_metadata_review_queue.jsonl",
+        "review_batches": out_dir / "s0147_repo_metadata_review_batches.json",
+        "review_csv": out_dir / "s0147_repo_metadata_review.csv",
+        "excluded": out_dir / "s0147_repo_metadata_excluded_records.jsonl",
+        "risk_json": out_dir / "s0147_repo_metadata_risk_report.json",
+        "risk_md": out_dir / "s0147_repo_metadata_risk_report.md",
+        "dry_run": out_dir / "s0147_repo_metadata_dry_run_report.json",
+        "menu_contract": out_dir / "s0147_repo_metadata_menu_contract.md",
+        "hashes": out_dir / "s0147_repo_metadata_patch_hashes.json",
+        "validation": out_dir / "s0147_repo_metadata_validation_report.json",
+        "operator_instructions": out_dir / "s0147_repo_metadata_operator_instructions.md",
+        "relation_context": out_dir / "s0147_relation_opportunities_context.md",
+    }
+
+    write_jsonl(paths["patch_preview"], operations)
+    write_jsonl(paths["review_queue"], queue)
+    write_json(paths["review_batches"], batches)
+    write_csv(paths["review_csv"], operations)
+    write_jsonl(paths["excluded"], excluded)
+    write_json(paths["risk_json"], risks)
+    paths["risk_md"].write_text(risk_report_md(risks), encoding="utf-8")
+    write_json(paths["dry_run"], dry_report)
+    paths["menu_contract"].write_text(menu_contract_md(), encoding="utf-8")
+    write_json(paths["validation"], validation)
+    paths["operator_instructions"].write_text(operator_instructions_md(batches), encoding="utf-8")
+    paths["relation_context"].write_text(relation_context_md(classification), encoding="utf-8")
+
+    hashes = {
+        "schema": "repo-metadata-patch-hashes/v1",
+        "session": session,
+        "canon_before_sha256": canon_sha,
+        "s0146_classification_sha256": classification_sha,
+        "patch_preview_sha256": file_sha256(paths["patch_preview"]),
+        "review_queue_sha256": file_sha256(paths["review_queue"]),
+        "review_batches_sha256": file_sha256(paths["review_batches"]),
+        "dry_run_report_sha256": file_sha256(paths["dry_run"]),
+        "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    }
+    write_json(paths["hashes"], hashes)
+    write_json(paths["summary_json"], summary)
+    paths["summary_md"].write_text(summary_markdown(summary, hashes), encoding="utf-8")
+
+    return {
+        "summary": summary,
+        "hashes": hashes,
+        "paths": {key: str(path) for key, path in paths.items()},
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build S0147 repo metadata patch preview")
+    parser.add_argument("--classification", default=str(DEFAULT_CLASSIFICATION))
+    parser.add_argument("--metadata-contract", default=str(DEFAULT_METADATA_CONTRACT))
+    parser.add_argument("--canon-glob", default=DEFAULT_CANON_GLOB)
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
+    parser.add_argument("--session", default="S0147")
+    parser.add_argument("--dry-run", action="store_true", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = build_repo_metadata_patch_preview(
+        classification=Path(args.classification),
+        metadata_contract=Path(args.metadata_contract),
+        canon_glob=args.canon_glob,
+        out_dir=Path(args.out_dir),
+        session=args.session,
+        dry_run=args.dry_run,
+    )
+    print(stable_json({"status": "ok", **result["summary"], "patch_preview_sha256": result["hashes"]["patch_preview_sha256"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python_scripts/build_semantic_text_authority_aware.py
+++ b/python_scripts/build_semantic_text_authority_aware.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""S0149 authority-aware semantic_text sidecar builder.
+
+This wrapper reuses the deterministic S0144 semantic_text builder, adds an
+authority-level header, and writes experimental outputs under
+data/out/local/pipeline/semantic_text_authority/s0149. It never writes canon
+shards and does not overwrite the S0144 sidecar path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import semantic_text_builder as base
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+DEFAULT_SESSION = "S0149"
+DEFAULT_OUT_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "semantic_text_authority" / "s0149"
+SCHEMA = "semantic-text-authority-aware-build/v1"
+SEMANTIC_TEXT_VERSION = "semantic-text-authority-aware/v1"
+
+AUTHORITY_HEADERS = {
+    "current_verified": "Este tiddler representa un artefacto actual verificado del repositorio.",
+    "historical_snapshot": "Este tiddler representa o describe un artefacto histórico, divergente o no vigente del repositorio.",
+    "narrative_reference": "Este tiddler documenta o menciona contenido técnico, pero no debe tratarse como archivo vigente del repositorio.",
+    "generated_derivative": "Este tiddler corresponde a una salida derivada o generada por pipeline.",
+    "external_reference": "Este tiddler corresponde a una referencia técnica externa al repositorio local.",
+    "unknown": "La autoridad técnica de este tiddler no está determinada.",
+}
+
+REVIEW_COLUMNS = [
+    "id",
+    "title",
+    "artifact_family",
+    "authority_level",
+    "mode",
+    "semantic_text_chars",
+    "semantic_text_sha256",
+    "warnings",
+]
+
+
+def stable_json(value: Any, *, indent: int | None = None) -> str:
+    if indent is None:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=indent)
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def authority_level_for(record: dict[str, Any]) -> str:
+    source_fields = record.get("source_fields") if isinstance(record.get("source_fields"), dict) else {}
+    raw = (
+        source_fields.get("authority_level")
+        or record.get("authority_level")
+        or source_fields.get("candidate_authority_level")
+        or record.get("candidate_authority_level")
+        or "unknown"
+    )
+    value = base.normalize_text(raw)
+    return value if value in AUTHORITY_HEADERS else "unknown"
+
+
+def output_paths(out_dir: Path, session: str) -> dict[str, Path]:
+    prefix = session.lower()
+    return {
+        "records": out_dir / f"{prefix}_semantic_text_authority_records.jsonl",
+        "index": out_dir / f"{prefix}_semantic_text_authority_index.json",
+        "coverage_report": out_dir / f"{prefix}_semantic_text_authority_coverage_report.json",
+        "summary": out_dir / f"{prefix}_semantic_text_authority_summary.md",
+        "review": out_dir / f"{prefix}_semantic_text_authority_review.csv",
+        "hashes": out_dir / f"{prefix}_semantic_text_authority_hashes.json",
+    }
+
+
+def authority_record(canon_record: dict[str, Any], semantic_record: dict[str, Any], *, mode: str, source_session: str) -> dict[str, Any]:
+    authority = authority_level_for(canon_record)
+    header = AUTHORITY_HEADERS[authority]
+    semantic_text = (
+        "# Autoridad técnica\n"
+        f"authority_level: {authority}\n"
+        f"{header}\n\n"
+        + semantic_record["semantic_text"]
+    )
+    semantic_hash = sha256_text(semantic_text)
+    warnings = sorted(set([*semantic_record.get("warnings", []), f"authority:{authority}"]))
+    return {
+        "id": semantic_record["id"],
+        "title": semantic_record["title"],
+        "artifact_family": semantic_record["artifact_family"],
+        "authority_level": authority,
+        "authority_statement": header,
+        "semantic_text": semantic_text,
+        "semantic_text_version": SEMANTIC_TEXT_VERSION,
+        "semantic_text_sha256": semantic_hash,
+        "source_record_sha256": semantic_record["source_record_sha256"],
+        "source_semantic_text_sha256": semantic_record["semantic_text_sha256"],
+        "sections_included": ["authority_header", *semantic_record["sections_included"]],
+        "mode": mode,
+        "preview": mode == "preview",
+        "generate": mode == "generate",
+        "authority_aware": True,
+        "source_session": source_session,
+        "dry_run": mode == "preview",
+        "modified_canon": False,
+        "canon_modified": False,
+        "relations_generated": False,
+        "candidate_relations_generated": False,
+        "warnings": warnings,
+    }
+
+
+def build_index(records: list[dict[str, Any]], *, mode: str, source_session: str) -> dict[str, Any]:
+    by_authority = Counter(record["authority_level"] for record in records)
+    by_family = Counter(record["artifact_family"] for record in records)
+    return {
+        "schema": "semantic-text-authority-index/v1",
+        "session": source_session,
+        "source_session": source_session,
+        "mode": mode,
+        "authority_aware": True,
+        "modified_canon": False,
+        "record_count": len(records),
+        "by_authority_level": dict(sorted(by_authority.items())),
+        "by_artifact_family": dict(sorted(by_family.items())),
+        "records": {
+            record["id"]: {
+                "title": record["title"],
+                "artifact_family": record["artifact_family"],
+                "authority_level": record["authority_level"],
+                "semantic_text_sha256": record["semantic_text_sha256"],
+            }
+            for record in sorted(records, key=lambda item: (item["id"], item["title"]))
+        },
+    }
+
+
+def build_coverage_report(records: list[dict[str, Any]], *, mode: str, source_session: str) -> dict[str, Any]:
+    by_authority: dict[str, dict[str, int]] = {}
+    for record in records:
+        bucket = by_authority.setdefault(
+            record["authority_level"],
+            {
+                "total_records": 0,
+                "records_with_semantic_text": 0,
+            },
+        )
+        bucket["total_records"] += 1
+        bucket["records_with_semantic_text"] += int(bool(record["semantic_text"]))
+    return {
+        "schema": "semantic-text-authority-coverage-report/v1",
+        "session": source_session,
+        "source_session": source_session,
+        "mode": mode,
+        "authority_aware": True,
+        "modified_canon": False,
+        "canon_modified": False,
+        "semantic_text_version": SEMANTIC_TEXT_VERSION,
+        "total_records": len(records),
+        "records_with_semantic_text": sum(1 for record in records if record["semantic_text"]),
+        "authority_levels_detected": sorted(by_authority),
+        "by_authority_level": dict(sorted(by_authority.items())),
+        "relations_generated": False,
+        "candidate_relations_generated": False,
+        "embeddings_executed": False,
+    }
+
+
+def summary_md(report: dict[str, Any]) -> str:
+    lines = [
+        "# S0149 semantic_text authority-aware summary",
+        "",
+        f"- mode: {report['mode']}",
+        "- authority_aware: true",
+        f"- total_records: {report['total_records']}",
+        f"- records_with_semantic_text: {report['records_with_semantic_text']}",
+        f"- authority_levels_detected: {report['authority_levels_detected']}",
+        "- modified_canon: false",
+        "- relations_generated: false",
+        "- candidate_relations_generated: false",
+        "- embeddings_executed: false",
+        "",
+        "| authority_level | total | semantic_text |",
+        "|---|---:|---:|",
+    ]
+    for authority, bucket in report["by_authority_level"].items():
+        lines.append(
+            f"| {authority} | {bucket['total_records']} | {bucket['records_with_semantic_text']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def review_rows(records: list[dict[str, Any]]) -> list[dict[str, str]]:
+    return [
+        {
+            "id": record["id"],
+            "title": record["title"],
+            "artifact_family": record["artifact_family"],
+            "authority_level": record["authority_level"],
+            "mode": record["mode"],
+            "semantic_text_chars": str(len(record["semantic_text"])),
+            "semantic_text_sha256": record["semantic_text_sha256"],
+            "warnings": "|".join(record["warnings"]),
+        }
+        for record in records
+    ]
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(stable_json(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(stable_json(record) + "\n" for record in records), encoding="utf-8")
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=REVIEW_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_hashes(paths: dict[str, Path], records: list[dict[str, Any]], *, mode: str, source_session: str) -> dict[str, Any]:
+    payload = {
+        "schema": "semantic-text-authority-hashes/v1",
+        "session": source_session,
+        "source_session": source_session,
+        "mode": mode,
+        "authority_aware": True,
+        "modified_canon": False,
+        "file_sha256": {
+            name: file_sha256(path)
+            for name, path in sorted(paths.items())
+            if name != "hashes" and path.exists()
+        },
+        "record_semantic_text_sha256": {
+            record["id"]: record["semantic_text_sha256"]
+            for record in sorted(records, key=lambda item: (item["id"], item["title"]))
+        },
+        "hashes_file_self_hash_included": False,
+    }
+    write_json(paths["hashes"], payload)
+    return payload
+
+
+def build_authority_outputs(
+    *,
+    canon_glob: str = base.DEFAULT_CANON_GLOB,
+    out_dir: Path = DEFAULT_OUT_DIR,
+    session: str = DEFAULT_SESSION,
+    mode: str = "preview",
+    type_policy: Path = base.DEFAULT_TYPE_POLICY,
+    max_content_chars: int = base.DEFAULT_MAX_CONTENT_CHARS,
+) -> dict[str, Any]:
+    session = session.upper()
+    if (out_dir / "s0144_semantic_text_records.jsonl").exists() or "semantic_text/s0144" in str(out_dir):
+        raise ValueError("S0149 authority-aware builder must not overwrite S0144 outputs")
+    canon_records = base.read_canon_records(canon_glob)
+    profiles = base.build_profiles({base.artifact_family_for(record) for record in canon_records}, max_content_chars)
+    policy = base.load_relation_policy(type_policy)
+    base_records = base.build_records(
+        canon_records,
+        policy=policy,
+        profiles=profiles,
+        preview_index=base.load_dry_run_preview_index(),
+        max_content_chars=max_content_chars,
+    )
+    records = [
+        authority_record(canon_record, semantic_record, mode=mode, source_session=session)
+        for canon_record, semantic_record in zip(canon_records, base_records, strict=True)
+    ]
+    paths = output_paths(out_dir, session)
+    coverage = build_coverage_report(records, mode=mode, source_session=session)
+    write_jsonl(paths["records"], records)
+    write_json(paths["index"], build_index(records, mode=mode, source_session=session))
+    write_json(paths["coverage_report"], coverage)
+    paths["summary"].parent.mkdir(parents=True, exist_ok=True)
+    paths["summary"].write_text(summary_md(coverage), encoding="utf-8")
+    write_csv(paths["review"], review_rows(records))
+    hashes = write_hashes(paths, records, mode=mode, source_session=session)
+    return {
+        "schema": SCHEMA,
+        "session": session,
+        "source_session": session,
+        "mode": mode,
+        "authority_aware": True,
+        "modified_canon": False,
+        "canon_modified": False,
+        "paths": {name: str(path) for name, path in paths.items()},
+        "summary": {
+            "record_count": len(records),
+            "authority_levels_detected": coverage["authority_levels_detected"],
+            "records_with_semantic_text": coverage["records_with_semantic_text"],
+            "hashes_sha256": file_sha256(paths["hashes"]),
+            "records_sha256": hashes["file_sha256"].get("records", ""),
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build S0149 authority-aware semantic_text sidecar")
+    parser.add_argument("--canon-glob", default=base.DEFAULT_CANON_GLOB)
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
+    parser.add_argument("--session", default=DEFAULT_SESSION)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--preview", action="store_true")
+    mode.add_argument("--generate", action="store_true")
+    parser.add_argument("--type-policy", default=str(base.DEFAULT_TYPE_POLICY))
+    parser.add_argument("--max-content-chars-per-section", type=int, default=base.DEFAULT_MAX_CONTENT_CHARS)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    mode = "generate" if args.generate else "preview"
+    result = build_authority_outputs(
+        canon_glob=args.canon_glob,
+        out_dir=Path(args.out_dir),
+        session=args.session,
+        mode=mode,
+        type_policy=Path(args.type_policy),
+        max_content_chars=args.max_content_chars_per_section,
+    )
+    print(stable_json(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python_scripts/characterize_repo_artifacts.py
+++ b/python_scripts/characterize_repo_artifacts.py
@@ -1,0 +1,1230 @@
+#!/usr/bin/env python3
+"""S0146 governed repo-artifact characterization.
+
+Read-only with respect to canon shards. The script joins S0145 technical
+candidate signals with observable canon/code-like evidence and the current
+worktree inventory, then writes dry-run review artifacts under
+data/out/local/pipeline/repo_artifacts/s0146/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import hashlib
+import json
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+
+SCHEMA = "repo-artifact-characterization/v1"
+DEFAULT_CANON_GLOB = str(REPO_ROOT / "data" / "out" / "local" / "tiddlers_*.jsonl")
+DEFAULT_S0145_CANDIDATES = (
+    REPO_ROOT
+    / "data"
+    / "out"
+    / "local"
+    / "pipeline"
+    / "unknown_artifact_family"
+    / "s0145"
+    / "s0145_unknown_classification_candidates.jsonl"
+)
+DEFAULT_OUT_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "repo_artifacts" / "s0146"
+
+REVIEW_COLUMNS = [
+    "id",
+    "title",
+    "tags",
+    "diagnostic_category",
+    "candidate_artifact_family",
+    "candidate_repo_path",
+    "repo_path_exists_in_git",
+    "repo_path_exists_in_worktree",
+    "candidate_repo_artifact_kind",
+    "candidate_repo_lifecycle_state",
+    "candidate_is_current_repo_artifact",
+    "candidate_authority_level",
+    "content_comparison",
+    "moved_to_candidate",
+    "confidence",
+    "risk_level",
+    "reason",
+    "recommended_action",
+]
+
+DIAGNOSTIC_CATEGORIES = [
+    "repo_snapshot_current",
+    "repo_snapshot_drifted",
+    "repo_snapshot_missing",
+    "moved_candidate",
+    "deleted_historical_candidate",
+    "generated_output",
+    "narrative_code_reference",
+    "embedded_code_block",
+    "documentation_with_code_example",
+    "session_or_diagnostic_narrative",
+    "external_technical_reference",
+    "unknown_repo_artifact",
+    "review_required",
+]
+
+REPO_ARTIFACT_KINDS = [
+    "source_code",
+    "test_code",
+    "shell_script",
+    "config",
+    "schema",
+    "documentation",
+    "ci_workflow",
+    "generated_output",
+    "data_fixture",
+    "external_reference",
+    "unknown_repo_artifact",
+]
+
+LIFECYCLE_STATES = [
+    "current_repo_artifact",
+    "historical_snapshot",
+    "missing_from_repo",
+    "moved_candidate",
+    "deleted_historical",
+    "generated_output",
+    "external_reference",
+    "unknown_lifecycle",
+    "review_required",
+]
+
+AUTHORITY_LEVELS = [
+    "current_verified",
+    "historical_snapshot",
+    "narrative_reference",
+    "generated_derivative",
+    "external_reference",
+    "unknown",
+]
+
+RELATION_OPPORTUNITY_TYPES = [
+    "possible_tested_by",
+    "possible_tests",
+    "possible_imports",
+    "possible_imported_by",
+    "possible_reads_from",
+    "possible_writes_to",
+    "possible_generates",
+    "possible_validates",
+    "possible_configured_by",
+    "possible_belongs_to_directory",
+    "possible_related_session",
+    "possible_documents",
+    "possible_implements",
+    "possible_superseded_by",
+    "possible_moved_to",
+]
+
+RECOMMENDED_ACTIONS = [
+    "accept_as_repo_artifact_later",
+    "apply_metadata_preview_later",
+    "review_manually",
+    "keep_as_narrative",
+    "keep_as_historical",
+    "mark_generated_derivative_later",
+    "exclude_from_repo_artifact",
+    "needs_new_rule",
+    "needs_relation_review_later",
+]
+
+CODE_EXTENSIONS = {
+    ".py",
+    ".go",
+    ".js",
+    ".ts",
+    ".tsx",
+    ".jsx",
+    ".rs",
+    ".java",
+    ".c",
+    ".cc",
+    ".cpp",
+    ".h",
+    ".hpp",
+    ".rb",
+    ".php",
+    ".sql",
+}
+CONFIG_EXTENSIONS = {
+    ".json",
+    ".jsonl",
+    ".yml",
+    ".yaml",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".lock",
+}
+DOC_EXTENSIONS = {".md", ".txt", ".rst"}
+TECH_PATH_PREFIXES = (
+    ".github/",
+    "python_scripts/",
+    "shell_scripts/",
+    "tests/",
+    "go/",
+    "docs/",
+    "esquemas/",
+    "data/",
+    "ux/",
+)
+SPECIAL_REPO_NAMES = {
+    "README.md",
+    "LICENSE",
+    ".gitignore",
+    ".gitattributes",
+    "go.work",
+    "go.work.sum",
+    "estructura.txt",
+    "tdc.sh",
+}
+GENERATED_PREFIXES = (
+    "data/out/",
+    "data/tmp/",
+    ".venv/",
+)
+GENERATED_PARTS = (
+    "/__pycache__/",
+    "/.pytest_cache/",
+    "/repository_export.egg-info/",
+    "/tiddlers-export/",
+)
+SESSION_TITLE_RE = re.compile(
+    r"^#### .*?(?:sesion|sesión|hipótesis|procedencia|balance|propuesta|diagnóstico)",
+    re.IGNORECASE,
+)
+PATH_TOKEN_RE = re.compile(
+    r"(?:(?:python_scripts|shell_scripts|tests|\.github|go|docs|data|esquemas|ux)/"
+    r"[A-Za-z0-9._/() -]+\.[A-Za-z0-9]+|"
+    r"(?:README\.md|LICENSE|go\.work(?:\.sum)?|estructura\.txt|\.gitignore|\.gitattributes))"
+)
+FENCE_RE = re.compile(r"```[A-Za-z0-9_+-]*\n(.*?)\n```", re.DOTALL)
+
+
+def stable_json(value: Any, *, indent: int | None = None) -> str:
+    if indent is None:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=indent)
+
+
+def normalize_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def clean_repo_path(value: str) -> str:
+    value = value.strip().replace("\\", "/")
+    if value.startswith("./"):
+        return value[2:]
+    return value
+
+
+def comparable_text(text: str) -> str:
+    return normalize_newlines(text).rstrip("\n")
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(comparable_text(text).encode("utf-8")).hexdigest()
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    if not path.exists():
+        return records
+    with path.open(encoding="utf-8") as handle:
+        for line_no, raw in enumerate(handle, start=1):
+            if not raw.strip():
+                continue
+            record = json.loads(raw)
+            if isinstance(record, dict):
+                record["_jsonl_source_path"] = str(path)
+                record["_jsonl_source_line"] = line_no
+                records.append(record)
+    return records
+
+
+def load_canon(canon_glob: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for shard in sorted(glob.glob(canon_glob)):
+        shard_path = Path(shard)
+        for record in read_jsonl(shard_path):
+            record["_canon_shard"] = shard_path.name
+            records.append(record)
+    return records
+
+
+def load_path_set(path: Path | None) -> set[str]:
+    if path is None or not path.exists():
+        return set()
+    values: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        value = clean_repo_path(raw)
+        if value:
+            values.add(value)
+    return values
+
+
+def collect_tags(record: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for key in ("tags", "source_tags", "normalized_tags"):
+        raw = record.get(key)
+        if isinstance(raw, list):
+            values.extend(str(item) for item in raw if str(item).strip())
+        elif isinstance(raw, str):
+            values.extend(raw.split())
+    source_fields = record.get("source_fields") if isinstance(record.get("source_fields"), dict) else {}
+    raw_tags = source_fields.get("tags") or source_fields.get("source_tags")
+    if isinstance(raw_tags, str):
+        values.extend(raw_tags.split())
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            deduped.append(value)
+    return deduped
+
+
+def record_text(record: dict[str, Any]) -> str:
+    text = record.get("text")
+    if isinstance(text, str) and text:
+        return text
+    content = record.get("content")
+    if isinstance(content, dict):
+        plain = content.get("plain")
+        if isinstance(plain, str):
+            return plain
+    return ""
+
+
+def first_code_block(record: dict[str, Any]) -> str:
+    content = record.get("content")
+    if isinstance(content, dict):
+        blocks = content.get("code_blocks")
+        if isinstance(blocks, list) and blocks:
+            first = blocks[0]
+            if isinstance(first, dict) and isinstance(first.get("text"), str):
+                return first["text"]
+    text = record_text(record)
+    match = FENCE_RE.search(text)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def looks_like_repo_path(value: str) -> bool:
+    value = clean_repo_path(value)
+    if not value:
+        return False
+    if value in SPECIAL_REPO_NAMES:
+        return True
+    return value.startswith(TECH_PATH_PREFIXES) and bool(Path(value).suffix)
+
+
+def path_tokens(text: str) -> list[str]:
+    found: list[str] = []
+    seen: set[str] = set()
+    for match in PATH_TOKEN_RE.finditer(text):
+        token = clean_repo_path(match.group(0).strip().strip("`'\",;:()[]{}"))
+        if token and token not in seen:
+            seen.add(token)
+            found.append(token)
+    return found
+
+
+def candidate_repo_path(record: dict[str, Any], git_files: set[str], worktree_files: set[str]) -> str:
+    candidates: list[str] = []
+    for key in ("title", "key"):
+        raw = record.get(key)
+        if isinstance(raw, str):
+            normalized = raw.strip().replace("\\", "/").lstrip("./")
+            normalized = clean_repo_path(raw)
+            if looks_like_repo_path(normalized):
+                candidates.append(normalized)
+    for token in path_tokens(record_text(record)):
+        candidates.append(token)
+    for candidate in candidates:
+        if candidate in git_files or candidate in worktree_files:
+            return candidate
+    for candidate in candidates:
+        if looks_like_repo_path(candidate):
+            return candidate
+    return ""
+
+
+def title_declares_repo_path(record: dict[str, Any]) -> bool:
+    for key in ("title", "key"):
+        raw = record.get(key)
+        if isinstance(raw, str) and looks_like_repo_path(clean_repo_path(raw)):
+            return True
+    return False
+
+
+def is_generated_path(path: str) -> bool:
+    clean = clean_repo_path(path)
+    wrapped = f"/{clean}/"
+    return clean.startswith(GENERATED_PREFIXES) or any(part in wrapped for part in GENERATED_PARTS)
+
+
+def is_session_or_diagnostic(record: dict[str, Any]) -> bool:
+    title = str(record.get("title") or "")
+    if SESSION_TITLE_RE.search(title):
+        return True
+    source_fields = record.get("source_fields") if isinstance(record.get("source_fields"), dict) else {}
+    family = str(source_fields.get("artifact_family") or record.get("artifact_family") or "")
+    return family.endswith("_de_sesion") or family.startswith("diagnostico_")
+
+
+def is_external_reference(text: str) -> bool:
+    return bool(re.search(r"\bhttps?://", text))
+
+
+def is_code_like(record: dict[str, Any]) -> bool:
+    text = record_text(record)
+    tags = " ".join(collect_tags(record)).casefold()
+    title = str(record.get("title") or "")
+    return (
+        record.get("role_primary") == "code"
+        or bool(first_code_block(record))
+        or "--- codigo" in tags
+        or "--- código" in tags
+        or looks_like_repo_path(title)
+        or bool(path_tokens(text))
+        or any(prefix in text for prefix in ("python_scripts/", "shell_scripts/", "tests/", ".github/workflows/"))
+    )
+
+
+def classify_repo_artifact_kind(path: str, *, external: bool = False) -> str:
+    if external:
+        return "external_reference"
+    clean = clean_repo_path(path)
+    suffix = Path(clean).suffix.lower()
+    name = Path(clean).name
+    if not clean:
+        return "unknown_repo_artifact"
+    if is_generated_path(clean):
+        return "generated_output"
+    if clean.startswith(".github/workflows/") and suffix in {".yml", ".yaml"}:
+        return "ci_workflow"
+    if clean.startswith("esquemas/"):
+        return "schema"
+    if clean.startswith("tests/fixtures/") and not name.startswith("test_"):
+        return "data_fixture"
+    if clean.startswith("tests/") or name.startswith("test_") or name.endswith("_test.go"):
+        return "test_code"
+    if clean.startswith("shell_scripts/") or suffix == ".sh" or name == "tdc.sh":
+        return "shell_script"
+    if suffix in DOC_EXTENSIONS or name.upper() == "README.MD":
+        return "documentation"
+    if suffix in CONFIG_EXTENSIONS or name in {".gitignore", ".gitattributes", "go.work", "go.work.sum"}:
+        return "config"
+    if suffix in CODE_EXTENSIONS:
+        return "source_code"
+    return "unknown_repo_artifact"
+
+
+def compare_content(record: dict[str, Any], repo_path: str) -> tuple[str, str, str]:
+    if not repo_path:
+        return "not_applicable", "", ""
+    path = REPO_ROOT / repo_path
+    if not path.exists() or not path.is_file():
+        return "not_applicable", "", ""
+    canon_code = first_code_block(record)
+    if not canon_code:
+        return "no_comparable_code_block", "", sha256_text(path.read_text(encoding="utf-8", errors="replace"))
+    worktree_text = path.read_text(encoding="utf-8", errors="replace")
+    canon_hash = sha256_text(canon_code)
+    worktree_hash = sha256_text(worktree_text)
+    if canon_code == worktree_text:
+        comparison = "exact_match"
+    elif comparable_text(canon_code) == comparable_text(worktree_text):
+        comparison = "normalized_newline_match"
+    else:
+        comparison = "substantive_diff"
+    return comparison, canon_hash, worktree_hash
+
+
+def moved_candidate_for(path: str, git_files: set[str], worktree_files: set[str]) -> str:
+    if not path:
+        return ""
+    basename = Path(path).name
+    if not basename:
+        return ""
+    alternatives = sorted(
+        candidate
+        for candidate in (git_files | worktree_files)
+        if Path(candidate).name == basename and candidate != path
+    )
+    return alternatives[0] if alternatives else ""
+
+
+def s0145_technical_candidates(path: Path | None) -> dict[str, dict[str, Any]]:
+    if path is None or not path.exists():
+        return {}
+    records: dict[str, dict[str, Any]] = {}
+    for item in read_jsonl(path):
+        if item.get("candidate_artifact_family") == "tiddler_tecnico":
+            records[str(item.get("id") or "")] = item
+    return records
+
+
+def input_source_for(*, in_s0145: bool, code_like: bool, repo_path: bool) -> str:
+    active = [in_s0145, code_like, repo_path]
+    if sum(1 for flag in active if flag) > 1:
+        return "mixed"
+    if in_s0145:
+        return "s0145_candidate"
+    if repo_path:
+        return "repo_path_like"
+    return "canon_code_like"
+
+
+def classify_record(
+    record: dict[str, Any],
+    *,
+    s0145_candidate: dict[str, Any] | None,
+    git_files: set[str],
+    worktree_files: set[str],
+) -> dict[str, Any]:
+    title = str(record.get("title") or "")
+    text = record_text(record)
+    tags = collect_tags(record)
+    repo_path = candidate_repo_path(record, git_files, worktree_files)
+    session_shape = is_session_or_diagnostic(record)
+    if session_shape and not title_declares_repo_path(record):
+        repo_path = ""
+    exists_git = repo_path in git_files if repo_path else False
+    exists_worktree = repo_path in worktree_files or (bool(repo_path) and (REPO_ROOT / repo_path).exists())
+    path_exists = exists_git or exists_worktree
+    signals: list[str] = []
+    if s0145_candidate:
+        signals.extend(str(item) for item in s0145_candidate.get("signals", []))
+        signals.append("s0145_tiddler_tecnico")
+    if repo_path:
+        signals.append("repo_path_detected")
+    if exists_git:
+        signals.append("git_path_exact")
+    if exists_worktree:
+        signals.append("worktree_path_exact")
+    if first_code_block(record):
+        signals.append("code_block_detected")
+    if session_shape:
+        signals.append("session_or_diagnostic_shape")
+
+    external = not repo_path and is_external_reference(text)
+    kind = classify_repo_artifact_kind(repo_path, external=external)
+    comparison, canon_hash, worktree_hash = compare_content(record, repo_path)
+    moved_to = "" if path_exists else moved_candidate_for(repo_path, git_files, worktree_files)
+    if moved_to:
+        signals.append("moved_basename_candidate")
+
+    diagnostic_category = "unknown_repo_artifact"
+    lifecycle = "unknown_lifecycle"
+    authority = "unknown"
+    current = "unknown"
+    confidence = "low"
+    risk = "medium"
+    action = "review_manually"
+    family = ""
+    reason = "Insufficient evidence for governed repo-artifact classification."
+
+    if repo_path and is_generated_path(repo_path):
+        diagnostic_category = "generated_output"
+        lifecycle = "generated_output"
+        authority = "generated_derivative"
+        current = "false"
+        confidence = "high"
+        risk = "critical"
+        action = "mark_generated_derivative_later"
+        family = "artefacto_repositorio"
+        reason = "Path is under generated/runtime output and must not be treated as repo source truth."
+    elif repo_path and path_exists:
+        family = "artefacto_repositorio"
+        if comparison in {"exact_match", "normalized_newline_match"}:
+            diagnostic_category = "repo_snapshot_current"
+            lifecycle = "current_repo_artifact"
+            authority = "current_verified"
+            current = "true"
+            confidence = "high"
+            risk = "low"
+            action = "accept_as_repo_artifact_later"
+            reason = "Repo path exists and canonized content matches current worktree content."
+        elif comparison == "substantive_diff":
+            diagnostic_category = "repo_snapshot_drifted"
+            lifecycle = "historical_snapshot"
+            authority = "historical_snapshot"
+            current = "false"
+            confidence = "high"
+            risk = "critical"
+            action = "review_manually"
+            reason = "Repo path exists but canonized content differs substantively from current worktree content."
+        else:
+            diagnostic_category = "review_required"
+            lifecycle = "review_required"
+            authority = "unknown"
+            current = "unknown"
+            confidence = "requires_human_review"
+            risk = "high"
+            action = "review_manually"
+            reason = "Repo path exists, but content cannot be compared; current authority is not proven."
+    elif repo_path and moved_to:
+        family = "artefacto_repositorio"
+        diagnostic_category = "moved_candidate"
+        lifecycle = "moved_candidate"
+        authority = "historical_snapshot"
+        current = "false"
+        confidence = "medium"
+        risk = "high"
+        action = "review_manually"
+        reason = "Original repo path is missing, but another worktree path has the same basename."
+    elif repo_path:
+        family = "artefacto_repositorio"
+        diagnostic_category = "repo_snapshot_missing"
+        lifecycle = "missing_from_repo"
+        authority = "historical_snapshot"
+        current = "false"
+        confidence = "medium"
+        risk = "critical"
+        action = "keep_as_historical"
+        reason = "Title or text indicates a repo path, but the path is absent from git/worktree."
+    elif is_session_or_diagnostic(record) and path_tokens(text):
+        diagnostic_category = "session_or_diagnostic_narrative"
+        lifecycle = "unknown_lifecycle"
+        authority = "narrative_reference"
+        current = "false"
+        confidence = "high"
+        risk = "high"
+        action = "keep_as_narrative"
+        reason = "Session or diagnostic narrative mentions code paths but does not represent a repo file snapshot."
+    elif first_code_block(record) and (title.endswith(".md") or "README" in title):
+        diagnostic_category = "documentation_with_code_example"
+        lifecycle = "unknown_lifecycle"
+        authority = "narrative_reference"
+        current = "false"
+        confidence = "medium"
+        risk = "high"
+        action = "keep_as_narrative"
+        reason = "Documentation-like tiddler contains code examples, not a verified repo file snapshot."
+    elif first_code_block(record):
+        diagnostic_category = "embedded_code_block"
+        lifecycle = "unknown_lifecycle"
+        authority = "narrative_reference"
+        current = "false"
+        confidence = "medium"
+        risk = "high"
+        action = "keep_as_narrative"
+        reason = "Tiddler contains embedded code without a verifiable repo path."
+    elif path_tokens(text):
+        diagnostic_category = "narrative_code_reference"
+        lifecycle = "unknown_lifecycle"
+        authority = "narrative_reference"
+        current = "false"
+        confidence = "medium"
+        risk = "medium"
+        action = "keep_as_narrative"
+        reason = "Tiddler mentions code paths or commands without representing a file snapshot."
+    elif external:
+        diagnostic_category = "external_technical_reference"
+        lifecycle = "external_reference"
+        authority = "external_reference"
+        current = "false"
+        confidence = "medium"
+        risk = "medium"
+        action = "exclude_from_repo_artifact"
+        reason = "Technical reference appears external to the repository."
+
+    if family == "artefacto_repositorio" and not repo_path:
+        confidence = "requires_human_review"
+        risk = "critical"
+        action = "review_manually"
+
+    return {
+        "id": str(record.get("id") or ""),
+        "title": title,
+        "tags": tags,
+        "input_source": input_source_for(
+            in_s0145=s0145_candidate is not None,
+            code_like=is_code_like(record),
+            repo_path=bool(repo_path),
+        ),
+        "s0145_candidate_artifact_family": str((s0145_candidate or {}).get("candidate_artifact_family") or ""),
+        "diagnostic_category": diagnostic_category,
+        "candidate_artifact_family": family,
+        "candidate_repo_path": repo_path,
+        "repo_path_exists_in_git": bool(exists_git),
+        "repo_path_exists_in_worktree": bool(exists_worktree),
+        "candidate_repo_directory": str(Path(repo_path).parent) if repo_path and str(Path(repo_path).parent) != "." else "",
+        "candidate_repo_extension": Path(repo_path).suffix.lower() if repo_path else "",
+        "candidate_repo_artifact_kind": kind,
+        "candidate_content_sha256": canon_hash,
+        "candidate_first_seen_at": str((record.get("source_fields") or {}).get("created") or record.get("created") or ""),
+        "candidate_last_seen_at": "S0146",
+        "candidate_repo_lifecycle_state": lifecycle,
+        "candidate_is_current_repo_artifact": current,
+        "candidate_source_export_session": "S0146",
+        "candidate_related_sessions": [],
+        "candidate_authority_level": authority,
+        "canon_content_sha256": canon_hash,
+        "worktree_content_sha256": worktree_hash,
+        "content_comparison": comparison,
+        "moved_to_candidate": moved_to,
+        "confidence": confidence,
+        "risk_level": risk,
+        "signals": sorted(set(signals)),
+        "reason": reason,
+        "recommended_action": action,
+        "applied_to_canon": False,
+        "dry_run": True,
+    }
+
+
+def build_relation_opportunities(classifications: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_path = {item["candidate_repo_path"]: item for item in classifications if item.get("candidate_repo_path")}
+    opportunities: list[dict[str, Any]] = []
+    for item in classifications:
+        path = item.get("candidate_repo_path") or ""
+        if not path:
+            continue
+        directory = item.get("candidate_repo_directory") or ""
+        if directory:
+            opportunities.append(
+                relation_opportunity(
+                    item,
+                    target_id="",
+                    target_title=directory,
+                    relation_type="possible_belongs_to_directory",
+                    evidence_strength="weak",
+                    evidence=f"repo_path directory is {directory}",
+                    risk_level="low",
+                )
+            )
+        moved_to = item.get("moved_to_candidate") or ""
+        if moved_to:
+            target = by_path.get(moved_to, {})
+            opportunities.append(
+                relation_opportunity(
+                    item,
+                    target_id=str(target.get("id") or ""),
+                    target_title=str(target.get("title") or moved_to),
+                    relation_type="possible_moved_to",
+                    evidence_strength="weak",
+                    evidence=f"missing path shares basename with {moved_to}",
+                    risk_level="high",
+                )
+            )
+        if item.get("candidate_repo_artifact_kind") == "test_code":
+            basename = Path(path).name
+            stem = basename.removeprefix("test_").removesuffix("_test.go")
+            possible_targets = [
+                f"python_scripts/{stem.removesuffix('.py')}.py",
+                f"go/{stem}.go",
+            ]
+            for target_path in possible_targets:
+                target = by_path.get(target_path)
+                if target:
+                    opportunities.append(
+                        relation_opportunity(
+                            item,
+                            target_id=str(target.get("id") or ""),
+                            target_title=str(target.get("title") or target_path),
+                            relation_type="possible_tests",
+                            evidence_strength="weak",
+                            evidence=f"test filename resembles {target_path}",
+                            risk_level="high",
+                        )
+                    )
+    return sorted(opportunities, key=lambda row: (row["source_title"], row["possible_relation_type"], row["target_title"]))
+
+
+def relation_opportunity(
+    source: dict[str, Any],
+    *,
+    target_id: str,
+    target_title: str,
+    relation_type: str,
+    evidence_strength: str,
+    evidence: str,
+    risk_level: str,
+) -> dict[str, Any]:
+    return {
+        "source_id": source.get("id", ""),
+        "source_title": source.get("title", ""),
+        "target_id": target_id,
+        "target_title": target_title,
+        "possible_relation_type": relation_type,
+        "evidence_strength": evidence_strength,
+        "evidence": evidence,
+        "risk_level": risk_level,
+        "requires_human_review": True,
+        "formal_relation_candidate": False,
+        "admissible_in_s0146": False,
+    }
+
+
+def select_universe(
+    canon_records: list[dict[str, Any]],
+    s0145_candidates: dict[str, dict[str, Any]],
+    git_files: set[str],
+    worktree_files: set[str],
+) -> list[tuple[dict[str, Any], dict[str, Any] | None]]:
+    selected: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+    for record in canon_records:
+        tid = str(record.get("id") or "")
+        s0145 = s0145_candidates.get(tid)
+        repo_path = candidate_repo_path(record, git_files, worktree_files)
+        if s0145 or is_code_like(record) or repo_path:
+            selected.append((record, s0145))
+    return sorted(selected, key=lambda pair: (str(pair[0].get("title") or ""), str(pair[0].get("id") or "")))
+
+
+def counter_for(rows: list[dict[str, Any]], key: str) -> dict[str, int]:
+    return dict(sorted(Counter(str(row.get(key) or "") for row in rows).items()))
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(stable_json(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(stable_json(row) + "\n" for row in rows), encoding="utf-8")
+
+
+def write_review_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=REVIEW_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    column: "|".join(row.get(column, [])) if isinstance(row.get(column), list) else row.get(column, "")
+                    for column in REVIEW_COLUMNS
+                }
+            )
+
+
+def display_path(path: Path) -> str:
+    if not path.is_absolute():
+        return path.as_posix()
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def build_summary(classifications: list[dict[str, Any]], *, s0145_total: int, additional_code_like: int) -> dict[str, Any]:
+    by_category = counter_for(classifications, "diagnostic_category")
+    return {
+        "schema": "repo-artifact-grouped-summary/v1",
+        "session": "S0146",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "total_evaluated": len(classifications),
+        "from_s0145": s0145_total,
+        "additional_code_like": additional_code_like,
+        "with_candidate_repo_path": sum(1 for row in classifications if row.get("candidate_repo_path")),
+        "with_git_path": sum(1 for row in classifications if row.get("repo_path_exists_in_git")),
+        "with_worktree_path": sum(1 for row in classifications if row.get("repo_path_exists_in_worktree")),
+        "by_diagnostic_category": by_category,
+        "by_candidate_repo_artifact_kind": counter_for(classifications, "candidate_repo_artifact_kind"),
+        "by_candidate_repo_lifecycle_state": counter_for(classifications, "candidate_repo_lifecycle_state"),
+        "by_candidate_authority_level": counter_for(classifications, "candidate_authority_level"),
+        "by_content_comparison": counter_for(classifications, "content_comparison"),
+        "by_risk_level": counter_for(classifications, "risk_level"),
+        "by_recommended_action": counter_for(classifications, "recommended_action"),
+        "s0147_strong_candidates": sum(
+            1
+            for row in classifications
+            if row.get("candidate_artifact_family") == "artefacto_repositorio"
+            and row.get("candidate_repo_path")
+            and row.get("candidate_authority_level") not in {"", "unknown"}
+            and row.get("candidate_repo_lifecycle_state") not in {"", "unknown_lifecycle"}
+            and row.get("content_comparison") not in {"no_comparable_code_block", "not_applicable"}
+            and row.get("risk_level") != "critical"
+        ),
+        "requires_human_review": sum(1 for row in classifications if row.get("confidence") == "requires_human_review" or row.get("risk_level") in {"high", "critical"}),
+    }
+
+
+def grouped_summary_md(summary: dict[str, Any], relation_count: int) -> str:
+    cat = summary["by_diagnostic_category"]
+    kind = summary["by_candidate_repo_artifact_kind"]
+    lifecycle = summary["by_candidate_repo_lifecycle_state"]
+    authority = summary["by_candidate_authority_level"]
+    dominant_kind = max(kind.items(), key=lambda item: item[1])[0] if kind else ""
+    dominant_lifecycle = max(lifecycle.items(), key=lambda item: item[1])[0] if lifecycle else ""
+    dominant_authority = max(authority.items(), key=lambda item: item[1])[0] if authority else ""
+    lines = [
+        "# S0146 repo_artifact grouped summary",
+        "",
+        f"- Total de tiddlers evaluados: {summary['total_evaluated']}",
+        f"- Total provenientes de S0145: {summary['from_s0145']}",
+        f"- Total code-like adicional detectado en canon: {summary['additional_code_like']}",
+        f"- Total con repo_path candidato: {summary['with_candidate_repo_path']}",
+        f"- Total con ruta en git: {summary['with_git_path']}",
+        f"- Total con ruta en worktree: {summary['with_worktree_path']}",
+        f"- Total current_repo_artifact: {lifecycle.get('current_repo_artifact', 0)}",
+        f"- Total repo_snapshot_current: {cat.get('repo_snapshot_current', 0)}",
+        f"- Total repo_snapshot_drifted: {cat.get('repo_snapshot_drifted', 0)}",
+        f"- Total repo_snapshot_missing: {cat.get('repo_snapshot_missing', 0)}",
+        f"- Total missing_from_repo: {lifecycle.get('missing_from_repo', 0)}",
+        f"- Total moved_candidate: {cat.get('moved_candidate', 0)}",
+        f"- Total deleted_historical_candidate: {cat.get('deleted_historical_candidate', 0)}",
+        f"- Total generated_output: {cat.get('generated_output', 0)}",
+        f"- Total narrative_code_reference: {cat.get('narrative_code_reference', 0)}",
+        f"- Total embedded_code_block: {cat.get('embedded_code_block', 0)}",
+        f"- Total documentation_with_code_example: {cat.get('documentation_with_code_example', 0)}",
+        f"- Total session_or_diagnostic_narrative: {cat.get('session_or_diagnostic_narrative', 0)}",
+        f"- Total external_technical_reference: {cat.get('external_technical_reference', 0)}",
+        f"- Total unknown_repo_artifact: {cat.get('unknown_repo_artifact', 0)}",
+        f"- Total review_required: {cat.get('review_required', 0)}",
+        f"- Total que podrian recibir artefacto_repositorio en S0147: {summary['s0147_strong_candidates']}",
+        f"- Total que requieren revision humana o exclusion antes de metadata: {summary['requires_human_review']}",
+        f"- Tipo repo_artifact_kind dominante: {dominant_kind}",
+        f"- Estado repo_lifecycle_state dominante: {dominant_lifecycle}",
+        f"- authority_level dominante: {dominant_authority}",
+        f"- Oportunidades relacionales detectadas: {relation_count}",
+        "",
+        "## Riesgos principales",
+        "- Authority falsa por rutas vigentes con contenido divergente.",
+        "- Sesiones narrativas que mencionan codigo y parecen snapshots.",
+        "- Outputs generados bajo data/out o data/tmp tratados como fuente de verdad.",
+        "- Bloques markdown de ejemplo confundidos con archivos ejecutables.",
+        "",
+        "## Reglas que funcionaron",
+        "- Ruta exacta en git/worktree mas comparacion de contenido para current_verified.",
+        "- Separacion entre snapshot, narrativa, output generado y referencia externa.",
+        "- Bloqueo de relaciones formales: solo oportunidades con formal_relation_candidate=false.",
+        "",
+        "## Reglas insuficientes",
+        "- Basename compartido solo permite moved_candidate debil, no rename confirmado.",
+        "- Nombres de tests parecidos no prueban relacion tests/tested_by.",
+        "- Markdown con codigo requiere revision antes de authority_level operativo.",
+        "",
+        "## Decision recomendada para S0147",
+        "Avanzar solo a patch preview reversible de metadata para registros con repo_path, authority_level y lifecycle definidos, content_comparison no ambiguo y risk_level distinto de critical.",
+        "",
+        "## Familia artefacto_repositorio",
+        "Conviene usar `artefacto_repositorio` como familia canonica futura solo para snapshots de archivos con metadata de path, hash, ciclo de vida y autoridad. No conviene promover en masa `tiddler_tecnico`.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def metadata_contract_md() -> str:
+    return """# S0146 repo_artifact metadata contract
+
+## Familia
+`artifact_family = artefacto_repositorio` identifica snapshots o representaciones gobernadas de artefactos del repositorio. No reemplaza Git y no convierte el canon en fuente viva de codigo.
+
+## Campos obligatorios futuros
+- `repo_path`
+- `repo_artifact_kind`
+- `content_sha256`
+- `last_seen_at`
+- `repo_lifecycle_state`
+- `is_current_repo_artifact`
+- `authority_level`
+
+## Campos derivados
+- `repo_directory`
+- `repo_extension`
+- `is_current_repo_artifact`
+
+## Campos opcionales
+- `first_seen_at`
+- `source_export_session`
+- `related_sessions`
+
+## Valores permitidos
+- `repo_artifact_kind`: source_code, test_code, shell_script, config, schema, documentation, ci_workflow, generated_output, data_fixture, external_reference, unknown_repo_artifact.
+- `repo_lifecycle_state`: current_repo_artifact, historical_snapshot, missing_from_repo, moved_candidate, deleted_historical, generated_output, external_reference, unknown_lifecycle, review_required.
+- `authority_level`: current_verified, historical_snapshot, narrative_reference, generated_derivative, external_reference, unknown.
+
+## Reglas de validacion
+- `current_verified` requiere `repo_path` actual y `content_sha256`/comparacion positiva.
+- Una ruta coincidente sin bloque comparable no basta para vigencia.
+- `generated_output` nunca debe tratarse como source_code vigente.
+- Sin `repo_path` verificable no hay `artefacto_repositorio` de confianza alta.
+
+## Bloqueos de admision futura
+- `risk_level=critical`.
+- `content_comparison` en `substantive_diff`, `no_comparable_code_block` o `not_applicable` para authority current.
+- `repo_lifecycle_state=unknown_lifecycle`.
+- `candidate_authority_level=unknown`.
+
+## Compatibilidad con source_fields
+Si estos campos se almacenan en `source_fields`, deben ser planos string -> string. Listas como `related_sessions` deben serializarse como JSON string. No se deben guardar relaciones ni markdown completo dentro de `source_fields`.
+
+## Compatibilidad con semantic_text
+- `current_verified`: puede presentarse como codigo vigente.
+- `historical_snapshot`: debe marcarse como historico.
+- `narrative_reference`: debe tratarse como explicacion, no archivo.
+- `generated_derivative`: debe marcarse como output derivado.
+- `unknown`: debe evitar lenguaje de autoridad.
+
+## Compatibilidad con relaciones tecnicas futuras
+Las relaciones tecnicas solo pueden generarse despues de separar evidencia fuerte y debil. S0146 produce oportunidades, no candidatos formales.
+"""
+
+
+def lifecycle_report(classifications: list[dict[str, Any]]) -> dict[str, Any]:
+    rows_by_state: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in classifications:
+        rows_by_state[str(row.get("candidate_repo_lifecycle_state") or "")].append(
+            {
+                "id": row.get("id"),
+                "title": row.get("title"),
+                "candidate_repo_path": row.get("candidate_repo_path"),
+                "diagnostic_category": row.get("diagnostic_category"),
+                "authority_level": row.get("candidate_authority_level"),
+                "content_comparison": row.get("content_comparison"),
+                "risk_level": row.get("risk_level"),
+            }
+        )
+    return {
+        "schema": "repo-artifact-lifecycle-report/v1",
+        "session": "S0146",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "by_state": {key: value for key, value in sorted(rows_by_state.items())},
+    }
+
+
+def lifecycle_report_md(report: dict[str, Any]) -> str:
+    lines = ["# S0146 repo lifecycle report", ""]
+    for state, rows in report["by_state"].items():
+        lines.append(f"## {state or 'empty'}")
+        lines.append(f"- count: {len(rows)}")
+        for row in rows[:10]:
+            lines.append(f"- {row['title']} | {row.get('candidate_repo_path') or 'no-path'} | {row.get('content_comparison')}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def path_mismatch_report(classifications: list[dict[str, Any]]) -> dict[str, Any]:
+    mismatches = [
+        row
+        for row in classifications
+        if row.get("content_comparison") in {"substantive_diff", "no_comparable_code_block"}
+        or row.get("candidate_repo_lifecycle_state") in {"missing_from_repo", "moved_candidate"}
+    ]
+    return {
+        "schema": "repo-artifact-path-mismatch-report/v1",
+        "session": "S0146",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "count": len(mismatches),
+        "items": [
+            {
+                "id": row.get("id"),
+                "title": row.get("title"),
+                "candidate_repo_path": row.get("candidate_repo_path"),
+                "moved_to_candidate": row.get("moved_to_candidate"),
+                "content_comparison": row.get("content_comparison"),
+                "diagnostic_category": row.get("diagnostic_category"),
+                "risk_level": row.get("risk_level"),
+                "reason": row.get("reason"),
+            }
+            for row in mismatches
+        ],
+    }
+
+
+def rules_payload() -> dict[str, Any]:
+    return {
+        "schema": "repo-artifact-rules/v1",
+        "session": "S0146",
+        "dry_run": True,
+        "diagnostic_categories": DIAGNOSTIC_CATEGORIES,
+        "repo_artifact_kinds": REPO_ARTIFACT_KINDS,
+        "repo_lifecycle_states": LIFECYCLE_STATES,
+        "authority_levels": AUTHORITY_LEVELS,
+        "relation_opportunity_types": RELATION_OPPORTUNITY_TYPES,
+        "recommended_actions": RECOMMENDED_ACTIONS,
+        "current_verified_requires": ["repo_path", "path_exists", "content_match"],
+        "weak_evidence_never_allows": ["current_verified", "formal_relation_candidate"],
+    }
+
+
+def samples_md(classifications: list[dict[str, Any]]) -> str:
+    by_category: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in classifications:
+        by_category[str(row.get("diagnostic_category"))].append(row)
+    lines = ["# S0146 repo artifact samples", ""]
+    for category in DIAGNOSTIC_CATEGORIES:
+        rows = by_category.get(category, [])
+        if not rows:
+            continue
+        lines.append(f"## {category}")
+        for row in rows[:5]:
+            lines.append(
+                f"- {row.get('title')} | path={row.get('candidate_repo_path') or 'no-path'} | "
+                f"comparison={row.get('content_comparison')} | risk={row.get('risk_level')}"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def build_repo_artifact_outputs(
+    *,
+    canon_glob: str = DEFAULT_CANON_GLOB,
+    s0145_candidates: Path | None = DEFAULT_S0145_CANDIDATES,
+    git_files: Path | None = None,
+    worktree_files: Path | None = None,
+    out_dir: Path = DEFAULT_OUT_DIR,
+    session: str = "S0146",
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    if not dry_run:
+        raise ValueError("S0146 only supports dry_run=true")
+    canon_records = load_canon(canon_glob)
+    s0145 = s0145_technical_candidates(s0145_candidates)
+    git_set = load_path_set(git_files)
+    worktree_set = load_path_set(worktree_files)
+    if not git_set:
+        git_set = {path.as_posix() for path in REPO_ROOT.rglob("*") if path.is_file()}
+    if not worktree_set:
+        worktree_set = set(git_set)
+
+    universe = select_universe(canon_records, s0145, git_set, worktree_set)
+    classifications = [
+        classify_record(record, s0145_candidate=s0145_candidate, git_files=git_set, worktree_files=worktree_set)
+        for record, s0145_candidate in universe
+    ]
+    classifications = sorted(classifications, key=lambda row: (row["title"], row["id"]))
+    relation_opportunities = build_relation_opportunities(classifications)
+
+    s0145_in_universe = sum(1 for _record, s0145_candidate in universe if s0145_candidate is not None)
+    additional_code_like = len(classifications) - s0145_in_universe
+    summary = build_summary(classifications, s0145_total=s0145_in_universe, additional_code_like=additional_code_like)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths = {
+        "inventory": out_dir / "s0146_technical_tiddler_inventory.json",
+        "classification": out_dir / "s0146_repo_artifact_classification.jsonl",
+        "grouped_summary_json": out_dir / "s0146_repo_artifact_grouped_summary.json",
+        "grouped_summary_md": out_dir / "s0146_repo_artifact_grouped_summary.md",
+        "review": out_dir / "s0146_repo_artifact_review.csv",
+        "metadata_contract": out_dir / "s0146_repo_artifact_metadata_contract.md",
+        "mapping_preview": out_dir / "s0146_repo_artifact_mapping_preview.json",
+        "lifecycle_json": out_dir / "s0146_repo_lifecycle_report.json",
+        "lifecycle_md": out_dir / "s0146_repo_lifecycle_report.md",
+        "path_mismatch": out_dir / "s0146_repo_path_mismatch_report.json",
+        "moved_candidates": out_dir / "s0146_moved_candidates.jsonl",
+        "generated_output_candidates": out_dir / "s0146_generated_output_candidates.jsonl",
+        "narrative_code_reference_candidates": out_dir / "s0146_narrative_code_reference_candidates.jsonl",
+        "relation_opportunities": out_dir / "s0146_repo_artifact_relation_opportunities.jsonl",
+        "rules": out_dir / "s0146_repo_artifact_rules.json",
+        "samples": out_dir / "s0146_repo_artifact_samples.md",
+    }
+
+    inventory = {
+        "schema": SCHEMA,
+        "session": session,
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "canon_records": len(canon_records),
+        "s0145_technical_candidates_available": len(s0145),
+        "evaluated_records": len(classifications),
+        "git_files": len(git_set),
+        "worktree_files": len(worktree_set),
+        "input_sources": counter_for(classifications, "input_source"),
+        "outputs": {key: display_path(path) for key, path in paths.items()},
+    }
+    mapping_preview = {
+        "schema": "repo-artifact-mapping-preview/v1",
+        "session": session,
+        "dry_run": True,
+        "mapping_allowed_in_s0146": False,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "relations_generated": False,
+        "formal_relation_candidates_generated": False,
+        "counts": {
+            "diagnostic_category": summary["by_diagnostic_category"],
+            "candidate_repo_artifact_kind": summary["by_candidate_repo_artifact_kind"],
+            "candidate_repo_lifecycle_state": summary["by_candidate_repo_lifecycle_state"],
+            "candidate_authority_level": summary["by_candidate_authority_level"],
+            "content_comparison": summary["by_content_comparison"],
+            "risk_level": summary["by_risk_level"],
+            "recommended_action": summary["by_recommended_action"],
+        },
+    }
+
+    write_json(paths["inventory"], inventory)
+    write_jsonl(paths["classification"], classifications)
+    write_json(paths["grouped_summary_json"], summary)
+    paths["grouped_summary_md"].write_text(grouped_summary_md(summary, len(relation_opportunities)), encoding="utf-8")
+    write_review_csv(paths["review"], classifications)
+    paths["metadata_contract"].write_text(metadata_contract_md(), encoding="utf-8")
+    write_json(paths["mapping_preview"], mapping_preview)
+    lifecycle = lifecycle_report(classifications)
+    write_json(paths["lifecycle_json"], lifecycle)
+    paths["lifecycle_md"].write_text(lifecycle_report_md(lifecycle), encoding="utf-8")
+    write_json(paths["path_mismatch"], path_mismatch_report(classifications))
+    write_jsonl(paths["moved_candidates"], [row for row in classifications if row["diagnostic_category"] == "moved_candidate"])
+    write_jsonl(paths["generated_output_candidates"], [row for row in classifications if row["diagnostic_category"] == "generated_output"])
+    write_jsonl(
+        paths["narrative_code_reference_candidates"],
+        [
+            row
+            for row in classifications
+            if row["diagnostic_category"] in {"narrative_code_reference", "session_or_diagnostic_narrative"}
+        ],
+    )
+    write_jsonl(paths["relation_opportunities"], relation_opportunities)
+    write_json(paths["rules"], rules_payload())
+    paths["samples"].write_text(samples_md(classifications), encoding="utf-8")
+
+    return {
+        "summary": summary,
+        "inventory": inventory,
+        "relation_opportunities": len(relation_opportunities),
+        "paths": {key: str(path) for key, path in paths.items()},
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="S0146 dry-run repo artifact characterization")
+    parser.add_argument("--canon-glob", default=DEFAULT_CANON_GLOB)
+    parser.add_argument("--s0145-candidates", default=str(DEFAULT_S0145_CANDIDATES))
+    parser.add_argument("--git-files", default="")
+    parser.add_argument("--worktree-files", default="")
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
+    parser.add_argument("--session", default="S0146")
+    parser.add_argument("--dry-run", action="store_true", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    s0145_path = Path(args.s0145_candidates) if args.s0145_candidates else None
+    result = build_repo_artifact_outputs(
+        canon_glob=args.canon_glob,
+        s0145_candidates=s0145_path,
+        git_files=Path(args.git_files) if args.git_files else None,
+        worktree_files=Path(args.worktree_files) if args.worktree_files else None,
+        out_dir=Path(args.out_dir),
+        session=args.session,
+        dry_run=args.dry_run,
+    )
+    print(stable_json({"status": "ok", **result["summary"], "relation_opportunities": result["relation_opportunities"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python_scripts/characterize_unknown_artifact_family.py
+++ b/python_scripts/characterize_unknown_artifact_family.py
@@ -1,0 +1,921 @@
+#!/usr/bin/env python3
+"""Characterize unknown artifact_family records for S0145.
+
+This script is read-only with respect to canon shards. It consumes the S0144
+semantic_text sidecar as the preferred source of the "unknown" set, joins those
+ids back to the local canon for observable evidence, and writes review reports
+under data/out/local/pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import hashlib
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+
+SCHEMA = "unknown-artifact-family-characterization/v1"
+DEFAULT_SESSION = "s0145"
+DEFAULT_CANON_GLOB = str(REPO_ROOT / "data" / "out" / "local" / "tiddlers_*.jsonl")
+DEFAULT_SEMANTIC_TEXT_RECORDS = (
+    REPO_ROOT
+    / "data"
+    / "out"
+    / "local"
+    / "pipeline"
+    / "semantic_text"
+    / "s0144"
+    / "s0144_semantic_text_records.jsonl"
+)
+DEFAULT_OUT_DIR = (
+    REPO_ROOT
+    / "data"
+    / "out"
+    / "local"
+    / "pipeline"
+    / "unknown_artifact_family"
+    / "s0145"
+)
+
+CANDIDATE_FAMILIES = [
+    "referencia_documental",
+    "referencia_tecnica",
+    "fuente_bibliografica",
+    "fuente_web",
+    "concepto",
+    "glosario",
+    "nota_auxiliar",
+    "recurso_externo",
+    "tiddler_tecnico",
+    "indice_o_navegacion",
+    "fragmento_de_estudio",
+    "unknown_real",
+    "requires_human_review",
+]
+
+CONFIDENCE_VALUES = ["high", "medium", "low", "requires_human_review"]
+RECOMMENDED_ACTIONS = [
+    "accept_candidate_family_later",
+    "review_manually",
+    "keep_unknown_for_now",
+    "needs_new_family",
+    "merge_with_existing_family",
+    "exclude_from_semantic_enrichment",
+]
+
+REVIEW_COLUMNS = [
+    "id",
+    "title",
+    "tags",
+    "candidate_artifact_family",
+    "confidence",
+    "signals",
+    "reason",
+    "sample_excerpt",
+    "recommended_action",
+]
+
+URL_RE = re.compile(r"\b(?:https?://|www\.)\S+", re.IGNORECASE)
+DOI_RE = re.compile(r"\b(?:doi:\s*)?10\.\d{4,9}/[-._;()/:A-Z0-9]+\b", re.IGNORECASE)
+YEAR_RE = re.compile(r"\b(?:19|20)\d{2}\b")
+AUTHOR_RE = re.compile(
+    r"\b(?:autor|autora|author|authors|editor|publisher|editorial|journal|"
+    r"revista|paper|articulo|article|libro|book|isbn|bibliografia|bibliography|"
+    r"cita|citation|fuente|source|referencia|reference)\b",
+    re.IGNORECASE,
+)
+TECH_EXT_RE = re.compile(
+    r"(?:^|[/\\\s])[\w.-]+\.(?:py|json|jsonl|md|sh|yaml|yml|toml|txt|csv|"
+    r"html|css|js|ts|tsx|sql|ini|cfg|lock)\b",
+    re.IGNORECASE,
+)
+PATH_RE = re.compile(
+    r"(?:^|\s)(?:\.?/)?(?:python_scripts|data/out|data/in|tests|docs|"
+    r"shell_scripts|\.github|ux|esquemas|scripts|src|bin)/[^\s`]+",
+    re.IGNORECASE,
+)
+COMMAND_RE = re.compile(
+    r"\b(?:python3|pytest|bash|git|npm|node|cargo|go test|sha256sum|jq|rg|grep)\b",
+    re.IGNORECASE,
+)
+CODE_RE = re.compile(r"```|\bdef\s+\w+\(|\bclass\s+\w+\b|\bimport\s+\w+|\{|\}", re.IGNORECASE)
+NAV_LINK_RE = re.compile(r"\[\[[^\]]+\]\]|\[[^\]]+\]\([^)]+\)")
+NAV_TERMS_RE = re.compile(r"\b(?:indice|index|toc|menu|navegacion|navigation|tabla de contenido|mapa)\b", re.IGNORECASE)
+DEFINITION_RE = re.compile(
+    r"(?:^|\n)\s*(?:definicion|definition)\s*:|"
+    r"(?:^|\n)\s*[^.\n]{2,90}\s+(?:es|son|se define como|consiste en|significa)\s+",
+    re.IGNORECASE,
+)
+CONCEPT_TERMS_RE = re.compile(r"\b(?:concepto|conceptual|marco conceptual|teoria|modelo)\b", re.IGNORECASE)
+NOTE_TERMS_RE = re.compile(
+    r"\b(?:nota|observacion|pendiente|todo|comentario|borrador|revision|"
+    r"operativo|proceso|bitacora|seguimiento)\b",
+    re.IGNORECASE,
+)
+FRAGMENT_TERMS_RE = re.compile(r"\b(?:fragmento|extracto|estudio tdc|corpus tdc|pieza de estudio)\b", re.IGNORECASE)
+EXTERNAL_TERMS_RE = re.compile(r"\b(?:recurso externo|enlace externo|link externo|sitio web|pagina web)\b", re.IGNORECASE)
+
+
+def stable_json_dumps(value: Any, *, indent: int | None = None) -> str:
+    if indent is None:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=indent)
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def normalize_text(value: Any) -> str:
+    text = "" if value is None else str(value)
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    lines = [re.sub(r"[ \t]+", " ", line).strip() for line in text.split("\n")]
+    collapsed: list[str] = []
+    previous_blank = False
+    for line in lines:
+        blank = not line
+        if blank and previous_blank:
+            continue
+        collapsed.append(line)
+        previous_blank = blank
+    return "\n".join(collapsed).strip()
+
+
+def parse_tags(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [normalize_text(item) for item in value if normalize_text(item)]
+    text = normalize_text(value)
+    if not text:
+        return []
+    tags: list[str] = []
+    for match in re.finditer(r"\[\[([^\]]+)\]\]|(\S+)", text):
+        tag = normalize_text(match.group(1) or match.group(2))
+        if tag:
+            tags.append(tag)
+    return tags
+
+
+def collect_tags(record: dict[str, Any]) -> list[str]:
+    tags: list[str] = []
+    tags.extend(parse_tags(record.get("tags")))
+    tags.extend(parse_tags(record.get("source_tags")))
+    sf = record.get("source_fields") if isinstance(record.get("source_fields"), dict) else {}
+    tags.extend(parse_tags(sf.get("tags")))
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for tag in tags:
+        key = tag.casefold()
+        if key not in seen:
+            seen.add(key)
+            deduped.append(tag)
+    return deduped
+
+
+def artifact_family_for(record: dict[str, Any]) -> str:
+    sf = record.get("source_fields") if isinstance(record.get("source_fields"), dict) else {}
+    value = sf.get("artifact_family") or record.get("artifact_family") or record.get("family") or ""
+    return normalize_text(value).casefold() or "unknown"
+
+
+def content_text(record: dict[str, Any]) -> str:
+    if record.get("text"):
+        return normalize_text(record.get("text"))
+    content = record.get("content")
+    if isinstance(content, dict):
+        return normalize_text(content.get("plain") or content.get("text") or content.get("markdown") or "")
+    return normalize_text(content)
+
+
+def source_fields_text(record: dict[str, Any]) -> str:
+    sf = record.get("source_fields") if isinstance(record.get("source_fields"), dict) else {}
+    structural_keys = {
+        "canonical_status",
+        "created",
+        "modified",
+        "provenance_ref",
+        "source_path",
+        "tags",
+        "tmap.id",
+        "type",
+    }
+    parts: list[str] = []
+    for key in sorted(sf):
+        if key.casefold() in structural_keys:
+            continue
+        parts.append(f"{key}: {normalize_text(sf.get(key))}")
+    return "\n".join(part for part in parts if part.strip())
+
+
+def deterministic_excerpt(record: dict[str, Any], limit: int = 420) -> str:
+    text = content_text(record)
+    if not text:
+        semantic = record.get("_semantic_text_record") or {}
+        text = normalize_text(semantic.get("semantic_text"))
+    if not text:
+        text = normalize_text(record.get("title"))
+    if len(text) <= limit:
+        return text
+    return text[: limit - len("[TRUNCATED]") - 1].rstrip() + "\n[TRUNCATED]"
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            record["_jsonl_source_path"] = str(path)
+            record["_jsonl_source_line"] = line_no
+            records.append(record)
+    return records
+
+
+def read_canon_records(canon_glob: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for shard in sorted(glob.glob(canon_glob)):
+        for record in load_jsonl(Path(shard)):
+            record["_canon_source_shard"] = shard
+            record["_canon_source_line"] = record.pop("_jsonl_source_line")
+            record.pop("_jsonl_source_path", None)
+            records.append(record)
+    return records
+
+
+def read_semantic_text_records(path: Path | None) -> list[dict[str, Any]]:
+    if path is None or not path.exists():
+        return []
+    return load_jsonl(path)
+
+
+def record_key(record: dict[str, Any]) -> tuple[str, str]:
+    return (normalize_text(record.get("title")).casefold(), normalize_text(record.get("id")))
+
+
+class Evidence:
+    def __init__(self) -> None:
+        self.scores: dict[str, int] = defaultdict(int)
+        self.signals: dict[str, list[str]] = defaultdict(list)
+        self.non_tag_signals: dict[str, int] = defaultdict(int)
+        self.tag_signals: dict[str, int] = defaultdict(int)
+
+    def add(self, family: str, signal: str, points: int, *, from_tag: bool = False) -> None:
+        if family not in CANDIDATE_FAMILIES:
+            raise ValueError(f"unknown candidate family: {family}")
+        self.scores[family] += points
+        if signal not in self.signals[family]:
+            self.signals[family].append(signal)
+        if from_tag:
+            self.tag_signals[family] += 1
+        else:
+            self.non_tag_signals[family] += 1
+
+
+def add_textual_signals(evidence: Evidence, *, title: str, body: str) -> None:
+    haystack = f"{title}\n{body}"
+    link_count = len(NAV_LINK_RE.findall(body))
+
+    if URL_RE.search(haystack):
+        evidence.add("fuente_web", "url_detected", 4)
+        evidence.add("referencia_documental", "url_detected", 2)
+        evidence.add("recurso_externo", "external_url_detected", 2)
+    if DOI_RE.search(haystack):
+        evidence.add("referencia_documental", "doi_detected", 5)
+        evidence.add("fuente_bibliografica", "doi_detected", 5)
+    if AUTHOR_RE.search(haystack):
+        evidence.add("referencia_documental", "bibliographic_or_source_terms", 3)
+        evidence.add("fuente_bibliografica", "bibliographic_or_source_terms", 2)
+    if YEAR_RE.search(haystack) and AUTHOR_RE.search(haystack):
+        evidence.add("referencia_documental", "year_with_source_or_author_terms", 2)
+    if EXTERNAL_TERMS_RE.search(haystack):
+        evidence.add("recurso_externo", "external_resource_terms", 3)
+        evidence.add("fuente_web", "external_resource_terms", 1)
+
+    if TECH_EXT_RE.search(title) or TECH_EXT_RE.search(body):
+        evidence.add("tiddler_tecnico", "technical_file_extension", 5)
+    if PATH_RE.search(haystack):
+        evidence.add("tiddler_tecnico", "repository_path_detected", 4)
+    if COMMAND_RE.search(body):
+        evidence.add("tiddler_tecnico", "command_or_tool_detected", 2)
+    if CODE_RE.search(body):
+        evidence.add("tiddler_tecnico", "code_or_structured_payload_detected", 2)
+    if URL_RE.search(haystack) and (TECH_EXT_RE.search(haystack) or COMMAND_RE.search(haystack)):
+        evidence.add("referencia_tecnica", "technical_reference_with_url_or_command", 4)
+
+    if NAV_TERMS_RE.search(haystack):
+        evidence.add("indice_o_navegacion", "navigation_terms", 3)
+    if link_count >= 5:
+        evidence.add("indice_o_navegacion", "many_wikilinks_or_markdown_links", 4)
+    elif link_count >= 2:
+        evidence.add("indice_o_navegacion", "multiple_wikilinks_or_markdown_links", 2)
+
+    if DEFINITION_RE.search(body):
+        evidence.add("concepto", "definition_pattern", 3)
+        title_words = [word for word in re.split(r"\s+", title.strip()) if word]
+        if 0 < len(title_words) <= 4 and len(body) <= 900:
+            evidence.add("glosario", "short_term_definition_pattern", 3)
+    if CONCEPT_TERMS_RE.search(haystack):
+        evidence.add("concepto", "conceptual_terms", 2)
+    if NOTE_TERMS_RE.search(haystack):
+        evidence.add("nota_auxiliar", "process_or_note_terms", 2)
+    if FRAGMENT_TERMS_RE.search(haystack):
+        evidence.add("fragmento_de_estudio", "study_fragment_terms", 3)
+
+
+def add_tag_signals(evidence: Evidence, tags: list[str]) -> None:
+    for tag in tags:
+        t = tag.casefold()
+        if any(word in t for word in ("referencia", "reference", "fuente", "bibliografia", "cita")):
+            evidence.add("referencia_documental", "tag_reference_hint", 1, from_tag=True)
+        if any(word in t for word in ("json", "codigo", "script", "python", "markdown", "shell", "config")):
+            evidence.add("tiddler_tecnico", "tag_technical_hint", 1, from_tag=True)
+        if any(word in t for word in ("indice", "index", "menu", "navegacion", "toc")):
+            evidence.add("indice_o_navegacion", "tag_navigation_hint", 1, from_tag=True)
+        if any(word in t for word in ("concepto", "conceptual", "teoria")):
+            evidence.add("concepto", "tag_concept_hint", 1, from_tag=True)
+        if any(word in t for word in ("glosario", "vocabulario")):
+            evidence.add("glosario", "tag_glossary_hint", 1, from_tag=True)
+        if any(word in t for word in ("nota", "operativo", "proceso", "borrador")):
+            evidence.add("nota_auxiliar", "tag_note_hint", 1, from_tag=True)
+
+
+def choose_candidate(evidence: Evidence) -> tuple[str, str, list[str], str, str]:
+    scored = [(family, evidence.scores[family]) for family in CANDIDATE_FAMILIES if evidence.scores.get(family, 0)]
+    if not scored:
+        return (
+            "unknown_real",
+            "low",
+            ["no_reproducible_non_tag_signal"],
+            "No reproducible signal was strong enough to propose a specific family.",
+            "keep_unknown_for_now",
+        )
+
+    scored.sort(key=lambda item: (-item[1], CANDIDATE_FAMILIES.index(item[0])))
+    top_family, top_score = scored[0]
+    tied = [family for family, score in scored if score == top_score]
+    non_tag = evidence.non_tag_signals.get(top_family, 0)
+
+    if non_tag == 0:
+        return (
+            "requires_human_review",
+            "requires_human_review",
+            sorted({signal for signals in evidence.signals.values() for signal in signals}),
+            "Only tag-derived hints were found; tags are evidence, not a classification decision.",
+            "review_manually",
+        )
+
+    if len(tied) > 1 and top_score < 6:
+        return (
+            "requires_human_review",
+            "requires_human_review",
+            sorted({signal for family in tied for signal in evidence.signals[family]}),
+            "Multiple candidate families have the same weak score; human review is required.",
+            "review_manually",
+        )
+
+    if top_family == "fuente_bibliografica" and evidence.scores.get("referencia_documental", 0) >= 3:
+        top_family = "referencia_documental"
+        top_score = evidence.scores[top_family]
+        non_tag = evidence.non_tag_signals.get(top_family, 0)
+
+    if top_score >= 5 and non_tag >= 2:
+        confidence = "high"
+        action = "accept_candidate_family_later"
+    elif top_score >= 3:
+        confidence = "medium"
+        action = "accept_candidate_family_later"
+    else:
+        confidence = "low"
+        action = "review_manually"
+
+    signals = evidence.signals.get(top_family, [])
+    reason = (
+        f"Deterministic score {top_score} for {top_family} with "
+        f"{non_tag} non-tag signal(s); tag hints were auxiliary only."
+    )
+    return top_family, confidence, signals, reason, action
+
+
+def classify_unknown_record(record: dict[str, Any]) -> dict[str, Any]:
+    title = normalize_text(record.get("title"))
+    tags = collect_tags(record)
+    body = "\n".join(part for part in [content_text(record), source_fields_text(record)] if part)
+    evidence = Evidence()
+    add_textual_signals(evidence, title=title, body=body)
+    add_tag_signals(evidence, tags)
+    family, confidence, signals, reason, action = choose_candidate(evidence)
+
+    return {
+        "id": normalize_text(record.get("id")),
+        "title": title,
+        "tags": tags,
+        "current_artifact_family": "unknown",
+        "candidate_artifact_family": family,
+        "confidence": confidence,
+        "signals": sorted(signals),
+        "reason": reason,
+        "sample_excerpt": deterministic_excerpt(record),
+        "recommended_action": action,
+        "dry_run": True,
+        "applied_to_canon": False,
+    }
+
+
+def select_unknown_records(
+    canon_records: list[dict[str, Any]],
+    semantic_records: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    canon_by_id = {
+        normalize_text(record.get("id")): record
+        for record in sorted(canon_records, key=record_key)
+        if normalize_text(record.get("id"))
+    }
+    semantic_by_id = {
+        normalize_text(record.get("id")): record
+        for record in semantic_records
+        if normalize_text(record.get("id"))
+    }
+
+    if semantic_records:
+        unknown_ids = [
+            normalize_text(record.get("id"))
+            for record in semantic_records
+            if normalize_text(record.get("artifact_family")).casefold() == "unknown"
+        ]
+        source = "semantic_text_records"
+    else:
+        unknown_ids = [
+            normalize_text(record.get("id"))
+            for record in canon_records
+            if artifact_family_for(record) == "unknown"
+        ]
+        source = "canon_artifact_family"
+
+    records: list[dict[str, Any]] = []
+    missing_from_canon = 0
+    for record_id in sorted(set(unknown_ids)):
+        base = dict(canon_by_id.get(record_id) or {})
+        if not base:
+            missing_from_canon += 1
+            sem = semantic_by_id.get(record_id, {})
+            base = {
+                "id": record_id,
+                "title": sem.get("title") or record_id,
+                "text": sem.get("semantic_text") or "",
+                "source_fields": {},
+            }
+        if record_id in semantic_by_id:
+            base["_semantic_text_record"] = semantic_by_id[record_id]
+        records.append(base)
+
+    meta = {
+        "unknown_source": source,
+        "semantic_text_records_available": bool(semantic_records),
+        "semantic_text_record_count": len(semantic_records),
+        "canon_record_count": len(canon_records),
+        "unknown_id_count": len(set(unknown_ids)),
+        "missing_unknown_records_from_canon": missing_from_canon,
+    }
+    return sorted(records, key=record_key), meta
+
+
+def build_inventory(
+    candidates: list[dict[str, Any]],
+    *,
+    meta: dict[str, Any],
+    session: str,
+) -> dict[str, Any]:
+    return {
+        "schema": "unknown-artifact-family-inventory/v1",
+        "session": session.upper(),
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "semantic_text_regenerated": False,
+        "embeddings_executed": False,
+        "total_unknown": len(candidates),
+        "source": meta,
+        "records": [
+            {
+                "id": item["id"],
+                "title": item["title"],
+                "tags": item["tags"],
+                "candidate_artifact_family": item["candidate_artifact_family"],
+                "confidence": item["confidence"],
+                "recommended_action": item["recommended_action"],
+            }
+            for item in candidates
+        ],
+    }
+
+
+def top_tags_for(items: list[dict[str, Any]], limit: int = 12) -> list[dict[str, Any]]:
+    counts: Counter[str] = Counter()
+    for item in items:
+        counts.update(item.get("tags") or [])
+    return [
+        {"tag": tag, "count": count}
+        for tag, count in sorted(counts.items(), key=lambda pair: (-pair[1], pair[0].casefold()))[:limit]
+    ]
+
+
+def build_grouped_summary(candidates: list[dict[str, Any]], *, session: str) -> dict[str, Any]:
+    by_family: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for item in candidates:
+        by_family[item["candidate_artifact_family"]].append(item)
+
+    family_counts = Counter(item["candidate_artifact_family"] for item in candidates)
+    confidence_counts = Counter(item["confidence"] for item in candidates)
+    action_counts = Counter(item["recommended_action"] for item in candidates)
+
+    groups: dict[str, Any] = {}
+    for family in sorted(by_family):
+        items = sorted(by_family[family], key=lambda item: (item["title"].casefold(), item["id"]))
+        groups[family] = {
+            "count": len(items),
+            "by_confidence": dict(sorted(Counter(item["confidence"] for item in items).items())),
+            "top_tags": top_tags_for(items),
+            "examples": [
+                {
+                    "id": item["id"],
+                    "title": item["title"],
+                    "confidence": item["confidence"],
+                    "signals": item["signals"],
+                }
+                for item in items[:8]
+            ],
+        }
+
+    high_or_medium = {
+        family
+        for family, items in by_family.items()
+        if family not in {"unknown_real", "requires_human_review"}
+        and any(item["confidence"] in {"high", "medium"} for item in items)
+    }
+    doubtful = {
+        family
+        for family, items in by_family.items()
+        if family in {"unknown_real", "requires_human_review"}
+        or any(item["confidence"] in {"low", "requires_human_review"} for item in items)
+    }
+
+    return {
+        "schema": "unknown-artifact-family-grouped-summary/v1",
+        "session": session.upper(),
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "total_unknown": len(candidates),
+        "by_candidate_artifact_family": dict(sorted(family_counts.items())),
+        "by_confidence": dict(sorted(confidence_counts.items())),
+        "by_recommended_action": dict(sorted(action_counts.items())),
+        "groups": groups,
+        "new_candidate_families_recommended": sorted(high_or_medium),
+        "doubtful_families_or_buckets": sorted(doubtful),
+        "unknown_real": family_counts.get("unknown_real", 0),
+        "requires_human_review": sum(
+            1
+            for item in candidates
+            if item["confidence"] == "requires_human_review"
+            or item["candidate_artifact_family"] == "requires_human_review"
+        ),
+    }
+
+
+def build_mapping_preview(candidates: list[dict[str, Any]], *, session: str) -> dict[str, Any]:
+    family_counts = Counter(item["candidate_artifact_family"] for item in candidates)
+    return {
+        "schema": "artifact-family-mapping-preview/v1",
+        "session": session.upper(),
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "mapping_allowed_in_s0145": False,
+        "total_unknown": len(candidates),
+        "mapped_high_confidence": sum(1 for item in candidates if item["confidence"] == "high"),
+        "mapped_medium_confidence": sum(1 for item in candidates if item["confidence"] == "medium"),
+        "mapped_low_confidence": sum(1 for item in candidates if item["confidence"] == "low"),
+        "requires_human_review": sum(1 for item in candidates if item["confidence"] == "requires_human_review"),
+        "keep_unknown_for_now": sum(1 for item in candidates if item["recommended_action"] == "keep_unknown_for_now"),
+        "by_candidate_artifact_family": dict(sorted(family_counts.items())),
+    }
+
+
+def classification_rules(session: str) -> dict[str, Any]:
+    return {
+        "schema": "unknown-artifact-family-classification-rules/v1",
+        "session": session.upper(),
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "candidate_families": CANDIDATE_FAMILIES,
+        "confidence_values": CONFIDENCE_VALUES,
+        "recommended_actions": RECOMMENDED_ACTIONS,
+        "principles": [
+            "candidate_artifact_family is not canonical artifact_family",
+            "tags are auxiliary signals and never decide a family by themselves",
+            "high confidence enables later batch review only; it does not apply metadata",
+            "semantic_text from S0144 can identify records but is not regenerated",
+        ],
+        "signal_groups": {
+            "referencia_documental": [
+                "url_detected",
+                "doi_detected",
+                "bibliographic_or_source_terms",
+                "year_with_source_or_author_terms",
+            ],
+            "tiddler_tecnico": [
+                "technical_file_extension",
+                "repository_path_detected",
+                "command_or_tool_detected",
+                "code_or_structured_payload_detected",
+            ],
+            "indice_o_navegacion": [
+                "navigation_terms",
+                "multiple_wikilinks_or_markdown_links",
+                "many_wikilinks_or_markdown_links",
+            ],
+            "concepto": ["definition_pattern", "conceptual_terms"],
+            "glosario": ["short_term_definition_pattern"],
+            "nota_auxiliar": ["process_or_note_terms"],
+            "fragmento_de_estudio": ["study_fragment_terms"],
+        },
+        "non_apply_policy": {
+            "mapping_allowed_in_s0145": False,
+            "artifact_family_written_to_canon": False,
+            "semantic_text_regenerated": False,
+            "embeddings_executed": False,
+        },
+    }
+
+
+def build_grouped_summary_md(summary: dict[str, Any]) -> str:
+    lines = [
+        "# S0145 unknown artifact_family grouped summary",
+        "",
+        f"- total_unknown: {summary['total_unknown']}",
+        "- dry_run: true",
+        "- applied_to_canon: false",
+        "- canon_modified: false",
+        "",
+        "## Distribution by candidate_artifact_family",
+        "",
+        "| candidate_artifact_family | count |",
+        "|---|---:|",
+    ]
+    for family, count in summary["by_candidate_artifact_family"].items():
+        lines.append(f"| {family} | {count} |")
+
+    lines.extend(["", "## Confidence", "", "| confidence | count |", "|---|---:|"])
+    for confidence, count in summary["by_confidence"].items():
+        lines.append(f"| {confidence} | {count} |")
+
+    lines.extend(["", "## Top tags and examples by group", ""])
+    for family, group in summary["groups"].items():
+        lines.append(f"### {family}")
+        lines.append("")
+        lines.append(f"- count: {group['count']}")
+        top_tags = ", ".join(f"{item['tag']} ({item['count']})" for item in group["top_tags"][:8]) or "(none)"
+        lines.append(f"- top_tags: {top_tags}")
+        lines.append("- examples:")
+        for example in group["examples"][:5]:
+            signals = ", ".join(example["signals"]) or "no_signal"
+            lines.append(f"  - {example['title']} [{example['confidence']}]: {signals}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Recommended new candidate families",
+            "",
+            ", ".join(summary["new_candidate_families_recommended"]) or "(none)",
+            "",
+            "## Doubtful families or buckets",
+            "",
+            ", ".join(summary["doubtful_families_or_buckets"]) or "(none)",
+            "",
+            f"- unknown_real: {summary['unknown_real']}",
+            f"- requires_human_review: {summary['requires_human_review']}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_artifact_family_proposal(summary: dict[str, Any], mapping_preview: dict[str, Any]) -> str:
+    lines = [
+        "# S0145 artifact_family proposal",
+        "",
+        "S0145 proposes candidate families only. It does not apply metadata, does not",
+        "rewrite canon shards, and does not regenerate semantic_text.",
+        "",
+        "## Counts",
+        "",
+        f"- total_unknown: {mapping_preview['total_unknown']}",
+        f"- mapped_high_confidence: {mapping_preview['mapped_high_confidence']}",
+        f"- mapped_medium_confidence: {mapping_preview['mapped_medium_confidence']}",
+        f"- mapped_low_confidence: {mapping_preview['mapped_low_confidence']}",
+        f"- requires_human_review: {mapping_preview['requires_human_review']}",
+        f"- keep_unknown_for_now: {mapping_preview['keep_unknown_for_now']}",
+        "",
+        "## Candidate families to review in S0146",
+        "",
+    ]
+    for family in summary["new_candidate_families_recommended"]:
+        count = summary["by_candidate_artifact_family"].get(family, 0)
+        lines.append(f"- {family}: {count}")
+    if not summary["new_candidate_families_recommended"]:
+        lines.append("- (none)")
+
+    lines.extend(
+        [
+            "",
+            "## Families not recommended yet",
+            "",
+            "- fuente_de_estudio: avoid introducing this UX layer until the clearer",
+            "  technical families above are reviewed.",
+            "- unknown_real: keep as a residual bucket until human review resolves it.",
+            "- requires_human_review: not a canonical family; it is a workflow bucket.",
+            "",
+            "## S0146 orientation",
+            "",
+            "S0146 should build a reversible patch preview only, preserving:",
+            "",
+            "- dry_run: true",
+            "- applied_to_canon: false unless a later explicit decision changes scope",
+            "- canon_modified: false",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_samples_md(summary: dict[str, Any]) -> str:
+    lines = [
+        "# S0145 unknown samples",
+        "",
+        "Deterministic examples by candidate family. Excerpts are in the JSONL review file.",
+        "",
+    ]
+    for family, group in summary["groups"].items():
+        lines.append(f"## {family}")
+        lines.append("")
+        for example in group["examples"][:8]:
+            signals = ", ".join(example["signals"]) or "no_signal"
+            lines.append(f"- {example['title']} [{example['confidence']}]: {signals}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def review_rows(candidates: list[dict[str, Any]]) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for item in candidates:
+        rows.append(
+            {
+                "id": item["id"],
+                "title": item["title"],
+                "tags": "|".join(item["tags"]),
+                "candidate_artifact_family": item["candidate_artifact_family"],
+                "confidence": item["confidence"],
+                "signals": "|".join(item["signals"]),
+                "reason": item["reason"],
+                "sample_excerpt": item["sample_excerpt"],
+                "recommended_action": item["recommended_action"],
+            }
+        )
+    return rows
+
+
+def output_paths(out_dir: Path, session: str) -> dict[str, Path]:
+    prefix = session.lower()
+    return {
+        "inventory": out_dir / f"{prefix}_unknown_inventory.json",
+        "classification_candidates": out_dir / f"{prefix}_unknown_classification_candidates.jsonl",
+        "grouped_summary": out_dir / f"{prefix}_unknown_grouped_summary.json",
+        "grouped_summary_md": out_dir / f"{prefix}_unknown_grouped_summary.md",
+        "review": out_dir / f"{prefix}_unknown_review.csv",
+        "proposal": out_dir / f"{prefix}_artifact_family_proposal.md",
+        "mapping_preview": out_dir / f"{prefix}_artifact_family_mapping_preview.json",
+        "rules": out_dir / f"{prefix}_unknown_classification_rules.json",
+        "samples": out_dir / f"{prefix}_unknown_samples.md",
+    }
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(stable_json_dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(stable_json_dumps(record) + "\n")
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=REVIEW_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def build_hashes(paths: dict[str, Path]) -> dict[str, Any]:
+    return {
+        "file_sha256": {
+            name: sha256_bytes(path.read_bytes())
+            for name, path in sorted(paths.items())
+            if path.exists()
+        }
+    }
+
+
+def build_unknown_artifact_family_outputs(
+    *,
+    canon_glob: str = DEFAULT_CANON_GLOB,
+    semantic_text_records: Path | str | None = DEFAULT_SEMANTIC_TEXT_RECORDS,
+    out_dir: Path | str = DEFAULT_OUT_DIR,
+    session: str = DEFAULT_SESSION,
+) -> dict[str, Any]:
+    canon_records = read_canon_records(canon_glob)
+    semantic_path = Path(semantic_text_records) if semantic_text_records else None
+    semantic_records = read_semantic_text_records(semantic_path)
+    unknown_records, meta = select_unknown_records(canon_records, semantic_records)
+    candidates = [classify_unknown_record(record) for record in unknown_records]
+    candidates.sort(key=lambda item: (item["title"].casefold(), item["id"]))
+
+    session_lower = session.lower()
+    paths = output_paths(Path(out_dir), session_lower)
+    inventory = build_inventory(candidates, meta=meta, session=session_lower)
+    grouped = build_grouped_summary(candidates, session=session_lower)
+    mapping = build_mapping_preview(candidates, session=session_lower)
+    rules = classification_rules(session_lower)
+
+    write_json(paths["inventory"], inventory)
+    write_jsonl(paths["classification_candidates"], candidates)
+    write_json(paths["grouped_summary"], grouped)
+    paths["grouped_summary_md"].write_text(build_grouped_summary_md(grouped), encoding="utf-8")
+    write_csv(paths["review"], review_rows(candidates))
+    paths["proposal"].write_text(build_artifact_family_proposal(grouped, mapping), encoding="utf-8")
+    write_json(paths["mapping_preview"], mapping)
+    write_json(paths["rules"], rules)
+    paths["samples"].write_text(build_samples_md(grouped), encoding="utf-8")
+
+    return {
+        "schema": SCHEMA,
+        "session": session_lower.upper(),
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "semantic_text_regenerated": False,
+        "embeddings_executed": False,
+        "paths": {name: str(path) for name, path in paths.items()},
+        "summary": {
+            "total_unknown": len(candidates),
+            "by_candidate_artifact_family": mapping["by_candidate_artifact_family"],
+            "by_confidence": grouped["by_confidence"],
+            "by_recommended_action": grouped["by_recommended_action"],
+        },
+        "hashes": build_hashes(paths),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Characterize unknown artifact_family records without modifying canon.",
+    )
+    parser.add_argument("--canon-glob", default=DEFAULT_CANON_GLOB)
+    parser.add_argument(
+        "--semantic-text-records",
+        default=str(DEFAULT_SEMANTIC_TEXT_RECORDS),
+        help="S0144 semantic_text records JSONL. Use an empty string to infer unknowns from canon only.",
+    )
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
+    parser.add_argument("--session", default=DEFAULT_SESSION)
+    parser.add_argument("--dry-run", action="store_true", help="Accepted for explicit non-apply mode.")
+    args = parser.parse_args()
+
+    semantic_records = args.semantic_text_records or None
+    result = build_unknown_artifact_family_outputs(
+        canon_glob=args.canon_glob,
+        semantic_text_records=semantic_records,
+        out_dir=args.out_dir,
+        session=args.session,
+    )
+    print(stable_json_dumps(result["summary"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python_scripts/legacy_test_classifier.py
+++ b/python_scripts/legacy_test_classifier.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Classify legacy pytest failures for governed S0150 test saneamiento."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_OUT_DIR = Path("data/out/local/pipeline/test_saneamiento/s0150")
+FAILED_RE = re.compile(r"^FAILED\s+([^\s]+)(?:\s+-\s+(.+))?$")
+SUMMARY_RE = re.compile(r"(?P<failed>\d+) failed, (?P<passed>\d+) passed(?:, (?P<skipped>\d+) skipped)?")
+PROTECTED_KEYWORDS = {
+    "canon",
+    "rollback",
+    "human_review",
+    "human review",
+    "apply",
+    "dry_run",
+    "dry-run",
+    "candidate",
+    "hash",
+    "mcp",
+    "mirror",
+    "exporter",
+}
+
+
+def stable_json(value: Any, *, indent: int | None = None) -> str:
+    if indent is None:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=indent)
+
+
+def classify_failure(nodeid: str, message: str) -> dict[str, Any]:
+    lower = f"{nodeid} {message}".lower()
+    categories: list[str] = []
+    if "classification_characterization" in nodeid or "derive_layers_characterization" in nodeid:
+        categories.extend(["baseline_freeze_obsolete", "needs_test_update"])
+    elif "readme" in lower:
+        categories.extend(["readme_expectation_obsolete", "needs_test_update"])
+    elif "legacy" in lower:
+        categories.append("legacy_flow_obsolete")
+    else:
+        categories.append("requires_human_review")
+
+    protected = sorted(keyword for keyword in PROTECTED_KEYWORDS if keyword in lower)
+    if protected and "requires_human_review" not in categories:
+        categories.append("requires_human_review")
+
+    removable = not protected and any(category in categories for category in {"legacy_flow_obsolete", "readme_expectation_obsolete"})
+    recommendation = "update_expected_baseline_with_human_review" if protected else "update_or_move_to_legacy"
+    if removable:
+        recommendation = "may_move_to_legacy_after_replacement"
+    return {
+        "nodeid": nodeid,
+        "message": message,
+        "classification": categories,
+        "protected_keywords": protected,
+        "removal_allowed": removable,
+        "recommendation": recommendation,
+    }
+
+
+def parse_pytest_log(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    failures = []
+    for line in text.splitlines():
+        match = FAILED_RE.match(line.strip())
+        if match:
+            failures.append(classify_failure(match.group(1), match.group(2) or ""))
+    summary = {
+        "failed": len(failures),
+        "passed": None,
+        "skipped": None,
+    }
+    for match in SUMMARY_RE.finditer(text):
+        summary = {
+            "failed": int(match.group("failed")),
+            "passed": int(match.group("passed")),
+            "skipped": int(match.group("skipped") or 0),
+        }
+    return {
+        "summary": summary,
+        "failures": failures,
+    }
+
+
+def paths(out_dir: Path = DEFAULT_OUT_DIR) -> dict[str, Path]:
+    return {
+        "classification_json": out_dir / "s0150_legacy_test_classification.json",
+        "classification_md": out_dir / "s0150_legacy_test_classification.md",
+        "update_plan": out_dir / "s0150_test_update_plan.md",
+        "pytest_log": out_dir / "s0150_pytest_full.log",
+    }
+
+
+def classification_markdown(payload: dict[str, Any]) -> str:
+    counts = Counter(category for failure in payload["failures"] for category in failure["classification"])
+    lines = [
+        "# S0150 legacy test classification",
+        "",
+        f"- pytest_failed_total: {payload['summary']['failed']}",
+        f"- pytest_passed_total: {payload['summary']['passed']}",
+        f"- pytest_skipped_total: {payload['summary']['skipped']}",
+        f"- classified_failures: {len(payload['failures'])}",
+        f"- classification_counts: {dict(sorted(counts.items()))}",
+        "",
+        "| nodeid | classification | removal_allowed | recommendation |",
+        "|---|---|---:|---|",
+    ]
+    for failure in payload["failures"]:
+        lines.append(
+            "| {nodeid} | {classes} | {removal} | {recommendation} |".format(
+                nodeid=failure["nodeid"],
+                classes=", ".join(failure["classification"]),
+                removal=str(failure["removal_allowed"]).lower(),
+                recommendation=failure["recommendation"],
+            )
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def update_plan_markdown(payload: dict[str, Any]) -> str:
+    protected = [failure for failure in payload["failures"] if failure["protected_keywords"]]
+    lines = [
+        "# S0150 test update plan",
+        "",
+        "## Policy",
+        "- Do not remove tests protecting canon, hashes, rollback, dry-run/apply separation, candidates, MCP/mirror, or repository exporter without explicit human review.",
+        "- Prefer updating stale baselines or moving obsolete flows to legacy with replacement tests.",
+        "",
+        "## Current recommendation",
+        "- Update frozen canon/derive/classification baselines only after human confirmation that 1597 records and 16 shards are the accepted current baseline.",
+        "- No tests were removed in S0150.",
+        f"- Protected failures requiring review: {len(protected)}.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def classify_pytest_log(*, pytest_log: Path, out_dir: Path = DEFAULT_OUT_DIR, session: str = "S0150") -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    p = paths(out_dir)
+    payload = parse_pytest_log(pytest_log)
+    payload.update(
+        {
+            "schema": "legacy-test-classification/v1",
+            "session": session,
+            "pytest_log": str(pytest_log),
+            "tests_updated": 0,
+            "tests_moved_to_legacy": 0,
+            "tests_removed": 0,
+            "critical_test_removal_permitted": False,
+        }
+    )
+    p["pytest_log"].write_text(pytest_log.read_text(encoding="utf-8", errors="replace"), encoding="utf-8")
+    p["classification_json"].write_text(stable_json(payload, indent=2) + "\n", encoding="utf-8")
+    p["classification_md"].write_text(classification_markdown(payload), encoding="utf-8")
+    p["update_plan"].write_text(update_plan_markdown(payload), encoding="utf-8")
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Classify legacy pytest failures")
+    parser.add_argument("--pytest-log", required=True)
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
+    parser.add_argument("--session", default="S0150")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    payload = classify_pytest_log(
+        pytest_log=Path(args.pytest_log),
+        out_dir=Path(args.out_dir),
+        session=str(args.session).upper(),
+    )
+    print(stable_json({"status": "ok", "summary": payload["summary"], "classified_failures": len(payload["failures"])}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python_scripts/operator_menu.py
+++ b/python_scripts/operator_menu.py
@@ -69,6 +69,8 @@ from tdc_cat import (  # noqa: E402
     tdc_cat_warning,
 )
 from relation_review_menu import option_relation_review_menu  # noqa: E402
+from repo_metadata_review_menu import option_repo_metadata_admission_menu  # noqa: E402
+from tdc_menu_registry import menu_text as registry_menu_text, resolve_choice as resolve_main_choice  # noqa: E402
 
 
 DEFAULT_SESSIONS_DIR = REPO_ROOT / "data" / "out" / "local" / "sessions"
@@ -2068,73 +2070,216 @@ def option_repository_exporter() -> None:
         tdc_cat_error(f"Exportador de repositorio termino con exit code {result.returncode}.")
 
 
+def option_build_or_import_canon(state: MenuState) -> None:
+    while True:
+        print(
+            "\nConstruir o importar canon\n"
+            "1) Construir canon desde HTML\n"
+            "2) Extraer HTML a JSONL temporal\n"
+            "3) Shardizar JSONL en canon local\n"
+            "4) Validar canon\n"
+            "0) Volver"
+        )
+        choice = prompt("> ").strip()
+        if choice == "0" or choice == "":
+            return
+        if choice == "1":
+            option_build_from_html(state)
+        elif choice == "2":
+            option_extract_html(state)
+        elif choice == "3":
+            option_shard_jsonl(state)
+        elif choice == "4":
+            option_validate_canon()
+        else:
+            print("Opcion invalida.")
+
+
+def option_export_or_consult_canon(state: MenuState) -> None:
+    while True:
+        print(
+            "\nExportar / consultar canon\n"
+            "1) Estado / exportar del canon\n"
+            "2) Ejecutar reverse\n"
+            "3) Validar canon\n"
+            "0) Volver"
+        )
+        choice = prompt("> ").strip()
+        if choice == "0" or choice == "":
+            return
+        if choice == "1":
+            option_canon_status()
+        elif choice == "2":
+            option_reverse(state)
+        elif choice == "3":
+            option_validate_canon()
+        else:
+            print("Opcion invalida.")
+
+
+def option_governed_admission(state: MenuState) -> None:
+    while True:
+        print(
+            "\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+            "  Revisión / admisión gobernada\n"
+            "  Canon: PROTEGIDO\n"
+            "  Apply: requiere confirmación humana explícita\n"
+            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n"
+            "1) Metadata técnica\n"
+            "2) Relaciones candidatas\n"
+            "3) Sesiones al canon\n"
+            "4) Estado de compuertas\n"
+            "5) Ver reportes de admisión\n"
+            "9) Avanzado / mantenimiento\n"
+            "0) Volver"
+        )
+        choice = prompt("> ").strip()
+        if choice == "0" or choice == "":
+            return
+        if choice == "1":
+            option_repo_metadata_admission_menu()
+        elif choice == "2":
+            option_relation_review_menu()
+        elif choice == "3":
+            option_session_sync(state)
+        elif choice == "4":
+            print("\nEstado de compuertas")
+            print(f"- Metadata S0149: {display(REPO_ROOT / 'data/out/local/pipeline/repo_metadata_admission/s0149/s0149_metadata_admission_dry_run_report.json')}")
+            print(f"- Relaciones: {display(REPO_ROOT / 'data/out/local/pipeline/relation_admission')}")
+            print(f"- Sesiones: {display(DEFAULT_ADMISSION_REPORT_DIR)}")
+        elif choice == "5":
+            option_reports()
+        elif choice == "9":
+            option_advanced_maintenance(state)
+        else:
+            print("Opcion invalida.")
+
+
+def option_reports_audit() -> None:
+    while True:
+        print(
+            "\nReportes / métricas / auditoría\n"
+            "1) Ver reportes / métricas\n"
+            "2) Auditar calidad canonica / nodos\n"
+            "3) Validar canon\n"
+            "0) Volver"
+        )
+        choice = prompt("> ").strip()
+        if choice == "0" or choice == "":
+            return
+        if choice == "1":
+            option_reports()
+        elif choice == "2":
+            option_canon_quality()
+        elif choice == "3":
+            option_validate_canon()
+        else:
+            print("Opcion invalida.")
+
+
+def option_rollback_menu() -> None:
+    while True:
+        print(
+            "\nRollback\n"
+            "1) Rollback de admision\n"
+            "2) Rollback de reconstruccion\n"
+            "0) Volver"
+        )
+        choice = prompt("> ").strip()
+        if choice == "0" or choice == "":
+            return
+        if choice == "1":
+            option_rollback()
+        elif choice == "2":
+            option_reconstruction_rollback()
+        else:
+            print("Opcion invalida.")
+
+
+def option_advanced_maintenance(state: MenuState) -> None:
+    while True:
+        print(
+            "\nAvanzado / mantenimiento\n"
+            "1) Preparacion técnica\n"
+            "2) Saneamiento del canon\n"
+            "3) Configurar MCP / mirror remoto\n"
+            "4) Revision relacional [alias histórico 16]\n"
+            "5) Metadata técnica [alias histórico 18]\n"
+            "6) Exportador de repositorio [alias histórico 17]\n"
+            "0) Volver"
+        )
+        choice = prompt("> ").strip()
+        if choice == "0" or choice == "":
+            return
+        if choice == "1":
+            option_preparation()
+        elif choice == "2":
+            option_canon_sanitation()
+        elif choice == "3":
+            option_mcp_manager()
+        elif choice == "4":
+            option_relation_review_menu()
+        elif choice == "5":
+            option_repo_metadata_admission_menu()
+        elif choice == "6":
+            option_repository_exporter()
+        else:
+            print("Opcion invalida.")
+
+
+def dispatch_main_choice(choice: str, state: MenuState) -> bool:
+    resolved = resolve_main_choice(choice)
+    if resolved is None:
+        print("Opcion invalida.")
+        return False
+    message = resolved.get("message")
+    if message:
+        print(message)
+    action = resolved["action"]
+    if action == "preparation":
+        option_preparation()
+    elif action == "build_or_import_canon":
+        option_build_or_import_canon(state)
+    elif action == "export_or_consult_canon":
+        option_export_or_consult_canon(state)
+    elif action == "session_sync":
+        option_session_sync(state)
+    elif action == "derivatives":
+        option_derivatives(state)
+    elif action == "governed_admission":
+        option_governed_admission(state)
+    elif action == "reports_audit":
+        option_reports_audit()
+    elif action == "rollback":
+        option_rollback_menu()
+    elif action == "repository_exporter":
+        option_repository_exporter()
+    elif action == "mcp_remote_config":
+        option_mcp_manager()
+    elif action == "advanced_maintenance":
+        option_advanced_maintenance(state)
+    elif action == "relation_review":
+        option_relation_review_menu()
+    elif action == "metadata_admission":
+        option_repo_metadata_admission_menu()
+    else:
+        print(f"Accion no implementada: {action}")
+        return False
+    return True
+
+
 def main_menu() -> None:
     state = MenuState()
     while True:
         tdc_cat_open()
-        print(
-            "\nTiddly Data Converter - Operador local\n\n"
-            "1) Preparacion\n"
-            "2) Exportar del canon\n"
-            "3) Construir canon desde HTML\n"
-            "4) Extraer HTML a JSONL temporal\n"
-            "5) Shardizar JSONL en canon local\n"
-            "6) Validar canon\n"
-            "7) Sincronizar entregables de sesiones al canon\n"
-            "8) Generar derivados\n"
-            "9) Ejecutar reverse\n"
-            "10) Ver reportes / metricas\n"
-            "11) Rollback de admision\n"
-            "12) Rollback de reconstruccion\n"
-            "13) Auditar calidad canonica / nodos\n"
-            "14) Configurar MCP / mirror remoto\n"
-            "15) Saneamiento del canon\n"
-            "16) Revision relacional [EXPERIMENTAL]\n"
-            "17) Exportador de repositorio\n"
-            "0) Salir"
-        )
+        print("\n" + registry_menu_text())
         choice = prompt("> ").strip()
         if choice == "0" or (choice == "" and not sys.stdin.isatty()):
             print("Salida.")
             return
         if choice == "":
             continue
-        if choice == "1":
-            option_preparation()
-        elif choice == "2":
-            option_canon_status()
-        elif choice == "3":
-            option_build_from_html(state)
-        elif choice == "4":
-            option_extract_html(state)
-        elif choice == "5":
-            option_shard_jsonl(state)
-        elif choice == "6":
-            option_validate_canon()
-        elif choice == "7":
-            option_session_sync(state)
-        elif choice == "8":
-            option_derivatives(state)
-        elif choice == "9":
-            option_reverse(state)
-        elif choice == "10":
-            option_reports()
-        elif choice == "11":
-            option_rollback()
-        elif choice == "12":
-            option_reconstruction_rollback()
-        elif choice == "13":
-            option_canon_quality()
-        elif choice == "14":
-            option_mcp_manager()
-        elif choice == "15":
-            option_canon_sanitation()
-        elif choice == "16":
-            option_relation_review_menu()
-        elif choice == "17":
-            option_repository_exporter()
-        else:
-            print("Opcion invalida.")
+        dispatch_main_choice(choice, state)
         pause()
 
 

--- a/python_scripts/repo_metadata_admission_gate.py
+++ b/python_scripts/repo_metadata_admission_gate.py
@@ -1,0 +1,1449 @@
+#!/usr/bin/env python3
+"""S0148 dry-run admission gate for approved repo metadata batches.
+
+This module verifies terminal decisions, S0147 hashes, batch risk, and patch
+invariants. It never applies metadata to canon shards.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import hashlib
+import json
+import re
+import shutil
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+
+S0147_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "repo_metadata_review" / "s0147"
+DEFAULT_PATCH_PREVIEW = S0147_DIR / "s0147_repo_metadata_patch_preview.jsonl"
+DEFAULT_REVIEW_BATCHES = S0147_DIR / "s0147_repo_metadata_review_batches.json"
+DEFAULT_PATCH_HASHES = S0147_DIR / "s0147_repo_metadata_patch_hashes.json"
+DEFAULT_DRY_RUN_REPORT = S0147_DIR / "s0147_repo_metadata_dry_run_report.json"
+DEFAULT_CLASSIFICATION = (
+    REPO_ROOT
+    / "data"
+    / "out"
+    / "local"
+    / "pipeline"
+    / "repo_artifacts"
+    / "s0146"
+    / "s0146_repo_artifact_classification.jsonl"
+)
+DEFAULT_CANON_GLOB = str(REPO_ROOT / "data" / "out" / "local" / "tiddlers_*.jsonl")
+DEFAULT_OUT_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "repo_metadata_review" / "s0148"
+DEFAULT_HUMAN_DECISIONS = DEFAULT_OUT_DIR / "s0148_repo_metadata_human_decisions.json"
+DEFAULT_S0149_OUT_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "repo_metadata_admission" / "s0149"
+DEFAULT_S0149_SELECTED_BATCHES = DEFAULT_S0149_OUT_DIR / "s0149_selected_batches.json"
+
+CURRENT_BATCH = "batch_current_verified"
+EXCLUDED_BATCH = "batch_excluded_review_required"
+S0149_RECOMMENDED_BATCHES = {
+    "batch_current_verified",
+    "batch_embedded_code",
+    "batch_narrative_reference",
+}
+S0149_NOT_RECOMMENDED_BATCHES = {
+    "batch_historical_review",
+    "batch_generated_derivative",
+}
+S0149_BLOCKED_BATCHES = {
+    EXCLUDED_BATCH,
+}
+S0149_BATCH_CHOICES = {
+    "1": "batch_current_verified",
+    "2": "batch_embedded_code",
+    "3": "batch_narrative_reference",
+    "4": "batch_historical_review",
+    "5": "batch_generated_derivative",
+    "6": EXCLUDED_BATCH,
+}
+S0149_DRY_RUN_TOKEN = "DRY RUN METADATA"
+S0149_APPLY_TOKEN = "APPLY METADATA S0149"
+ALLOWED_DECISIONS = {"approved", "rejected", "deferred"}
+SESSION_TITLE_RE = re.compile(
+    r"^#### .*?(sesión|sesion|diagnóstico|diagnostico|hipótesis|hipotesis|procedencia|balance|propuesta|contrato)",
+    re.IGNORECASE,
+)
+
+
+def stable_json(value: Any, *, indent: int | None = None) -> str:
+    if indent is None:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=indent)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def tree_sha256(glob_pattern: str) -> str:
+    digest = hashlib.sha256()
+    for path_str in sorted(glob.glob(glob_pattern)):
+        path = Path(path_str)
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def read_json(path: Path, default: Any | None = None) -> Any:
+    if not path.exists():
+        if default is not None:
+            return default
+        raise FileNotFoundError(path)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for raw in handle:
+            if raw.strip():
+                value = json.loads(raw)
+                if isinstance(value, dict):
+                    rows.append(value)
+    return rows
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(stable_json(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(stable_json(row) + "\n" for row in rows), encoding="utf-8")
+
+
+def append_audit(path: Path, action: str, *, batch_id: str = "", result: str = "", timestamp: str | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "timestamp": timestamp or utc_now(),
+        "action": action,
+        "batch_id": batch_id,
+        "result": result,
+        "decision_source": "terminal",
+        "dry_run": True,
+        "applied_to_canon": False,
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(stable_json(payload) + "\n")
+
+
+def s0148_paths(out_dir: Path = DEFAULT_OUT_DIR) -> dict[str, Path]:
+    return {
+        "human_decisions": out_dir / "s0148_repo_metadata_human_decisions.json",
+        "batch_approvals": out_dir / "s0148_repo_metadata_batch_approvals.json",
+        "gate_report": out_dir / "s0148_repo_metadata_gate_report.json",
+        "admission_ready": out_dir / "s0148_repo_metadata_admission_ready_dry_run.jsonl",
+        "blocked_records": out_dir / "s0148_repo_metadata_blocked_records.jsonl",
+        "rejected_or_deferred": out_dir / "s0148_repo_metadata_rejected_or_deferred_batches.json",
+        "terminal_audit": out_dir / "s0148_repo_metadata_terminal_audit.jsonl",
+        "hash_verification": out_dir / "s0148_repo_metadata_hash_verification.json",
+        "risk_verification": out_dir / "s0148_repo_metadata_risk_verification.json",
+        "operator_summary": out_dir / "s0148_repo_metadata_operator_summary.md",
+        "next_apply_plan": out_dir / "s0148_repo_metadata_next_apply_plan.md",
+    }
+
+
+def s0149_paths(out_dir: Path = DEFAULT_S0149_OUT_DIR) -> dict[str, Path]:
+    return {
+        "selected_batches": out_dir / "s0149_selected_batches.json",
+        "dry_run_report": out_dir / "s0149_metadata_admission_dry_run_report.json",
+        "ready": out_dir / "s0149_metadata_admission_ready.jsonl",
+        "blocked": out_dir / "s0149_metadata_admission_blocked.jsonl",
+        "patch_preview": out_dir / "s0149_metadata_admission_patch_preview.jsonl",
+        "review": out_dir / "s0149_metadata_admission_review.csv",
+        "summary": out_dir / "s0149_metadata_admission_summary.md",
+        "audit": out_dir / "s0149_metadata_admission_audit_log.jsonl",
+        "operator_flow": out_dir / "s0149_metadata_operator_flow_report.md",
+        "apply_report": out_dir / "s0149_metadata_apply_report.json",
+        "apply_log": out_dir / "s0149_metadata_apply_log.jsonl",
+        "applied_records": out_dir / "s0149_metadata_applied_records.jsonl",
+        "before_after_hashes": out_dir / "s0149_metadata_before_after_hashes.json",
+        "apply_summary": out_dir / "s0149_metadata_apply_summary.md",
+        "rollback_report": out_dir / "s0149_metadata_rollback_report.json",
+        "rollback_log": out_dir / "s0149_metadata_rollback_log.jsonl",
+        "backups": out_dir / "backups",
+    }
+
+
+def empty_decisions_doc() -> dict[str, Any]:
+    return {
+        "schema": "repo-metadata-human-decisions/v1",
+        "session": "S0148",
+        "decision_source": "terminal",
+        "created_by_agent": False,
+        "dry_run": True,
+        "applied_to_canon": False,
+        "human_approval_found": False,
+        "decisions": [],
+    }
+
+
+def ensure_decisions_file(path: Path) -> dict[str, Any]:
+    if path.exists():
+        data = read_json(path)
+        if isinstance(data, dict):
+            return data
+    data = empty_decisions_doc()
+    write_json(path, data)
+    return data
+
+
+def expected_token(batch_id: str, decision: str) -> str:
+    if batch_id == CURRENT_BATCH and decision == "approved":
+        return "APROBAR_METADATA_BATCH_CURRENT_VERIFIED"
+    if batch_id == CURRENT_BATCH and decision == "rejected":
+        return "RECHAZAR_METADATA_BATCH_CURRENT_VERIFIED"
+    if batch_id == CURRENT_BATCH and decision == "deferred":
+        return "DIFERIR_METADATA_BATCH_CURRENT_VERIFIED"
+    stem = batch_id.upper()
+    if stem.startswith("BATCH_"):
+        stem = stem.removeprefix("BATCH_")
+    verb = {"approved": "APROBAR", "rejected": "RECHAZAR", "deferred": "DIFERIR"}[decision]
+    return f"{verb}_METADATA_{stem}"
+
+
+def token_name(decision: str) -> str:
+    return {
+        "approved": "approve",
+        "rejected": "reject",
+        "deferred": "defer",
+    }[decision]
+
+
+def batch_rows(patch_rows: list[dict[str, Any]], batch_id: str) -> list[dict[str, Any]]:
+    return [row for row in patch_rows if row.get("batch_id") == batch_id]
+
+
+def subset_sha(rows: list[dict[str, Any]]) -> str:
+    ordered = sorted(rows, key=lambda row: stable_json(row))
+    return hashlib.sha256("".join(stable_json(row) + "\n" for row in ordered).encode("utf-8")).hexdigest()
+
+
+def record_terminal_decision(
+    *,
+    batch_id: str,
+    decision: str,
+    token: str,
+    patch_preview: Path = DEFAULT_PATCH_PREVIEW,
+    review_batches: Path = DEFAULT_REVIEW_BATCHES,
+    patch_hashes: Path = DEFAULT_PATCH_HASHES,
+    human_decisions: Path = DEFAULT_HUMAN_DECISIONS,
+    out_dir: Path = DEFAULT_OUT_DIR,
+    timestamp: str | None = None,
+) -> dict[str, Any]:
+    if decision not in ALLOWED_DECISIONS:
+        raise ValueError(f"invalid decision: {decision}")
+    paths = s0148_paths(out_dir)
+    doc = ensure_decisions_file(human_decisions)
+    batches_doc = read_json(review_batches)
+    batches = batches_doc.get("batches") or {}
+    hashes = read_json(patch_hashes)
+    rows = read_jsonl(patch_preview)
+
+    if batch_id not in batches:
+        append_audit(paths["terminal_audit"], f"{decision}_batch", batch_id=batch_id, result="batch_not_found", timestamp=timestamp)
+        return {"status": "blocked", "batch_id": batch_id, "decision": decision, "reason": "batch_not_found"}
+    if decision == "approved" and batch_id == EXCLUDED_BATCH:
+        append_audit(paths["terminal_audit"], "approve_batch", batch_id=batch_id, result="batch_not_approvable", timestamp=timestamp)
+        return {"status": "blocked", "batch_id": batch_id, "decision": decision, "reason": "batch_not_approvable"}
+
+    expected = expected_token(batch_id, decision)
+    if token != expected:
+        append_audit(paths["terminal_audit"], f"{decision}_batch", batch_id=batch_id, result="invalid_token", timestamp=timestamp)
+        return {"status": "blocked", "batch_id": batch_id, "decision": decision, "reason": "invalid_token"}
+
+    batch = batches[batch_id]
+    matching_rows = batch_rows(rows, batch_id)
+    batch_sha = batch.get("patch_sha256") or subset_sha(matching_rows)
+    decision_payload = {
+        "batch_id": batch_id,
+        "decision": decision,
+        "human_approved": decision == "approved",
+        "token_verified": True,
+        "token_name": expected,
+        "decision_timestamp": timestamp or utc_now(),
+        "patch_sha256": hashes.get("patch_preview_sha256", ""),
+        "batch_sha256": batch_sha,
+        "canon_before_sha256": hashes.get("canon_before_sha256", ""),
+        "s0146_classification_sha256": hashes.get("s0146_classification_sha256", ""),
+        "source_session": "S0147",
+        "decision_source": "terminal",
+    }
+
+    decisions = [item for item in doc.get("decisions", []) if item.get("batch_id") != batch_id]
+    decisions.append(decision_payload)
+    decisions = sorted(decisions, key=lambda item: str(item.get("batch_id", "")))
+    doc = {
+        "schema": "repo-metadata-human-decisions/v1",
+        "session": "S0148",
+        "decision_source": "terminal",
+        "created_by_agent": False,
+        "dry_run": True,
+        "applied_to_canon": False,
+        "human_approval_found": any(item.get("decision") == "approved" and item.get("human_approved") is True for item in decisions),
+        "decisions": decisions,
+    }
+    write_json(human_decisions, doc)
+    append_audit(paths["terminal_audit"], f"{decision}_batch", batch_id=batch_id, result="recorded", timestamp=timestamp)
+    return {"status": "ok", "batch_id": batch_id, "decision": decision, "token_verified": True}
+
+
+def hash_verification(
+    *,
+    patch_preview: Path,
+    review_batches: Path,
+    patch_hashes: Path,
+    dry_run_report: Path,
+    s0146_classification: Path,
+    canon_glob: str,
+) -> dict[str, Any]:
+    hashes = read_json(patch_hashes)
+    checks = [
+        {
+            "name": "patch_preview_sha256",
+            "expected": hashes.get("patch_preview_sha256", ""),
+            "actual": file_sha256(patch_preview),
+        },
+        {
+            "name": "review_batches_sha256",
+            "expected": hashes.get("review_batches_sha256", ""),
+            "actual": file_sha256(review_batches),
+        },
+        {
+            "name": "dry_run_report_sha256",
+            "expected": hashes.get("dry_run_report_sha256", ""),
+            "actual": file_sha256(dry_run_report),
+        },
+        {
+            "name": "s0146_classification_sha256",
+            "expected": hashes.get("s0146_classification_sha256", ""),
+            "actual": file_sha256(s0146_classification),
+        },
+        {
+            "name": "canon_before_sha256",
+            "expected": hashes.get("canon_before_sha256", ""),
+            "actual": tree_sha256(canon_glob),
+        },
+    ]
+    for check in checks:
+        check["match"] = check["expected"] == check["actual"]
+    return {
+        "schema": "repo-metadata-hash-verification/v1",
+        "session": "S0148",
+        "all_hashes_match": all(check["match"] for check in checks),
+        "checks": checks,
+    }
+
+
+def verify_patch_invariants(rows: list[dict[str, Any]]) -> list[dict[str, str]]:
+    violations: list[dict[str, str]] = []
+    for row in rows:
+        op_id = str(row.get("op_id", ""))
+        if row.get("dry_run") is not True:
+            violations.append({"op_id": op_id, "reason": "patch_record_not_dry_run"})
+        if row.get("applied_to_canon") is not False:
+            violations.append({"op_id": op_id, "reason": "patch_record_applied_to_canon"})
+        if row.get("human_approved") is not False:
+            violations.append({"op_id": op_id, "reason": "s0147_patch_human_approved_true"})
+        if "relations" in row or "candidate_relations" in row:
+            violations.append({"op_id": op_id, "reason": "relation_field_present"})
+        fields = row.get("fields_preview") if isinstance(row.get("fields_preview"), dict) else {}
+        if "relations" in fields or "candidate_relations" in fields:
+            violations.append({"op_id": op_id, "reason": "relation_field_present_in_fields_preview"})
+        title = str(row.get("target_title") or "")
+        if "artifact_family" in fields and SESSION_TITLE_RE.search(title):
+            violations.append({"op_id": op_id, "reason": "artifact_family_change_on_session_or_diagnostic"})
+    return violations
+
+
+def risk_verification_for_batches(approved_batches: list[str], rows: list[dict[str, Any]]) -> dict[str, Any]:
+    approved_rows = [row for row in rows if row.get("batch_id") in set(approved_batches)]
+    risk_counts = Counter(str(row.get("source_risk_level") or row.get("risk_level") or "") for row in approved_rows)
+    critical_count = risk_counts.get("critical", 0)
+    return {
+        "schema": "repo-metadata-risk-verification/v1",
+        "session": "S0148",
+        "approved_batches": approved_batches,
+        "records_by_risk_level": dict(sorted(risk_counts.items())),
+        "critical_count": critical_count,
+        "high_count": risk_counts.get("high", 0),
+        "medium_count": risk_counts.get("medium", 0),
+        "low_count": risk_counts.get("low", 0),
+        "blocked_due_to_risk": critical_count > 0,
+    }
+
+
+def rejected_or_deferred_doc(decisions: list[dict[str, Any]], batches: dict[str, Any]) -> dict[str, Any]:
+    by_decision: dict[str, list[str]] = {key: [] for key in ("rejected", "deferred", "approved")}
+    for decision in decisions:
+        value = str(decision.get("decision") or "")
+        if value in by_decision:
+            by_decision[value].append(str(decision.get("batch_id") or ""))
+    reviewed = set(by_decision["rejected"] + by_decision["deferred"] + by_decision["approved"])
+    return {
+        "schema": "repo-metadata-rejected-or-deferred-batches/v1",
+        "session": "S0148",
+        "rejected_batches": sorted(by_decision["rejected"]),
+        "deferred_batches": sorted(by_decision["deferred"]),
+        "not_reviewed_batches": sorted(set(batches) - reviewed),
+        "blocked_by_policy": [EXCLUDED_BATCH] if EXCLUDED_BATCH in batches else [],
+        "dry_run": True,
+        "applied_to_canon": False,
+    }
+
+
+def approval_summary(decisions: list[dict[str, Any]], batches: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema": "repo-metadata-batch-approvals/v1",
+        "session": "S0148",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "approved_batches": sorted(
+            str(item.get("batch_id")) for item in decisions if item.get("decision") == "approved" and item.get("human_approved") is True
+        ),
+        "rejected_batches": sorted(str(item.get("batch_id")) for item in decisions if item.get("decision") == "rejected"),
+        "deferred_batches": sorted(str(item.get("batch_id")) for item in decisions if item.get("decision") == "deferred"),
+        "available_batches": sorted(batches),
+        "recommended_batch": CURRENT_BATCH,
+    }
+
+
+def ready_record(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "op_id": row.get("op_id", ""),
+        "target_id": row.get("target_id", ""),
+        "target_title": row.get("target_title", ""),
+        "batch_id": row.get("batch_id", ""),
+        "fields_preview": row.get("fields_preview", {}),
+        "human_approved": True,
+        "gate_status": "admission_ready_dry_run",
+        "dry_run": True,
+        "applied_to_canon": False,
+    }
+
+
+def blocked_record(row: dict[str, Any], reason: str) -> dict[str, Any]:
+    return {
+        "op_id": row.get("op_id", ""),
+        "target_id": row.get("target_id", ""),
+        "target_title": row.get("target_title", ""),
+        "batch_id": row.get("batch_id", ""),
+        "block_reason": reason,
+        "risk_level": row.get("source_risk_level", row.get("risk_level", "")),
+        "dry_run": True,
+        "applied_to_canon": False,
+    }
+
+
+def operator_summary_md(report: dict[str, Any], hashes: dict[str, Any], risks: dict[str, Any]) -> str:
+    lines = [
+        "# S0148 repo metadata operator summary",
+        "",
+        f"- Approved batches: {report['approved_batches']}",
+        f"- Rejected batches: {report['rejected_batches']}",
+        f"- Deferred batches: {report['deferred_batches']}",
+        f"- Human approval found: {report['human_approval_found']}",
+        f"- Gate blocked: {report['blocked']}",
+        f"- Admission ready dry-run records: {report['admission_ready_dry_run']}",
+        f"- Blocked records: {report['blocked_records']}",
+        f"- Block reasons: {report['block_reasons']}",
+        f"- Hashes match: {hashes['all_hashes_match']}",
+        f"- Critical approved records: {risks['critical_count']}",
+        "",
+        "## Not applied",
+        "- Metadata was not applied to canon.",
+        "- No formal relations or candidate_relations were generated.",
+        "- semantic_text, embeddings, enriched, AI and chunks were not regenerated.",
+        "",
+        "## S0149",
+        "S0149 can consume the approved dry-run artifacts only if hashes still match and human approval remains valid.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def next_apply_plan_md(report: dict[str, Any], hashes: dict[str, Any]) -> str:
+    approved = report["approved_batches"]
+    lines = [
+        "# S0148 next apply plan for S0149",
+        "",
+        "S0149 is the candidate session for governed admission of approved repo metadata.",
+        "",
+        "## Inputs",
+        "- `data/out/local/pipeline/repo_metadata_review/s0148/s0148_repo_metadata_human_decisions.json`",
+        "- `data/out/local/pipeline/repo_metadata_review/s0148/s0148_repo_metadata_gate_report.json`",
+        "- `data/out/local/pipeline/repo_metadata_review/s0148/s0148_repo_metadata_admission_ready_dry_run.jsonl`",
+        "- `data/out/local/pipeline/repo_metadata_review/s0148/s0148_repo_metadata_hash_verification.json`",
+        "",
+        "## Approved batch",
+        f"- {approved if approved else 'None'}",
+        "",
+        "## Hashes S0149 must verify",
+    ]
+    for check in hashes["checks"]:
+        lines.append(f"- {check['name']}: `{check['expected']}`")
+    lines.extend(
+        [
+            "",
+            "## Dry-run records",
+            f"- admission_ready_dry_run: {report['admission_ready_dry_run']}",
+            f"- blocked_records: {report['blocked_records']}",
+            "",
+            "S0149 must not apply if hashes change, approval is missing, the approved batch differs, or any critical risk appears.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def run_gate(
+    *,
+    patch_preview: Path = DEFAULT_PATCH_PREVIEW,
+    review_batches: Path = DEFAULT_REVIEW_BATCHES,
+    patch_hashes: Path = DEFAULT_PATCH_HASHES,
+    dry_run_report: Path = DEFAULT_DRY_RUN_REPORT,
+    human_decisions: Path = DEFAULT_HUMAN_DECISIONS,
+    canon_glob: str = DEFAULT_CANON_GLOB,
+    s0146_classification: Path = DEFAULT_CLASSIFICATION,
+    out_dir: Path = DEFAULT_OUT_DIR,
+    session: str = "S0148",
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    if session != "S0148":
+        raise ValueError("this gate is scoped to S0148")
+    if not dry_run:
+        raise ValueError("S0148 only supports dry_run=true")
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths = s0148_paths(out_dir)
+    decisions_doc = ensure_decisions_file(human_decisions)
+    patch_rows = read_jsonl(patch_preview)
+    batches_doc = read_json(review_batches)
+    batches = batches_doc.get("batches") or {}
+    decisions = decisions_doc.get("decisions") if isinstance(decisions_doc.get("decisions"), list) else []
+
+    approved_decisions = [
+        item
+        for item in decisions
+        if item.get("decision") == "approved"
+        and item.get("human_approved") is True
+        and item.get("token_verified") is True
+        and item.get("decision_source") == "terminal"
+    ]
+    rejected_batches = sorted(str(item.get("batch_id")) for item in decisions if item.get("decision") == "rejected")
+    deferred_batches = sorted(str(item.get("batch_id")) for item in decisions if item.get("decision") == "deferred")
+    approved_batches = sorted(str(item.get("batch_id")) for item in approved_decisions)
+
+    hash_doc = hash_verification(
+        patch_preview=patch_preview,
+        review_batches=review_batches,
+        patch_hashes=patch_hashes,
+        dry_run_report=dry_run_report,
+        s0146_classification=s0146_classification,
+        canon_glob=canon_glob,
+    )
+    risk_doc = risk_verification_for_batches(approved_batches, patch_rows)
+
+    block_reasons: list[str] = []
+    blocked_rows: list[dict[str, Any]] = []
+    ready_rows: list[dict[str, Any]] = []
+
+    if not approved_decisions:
+        block_reasons.append("no_human_approval")
+    if decisions_doc.get("created_by_agent") is not False:
+        block_reasons.append("human_decisions_created_by_agent_not_false")
+    if not hash_doc["all_hashes_match"]:
+        block_reasons.extend(f"hash_mismatch:{check['name']}" for check in hash_doc["checks"] if not check["match"])
+
+    invariant_violations = verify_patch_invariants(patch_rows)
+    for violation in invariant_violations:
+        block_reasons.append(violation["reason"])
+    if risk_doc["blocked_due_to_risk"]:
+        block_reasons.append("critical_risk_in_approved_batch")
+
+    for batch_id in approved_batches:
+        if batch_id not in batches:
+            block_reasons.append(f"batch_not_found:{batch_id}")
+            continue
+        if batch_id == EXCLUDED_BATCH:
+            block_reasons.append("excluded_batch_not_approvable")
+        batch = batches[batch_id]
+        decision = next(item for item in approved_decisions if item.get("batch_id") == batch_id)
+        rows = batch_rows(patch_rows, batch_id)
+        computed_batch_sha = subset_sha(rows)
+        if decision.get("batch_sha256") != batch.get("patch_sha256"):
+            block_reasons.append(f"decision_batch_sha_mismatch:{batch_id}")
+        if batch.get("patch_sha256") != computed_batch_sha:
+            block_reasons.append(f"computed_batch_sha_mismatch:{batch_id}")
+        if decision.get("patch_sha256") != read_json(patch_hashes).get("patch_preview_sha256"):
+            block_reasons.append(f"decision_patch_sha_mismatch:{batch_id}")
+        if decision.get("canon_before_sha256") != read_json(patch_hashes).get("canon_before_sha256"):
+            block_reasons.append(f"decision_canon_sha_mismatch:{batch_id}")
+        if decision.get("s0146_classification_sha256") != read_json(patch_hashes).get("s0146_classification_sha256"):
+            block_reasons.append(f"decision_classification_sha_mismatch:{batch_id}")
+        if any(row.get("patch_lane") == "lane_f_excluded_review_required" for row in rows):
+            block_reasons.append(f"lane_f_in_approved_batch:{batch_id}")
+        if any(row.get("source_risk_level") == "critical" for row in rows):
+            block_reasons.append(f"critical_risk_in_batch:{batch_id}")
+        if any(row.get("applied_to_canon") is not False for row in rows):
+            block_reasons.append(f"applied_record_in_batch:{batch_id}")
+        if any(row.get("dry_run") is not True for row in rows):
+            block_reasons.append(f"non_dry_run_record_in_batch:{batch_id}")
+        if any("relations" in row or "candidate_relations" in row for row in rows):
+            block_reasons.append(f"relation_field_in_batch:{batch_id}")
+
+    block_reasons = sorted(set(block_reasons))
+    blocked = bool(block_reasons)
+
+    if not blocked:
+        for row in patch_rows:
+            if row.get("batch_id") in set(approved_batches):
+                ready_rows.append(ready_record(row))
+    elif approved_batches:
+        reason = ";".join(block_reasons)
+        for row in patch_rows:
+            if row.get("batch_id") in set(approved_batches):
+                blocked_rows.append(blocked_record(row, reason))
+
+    rejected_doc = rejected_or_deferred_doc(decisions, batches)
+    approvals_doc = approval_summary(decisions, batches)
+    report = {
+        "schema": "repo-metadata-admission-gate-report/v1",
+        "session": "S0148",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "human_approval_found": bool(approved_decisions),
+        "approved_batches": approved_batches,
+        "rejected_batches": rejected_batches,
+        "deferred_batches": deferred_batches,
+        "admission_ready_dry_run": len(ready_rows),
+        "blocked_records": len(blocked_rows),
+        "blocked": blocked,
+        "block_reasons": block_reasons,
+        "hash_verification": hash_doc,
+        "risk_verification": risk_doc,
+        "relations_generated": False,
+        "candidate_relations_generated": False,
+        "formal_relation_candidates_generated": False,
+        "semantic_text_modified": False,
+    }
+
+    write_json(paths["batch_approvals"], approvals_doc)
+    write_json(paths["hash_verification"], hash_doc)
+    write_json(paths["risk_verification"], risk_doc)
+    write_json(paths["rejected_or_deferred"], rejected_doc)
+    write_json(paths["gate_report"], report)
+    write_jsonl(paths["admission_ready"], ready_rows)
+    write_jsonl(paths["blocked_records"], blocked_rows)
+    if not paths["terminal_audit"].exists():
+        paths["terminal_audit"].write_text("", encoding="utf-8")
+    paths["operator_summary"].write_text(operator_summary_md(report, hash_doc, risk_doc), encoding="utf-8")
+    paths["next_apply_plan"].write_text(next_apply_plan_md(report, hash_doc), encoding="utf-8")
+    append_audit(paths["terminal_audit"], "run_gate_dry_run", result="blocked" if blocked else "ready")
+    return report
+
+
+def s0149_audit_event(
+    path: Path,
+    action: str,
+    *,
+    result: str,
+    details: dict[str, Any] | None = None,
+    timestamp: str | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "timestamp": timestamp or utc_now(),
+        "session": "S0149",
+        "action": action,
+        "result": result,
+        "dry_run_default": True,
+        "apply_requires_token": S0149_APPLY_TOKEN,
+        "applied_to_canon": False,
+        "details": details or {},
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(stable_json(payload) + "\n")
+
+
+def s0149_batch_catalog(review_batches: Path = DEFAULT_REVIEW_BATCHES) -> dict[str, dict[str, Any]]:
+    batches = read_json(review_batches).get("batches") or {}
+    catalog: dict[str, dict[str, Any]] = {}
+    reverse_choices = {batch_id: number for number, batch_id in S0149_BATCH_CHOICES.items()}
+    for batch_id, batch in sorted(batches.items()):
+        catalog[batch_id] = {
+            "batch_id": batch_id,
+            "choice": reverse_choices.get(batch_id, ""),
+            "batch_label": batch.get("batch_label", ""),
+            "record_count": int(batch.get("record_count") or 0),
+            "patch_lane": batch.get("patch_lane", ""),
+            "risk_profile": batch.get("risk_profile") or {},
+            "recommended": batch_id in S0149_RECOMMENDED_BATCHES,
+            "recommended_by_default": batch_id in S0149_RECOMMENDED_BATCHES,
+            "not_recommended_by_default": batch_id in S0149_NOT_RECOMMENDED_BATCHES,
+            "blocked": batch_id in S0149_BLOCKED_BATCHES,
+            "block_reason": "excluded_review_required" if batch_id in S0149_BLOCKED_BATCHES else "",
+        }
+    return catalog
+
+
+def normalize_s0149_batch_token(raw: str) -> str:
+    value = raw.strip()
+    if not value:
+        return ""
+    if value in S0149_BATCH_CHOICES:
+        return S0149_BATCH_CHOICES[value]
+    if value.startswith("batch_"):
+        return value
+    aliases = {
+        "current_verified": "batch_current_verified",
+        "embedded_code": "batch_embedded_code",
+        "narrative_reference": "batch_narrative_reference",
+        "historical_review": "batch_historical_review",
+        "generated_derivative": "batch_generated_derivative",
+        "excluded": EXCLUDED_BATCH,
+        "excluded_review_required": EXCLUDED_BATCH,
+        "review_required": EXCLUDED_BATCH,
+    }
+    return aliases.get(value, value)
+
+
+def parse_s0149_batch_selection(selection: str | list[str] | tuple[str, ...]) -> dict[str, Any]:
+    if isinstance(selection, str):
+        raw_items = [item.strip() for item in selection.split(",")]
+    else:
+        raw_items = [str(item).strip() for item in selection]
+    selected: list[str] = []
+    duplicates: list[str] = []
+    seen: set[str] = set()
+    for item in raw_items:
+        batch_id = normalize_s0149_batch_token(item)
+        if not batch_id:
+            continue
+        if batch_id in seen:
+            duplicates.append(batch_id)
+            continue
+        seen.add(batch_id)
+        selected.append(batch_id)
+    return {
+        "selected_batch_ids": selected,
+        "duplicates": sorted(set(duplicates)),
+        "empty_selection": not selected,
+    }
+
+
+def select_s0149_batches(
+    selection: str | list[str] | tuple[str, ...],
+    *,
+    review_batches: Path = DEFAULT_REVIEW_BATCHES,
+    out_dir: Path = DEFAULT_S0149_OUT_DIR,
+    timestamp: str | None = None,
+) -> dict[str, Any]:
+    paths = s0149_paths(out_dir)
+    catalog = s0149_batch_catalog(review_batches)
+    parsed = parse_s0149_batch_selection(selection)
+    selected_ids = parsed["selected_batch_ids"]
+    invalid = [batch_id for batch_id in selected_ids if batch_id not in catalog]
+    blocked = [batch_id for batch_id in selected_ids if batch_id in S0149_BLOCKED_BATCHES]
+    selected_batches = [
+        catalog[batch_id]
+        for batch_id in selected_ids
+        if batch_id in catalog
+    ]
+    valid = not parsed["empty_selection"] and not invalid and not blocked
+    doc = {
+        "schema": "repo-metadata-s0149-selected-batches/v1",
+        "session": "S0149",
+        "source_session": "S0147",
+        "created_at": timestamp or utc_now(),
+        "selection_source": "terminal_or_cli",
+        "dry_run_token_required_for_interactive_menu": S0149_DRY_RUN_TOKEN,
+        "apply_token_required": S0149_APPLY_TOKEN,
+        "human_approval_simulated": False,
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "valid": valid,
+        "empty_selection": parsed["empty_selection"],
+        "selected_batch_ids": selected_ids,
+        "selected_batches": selected_batches,
+        "selected_operation_count": sum(int(item.get("record_count") or 0) for item in selected_batches),
+        "invalid_batch_ids": invalid,
+        "blocked_batch_ids": blocked,
+        "duplicate_batch_ids": parsed["duplicates"],
+        "recommended_batch_ids": sorted(S0149_RECOMMENDED_BATCHES),
+        "not_recommended_by_default_batch_ids": sorted(S0149_NOT_RECOMMENDED_BATCHES),
+        "blocked_batch_policy": sorted(S0149_BLOCKED_BATCHES),
+        "available_batches": list(catalog.values()),
+        "relations_generated": False,
+        "formal_relation_candidates_generated": False,
+        "candidate_relations_generated": False,
+    }
+    write_json(paths["selected_batches"], doc)
+    s0149_audit_event(
+        paths["audit"],
+        "select_batches",
+        result="valid" if valid else "blocked",
+        details={
+            "selected_batch_ids": selected_ids,
+            "invalid_batch_ids": invalid,
+            "blocked_batch_ids": blocked,
+            "empty_selection": parsed["empty_selection"],
+        },
+        timestamp=timestamp,
+    )
+    return doc
+
+
+def s0149_selected_batch_ids(selected_batches: Path) -> list[str]:
+    doc = read_json(selected_batches)
+    values = doc.get("selected_batch_ids")
+    if isinstance(values, list):
+        return [str(item) for item in values]
+    selected = doc.get("selected_batches")
+    if isinstance(selected, list):
+        ids: list[str] = []
+        for item in selected:
+            if isinstance(item, dict) and item.get("batch_id"):
+                ids.append(str(item["batch_id"]))
+            elif isinstance(item, str):
+                ids.append(item)
+        return ids
+    return []
+
+
+def s0149_ready_record(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "op_id": row.get("op_id", ""),
+        "target_id": row.get("target_id", ""),
+        "target_title": row.get("target_title", ""),
+        "batch_id": row.get("batch_id", ""),
+        "patch_lane": row.get("patch_lane", ""),
+        "risk_level": row.get("source_risk_level", row.get("risk_level", "")),
+        "fields_preview": row.get("fields_preview", {}),
+        "selected_for_admission": True,
+        "human_approved": False,
+        "requires_apply_confirmation": True,
+        "gate_status": "metadata_admission_ready_dry_run",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+    }
+
+
+def s0149_blocked_record(row: dict[str, Any], reason: str) -> dict[str, Any]:
+    return {
+        "op_id": row.get("op_id", ""),
+        "target_id": row.get("target_id", ""),
+        "target_title": row.get("target_title", ""),
+        "batch_id": row.get("batch_id", ""),
+        "patch_lane": row.get("patch_lane", ""),
+        "risk_level": row.get("source_risk_level", row.get("risk_level", "")),
+        "block_reason": reason,
+        "selected_for_admission": True,
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+    }
+
+
+def s0149_preview_record(row: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(row)
+    payload["session"] = "S0149"
+    payload["source_session"] = "S0147"
+    payload["selected_for_admission"] = True
+    payload["dry_run"] = True
+    payload["human_approved"] = False
+    payload["applied_to_canon"] = False
+    payload["canon_modified"] = False
+    return payload
+
+
+def write_s0149_review_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    fieldnames = [
+        "op_id",
+        "target_id",
+        "target_title",
+        "batch_id",
+        "patch_lane",
+        "risk_level",
+        "fields_preview_keys",
+        "gate_status",
+        "block_reason",
+        "applied_to_canon",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            fields_preview = row.get("fields_preview") if isinstance(row.get("fields_preview"), dict) else {}
+            writer.writerow(
+                {
+                    "op_id": row.get("op_id", ""),
+                    "target_id": row.get("target_id", ""),
+                    "target_title": row.get("target_title", ""),
+                    "batch_id": row.get("batch_id", ""),
+                    "patch_lane": row.get("patch_lane", ""),
+                    "risk_level": row.get("risk_level", row.get("source_risk_level", "")),
+                    "fields_preview_keys": "|".join(sorted(fields_preview)),
+                    "gate_status": row.get("gate_status", ""),
+                    "block_reason": row.get("block_reason", ""),
+                    "applied_to_canon": str(row.get("applied_to_canon") is True).lower(),
+                }
+            )
+
+
+def s0149_summary_md(report: dict[str, Any]) -> str:
+    lines = [
+        "# S0149 metadata admission summary",
+        "",
+        f"- Selected batches: {report['selected_batch_ids']}",
+        f"- Selected operations: {report['selected_operation_count']}",
+        f"- Ready operations: {report['admission_ready']}",
+        f"- Blocked operations: {report['blocked_records']}",
+        f"- Gate blocked: {report['blocked']}",
+        f"- Block reasons: {report['block_reasons']}",
+        f"- Hashes match: {report['hash_verification']['all_hashes_match']}",
+        "- Apply executed: false",
+        "- Canon modified: false",
+        "- Relations generated: false",
+        "- Candidate relations generated: false",
+        "- Semantic_text modified in metadata step: false",
+        "",
+        "## Apply policy",
+        f"- Apply requires a successful dry-run and exact token `{S0149_APPLY_TOKEN}`.",
+        "- Apply is not executed by dry-run.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def s0149_operator_flow_md(report: dict[str, Any]) -> str:
+    lines = [
+        "# S0149 metadata operator flow",
+        "",
+        "## Estado",
+        f"- seleccion_actual: {report['selected_batch_ids']}",
+        f"- dry_run_status: {'blocked' if report['blocked'] else 'ready'}",
+        f"- admission_ready: {report['admission_ready']}",
+        f"- blocked_records: {report['blocked_records']}",
+        "- apply_status: not_executed",
+        "- canon_modified: false",
+        "",
+        "## Tokens",
+        f"- dry_run_menu_token: `{S0149_DRY_RUN_TOKEN}`",
+        f"- apply_token: `{S0149_APPLY_TOKEN}`",
+        "",
+        "## Separacion",
+        "- Este flujo no genera relaciones.",
+        "- Este flujo no genera candidate_relations.",
+        "- semantic_text authority-aware se ejecuta en ruta separada.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def s0149_apply_not_executed_report(reason: str, *, dry_run_report: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "schema": "repo-metadata-s0149-apply-report/v1",
+        "session": "S0149",
+        "apply_executed": False,
+        "apply_blocked": True,
+        "block_reasons": [reason],
+        "records_modified": 0,
+        "dry_run_report_ready": bool(dry_run_report and dry_run_report.get("blocked") is False),
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "relations_generated": False,
+        "formal_relation_candidates_generated": False,
+        "candidate_relations_generated": False,
+        "semantic_text_modified": False,
+    }
+
+
+def run_s0149_dry_run(
+    *,
+    patch_preview: Path = DEFAULT_PATCH_PREVIEW,
+    review_batches: Path = DEFAULT_REVIEW_BATCHES,
+    patch_hashes: Path = DEFAULT_PATCH_HASHES,
+    dry_run_report: Path = DEFAULT_DRY_RUN_REPORT,
+    selected_batches: Path = DEFAULT_S0149_SELECTED_BATCHES,
+    canon_glob: str = DEFAULT_CANON_GLOB,
+    s0146_classification: Path = DEFAULT_CLASSIFICATION,
+    out_dir: Path = DEFAULT_S0149_OUT_DIR,
+) -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths = s0149_paths(out_dir)
+    patch_rows = read_jsonl(patch_preview)
+    batches_doc = read_json(review_batches)
+    batches = batches_doc.get("batches") or {}
+    selected_doc = read_json(selected_batches)
+    selected_ids = s0149_selected_batch_ids(selected_batches)
+    selected_set = set(selected_ids)
+    selected_rows = [row for row in patch_rows if row.get("batch_id") in selected_set]
+
+    hash_doc = hash_verification(
+        patch_preview=patch_preview,
+        review_batches=review_batches,
+        patch_hashes=patch_hashes,
+        dry_run_report=dry_run_report,
+        s0146_classification=s0146_classification,
+        canon_glob=canon_glob,
+    )
+    hash_doc["session"] = "S0149"
+    risk_doc = risk_verification_for_batches(selected_ids, patch_rows)
+    risk_doc["session"] = "S0149"
+
+    block_reasons: list[str] = []
+    if selected_doc.get("valid") is not True:
+        block_reasons.append("selected_batches_invalid")
+    if not selected_ids:
+        block_reasons.append("empty_selection")
+    missing = [batch_id for batch_id in selected_ids if batch_id not in batches]
+    block_reasons.extend(f"batch_not_found:{batch_id}" for batch_id in missing)
+    if EXCLUDED_BATCH in selected_set:
+        block_reasons.append("excluded_batch_not_approvable")
+    if selected_doc.get("blocked_batch_ids"):
+        block_reasons.extend(f"blocked_batch_selected:{batch_id}" for batch_id in selected_doc["blocked_batch_ids"])
+    if selected_doc.get("invalid_batch_ids"):
+        block_reasons.extend(f"invalid_batch_selected:{batch_id}" for batch_id in selected_doc["invalid_batch_ids"])
+    if not hash_doc["all_hashes_match"]:
+        block_reasons.extend(f"hash_mismatch:{check['name']}" for check in hash_doc["checks"] if not check["match"])
+    invariant_violations = verify_patch_invariants(selected_rows)
+    block_reasons.extend(violation["reason"] for violation in invariant_violations)
+    if risk_doc["critical_count"] > 0:
+        block_reasons.append("critical_risk_in_selected_batches")
+
+    for batch_id in selected_ids:
+        if batch_id not in batches:
+            continue
+        rows = batch_rows(patch_rows, batch_id)
+        computed_batch_sha = subset_sha(rows)
+        if batches[batch_id].get("patch_sha256") != computed_batch_sha:
+            block_reasons.append(f"computed_batch_sha_mismatch:{batch_id}")
+        if any(row.get("patch_lane") == "lane_f_excluded_review_required" for row in rows):
+            block_reasons.append(f"lane_f_in_selected_batch:{batch_id}")
+        if any(row.get("applied_to_canon") is not False for row in rows):
+            block_reasons.append(f"applied_record_in_selected_batch:{batch_id}")
+        if any(row.get("dry_run") is not True for row in rows):
+            block_reasons.append(f"non_dry_run_record_in_selected_batch:{batch_id}")
+        if any("relations" in row or "candidate_relations" in row for row in rows):
+            block_reasons.append(f"relation_field_in_selected_batch:{batch_id}")
+
+    block_reasons = sorted(set(block_reasons))
+    blocked = bool(block_reasons)
+    ready_rows = [s0149_ready_record(row) for row in selected_rows] if not blocked else []
+    blocked_rows = [s0149_blocked_record(row, ";".join(block_reasons)) for row in selected_rows] if blocked else []
+    preview_rows = [s0149_preview_record(row) for row in selected_rows]
+
+    report = {
+        "schema": "repo-metadata-s0149-admission-dry-run-report/v1",
+        "session": "S0149",
+        "source_session": "S0147",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "selected_batches_path": str(selected_batches),
+        "selected_batch_ids": selected_ids,
+        "selected_operation_count": len(selected_rows),
+        "admission_ready": len(ready_rows),
+        "blocked_records": len(blocked_rows),
+        "blocked": blocked,
+        "block_reasons": block_reasons,
+        "hash_verification": hash_doc,
+        "risk_verification": risk_doc,
+        "invariant_violations": invariant_violations,
+        "relations_generated": False,
+        "formal_relation_candidates_generated": False,
+        "candidate_relations_generated": False,
+        "semantic_text_modified": False,
+        "apply_requires_human_token": S0149_APPLY_TOKEN,
+    }
+
+    write_json(paths["dry_run_report"], report)
+    write_jsonl(paths["ready"], ready_rows)
+    write_jsonl(paths["blocked"], blocked_rows)
+    write_jsonl(paths["patch_preview"], preview_rows)
+    write_s0149_review_csv(paths["review"], [*ready_rows, *blocked_rows])
+    paths["summary"].write_text(s0149_summary_md(report), encoding="utf-8")
+    paths["operator_flow"].write_text(s0149_operator_flow_md(report), encoding="utf-8")
+    write_json(paths["apply_report"], s0149_apply_not_executed_report("apply_not_requested", dry_run_report=report))
+    s0149_audit_event(
+        paths["audit"],
+        "run_dry_run",
+        result="blocked" if blocked else "ready",
+        details={
+            "selected_batch_ids": selected_ids,
+            "admission_ready": len(ready_rows),
+            "blocked_records": len(blocked_rows),
+            "block_reasons": block_reasons,
+        },
+    )
+    return report
+
+
+def canon_sha256_lines(canon_glob: str) -> str:
+    lines = []
+    for path_str in sorted(glob.glob(canon_glob)):
+        path = Path(path_str)
+        lines.append(f"{file_sha256(path)}  {path.name}")
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def backup_s0149_canon(canon_glob: str, out_dir: Path) -> Path:
+    paths = s0149_paths(out_dir)
+    backup_root = paths["backups"]
+    backup_dir = backup_root / "canon_before_apply"
+    if backup_dir.exists():
+        shutil.rmtree(backup_dir)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    shards = [Path(path_str) for path_str in sorted(glob.glob(canon_glob))]
+    for shard in shards:
+        shutil.copy2(shard, backup_dir / shard.name)
+    (backup_root / "tiddlers_before_apply.sha256").write_text(canon_sha256_lines(canon_glob), encoding="utf-8")
+    manifest = {
+        "schema": "repo-metadata-s0149-rollback-manifest/v1",
+        "session": "S0149",
+        "created_at": utc_now(),
+        "backup_dir": str(backup_dir),
+        "shards": [
+            {
+                "source": str(shard),
+                "backup": str(backup_dir / shard.name),
+                "sha256": file_sha256(shard),
+            }
+            for shard in shards
+        ],
+    }
+    write_json(backup_root / "rollback_manifest.json", manifest)
+    return backup_dir
+
+
+def title_is_session_or_diagnostic(title: Any) -> bool:
+    return bool(SESSION_TITLE_RE.search(str(title or "")))
+
+
+def applyable_fields_for_row(row: dict[str, Any]) -> tuple[dict[str, Any], dict[str, str]]:
+    fields = row.get("fields_preview") if isinstance(row.get("fields_preview"), dict) else {}
+    applied: dict[str, Any] = {}
+    skipped: dict[str, str] = {}
+    for key, value in fields.items():
+        if key in {"relations", "candidate_relations"}:
+            skipped[key] = "relation_fields_forbidden"
+            continue
+        if key == "artifact_family":
+            if row.get("batch_id") != CURRENT_BATCH:
+                skipped[key] = "artifact_family_only_allowed_for_current_verified"
+                continue
+            if value != "artefacto_repositorio":
+                skipped[key] = "artifact_family_value_not_allowed"
+                continue
+            if title_is_session_or_diagnostic(row.get("target_title")):
+                skipped[key] = "artifact_family_preserved_for_session_or_diagnostic"
+                continue
+        applied[key] = value
+    return applied, skipped
+
+
+def apply_s0149_metadata(
+    *,
+    patch_preview: Path = DEFAULT_PATCH_PREVIEW,
+    review_batches: Path = DEFAULT_REVIEW_BATCHES,
+    patch_hashes: Path = DEFAULT_PATCH_HASHES,
+    s0147_dry_run_report: Path = DEFAULT_DRY_RUN_REPORT,
+    dry_run_report_path: Path | None = None,
+    selected_batches: Path = DEFAULT_S0149_SELECTED_BATCHES,
+    canon_glob: str = DEFAULT_CANON_GLOB,
+    s0146_classification: Path = DEFAULT_CLASSIFICATION,
+    out_dir: Path = DEFAULT_S0149_OUT_DIR,
+    apply_token: str | None = None,
+) -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths = s0149_paths(out_dir)
+    dry_path = dry_run_report_path or paths["dry_run_report"]
+
+    def block(reason: str) -> dict[str, Any]:
+        report = s0149_apply_not_executed_report(reason)
+        write_json(paths["apply_report"], report)
+        s0149_audit_event(paths["apply_log"], "apply", result="blocked", details={"reason": reason})
+        return report
+
+    if apply_token != S0149_APPLY_TOKEN:
+        return block("invalid_or_missing_apply_token")
+    if not dry_path.exists():
+        return block("missing_successful_dry_run")
+    dry_report = read_json(dry_path)
+    if dry_report.get("session") != "S0149" or dry_report.get("blocked") is not False:
+        return block("dry_run_not_successful")
+    selected_ids = s0149_selected_batch_ids(selected_batches)
+    if selected_ids != dry_report.get("selected_batch_ids"):
+        return block("selected_batches_changed_since_dry_run")
+
+    hash_doc = hash_verification(
+        patch_preview=patch_preview,
+        review_batches=review_batches,
+        patch_hashes=patch_hashes,
+        dry_run_report=s0147_dry_run_report,
+        s0146_classification=s0146_classification,
+        canon_glob=canon_glob,
+    )
+    hash_doc["session"] = "S0149"
+    if not hash_doc["all_hashes_match"]:
+        write_json(paths["apply_report"], s0149_apply_not_executed_report("hash_mismatch_before_apply", dry_run_report=dry_report))
+        s0149_audit_event(paths["apply_log"], "apply", result="blocked", details={"reason": "hash_mismatch_before_apply", "hash_verification": hash_doc})
+        return read_json(paths["apply_report"])
+
+    patch_rows = read_jsonl(patch_preview)
+    selected_rows = [row for row in patch_rows if row.get("batch_id") in set(selected_ids)]
+    risk_doc = risk_verification_for_batches(selected_ids, patch_rows)
+    if risk_doc["critical_count"] > 0:
+        return block("critical_risk_in_selected_batches")
+    if EXCLUDED_BATCH in selected_ids:
+        return block("excluded_batch_not_approvable")
+    if verify_patch_invariants(selected_rows):
+        return block("patch_invariant_violation")
+
+    before_tree = tree_sha256(canon_glob)
+    backup_s0149_canon(canon_glob, out_dir)
+    operations_by_id: dict[str, list[dict[str, Any]]] = {}
+    for row in selected_rows:
+        operations_by_id.setdefault(str(row.get("target_id") or ""), []).append(row)
+
+    applied_records: list[dict[str, Any]] = []
+    modified_ids: set[str] = set()
+    for shard_str in sorted(glob.glob(canon_glob)):
+        shard = Path(shard_str)
+        new_lines: list[str] = []
+        changed = False
+        with shard.open(encoding="utf-8") as handle:
+            for raw in handle:
+                if not raw.strip():
+                    new_lines.append(raw)
+                    continue
+                record = json.loads(raw)
+                record_id = str(record.get("id") or "")
+                ops = operations_by_id.get(record_id, [])
+                if not ops:
+                    new_lines.append(raw if raw.endswith("\n") else raw + "\n")
+                    continue
+                original = stable_json(record)
+                source_fields = record.get("source_fields")
+                if not isinstance(source_fields, dict):
+                    source_fields = {}
+                    record["source_fields"] = source_fields
+                applied_fields: dict[str, Any] = {}
+                skipped_fields: dict[str, str] = {}
+                for op in ops:
+                    applyable, skipped = applyable_fields_for_row(op)
+                    source_fields.update(applyable)
+                    applied_fields.update(applyable)
+                    skipped_fields.update(skipped)
+                if stable_json(record) != original:
+                    changed = True
+                    modified_ids.add(record_id)
+                applied_records.append(
+                    {
+                        "target_id": record_id,
+                        "target_title": record.get("title", ""),
+                        "source_shard": str(shard),
+                        "operation_count": len(ops),
+                        "applied_fields": applied_fields,
+                        "skipped_fields": skipped_fields,
+                        "relations_generated": False,
+                        "candidate_relations_generated": False,
+                    }
+                )
+                new_lines.append(stable_json(record) + "\n")
+        if changed:
+            shard.write_text("".join(new_lines), encoding="utf-8")
+
+    after_tree = tree_sha256(canon_glob)
+    canon_modified = before_tree != after_tree
+    write_jsonl(paths["applied_records"], applied_records)
+    before_after = {
+        "schema": "repo-metadata-s0149-before-after-hashes/v1",
+        "session": "S0149",
+        "before_tree_sha256": before_tree,
+        "after_tree_sha256": after_tree,
+        "canon_modified": canon_modified,
+        "before_files": read_json(paths["backups"] / "rollback_manifest.json").get("shards", []),
+    }
+    write_json(paths["before_after_hashes"], before_after)
+    report = {
+        "schema": "repo-metadata-s0149-apply-report/v1",
+        "session": "S0149",
+        "apply_executed": True,
+        "apply_blocked": False,
+        "block_reasons": [],
+        "selected_batch_ids": selected_ids,
+        "records_modified": len(modified_ids),
+        "applied_records": len(applied_records),
+        "applied_to_canon": True,
+        "canon_modified": canon_modified,
+        "relations_generated": False,
+        "formal_relation_candidates_generated": False,
+        "candidate_relations_generated": False,
+        "semantic_text_modified": False,
+        "rollback_available": True,
+        "hashes": before_after,
+    }
+    write_json(paths["apply_report"], report)
+    paths["apply_summary"].write_text(
+        "\n".join(
+            [
+                "# S0149 metadata apply summary",
+                "",
+                f"- apply_executed: {str(report['apply_executed']).lower()}",
+                f"- records_modified: {report['records_modified']}",
+                f"- canon_modified: {str(canon_modified).lower()}",
+                "- relations_generated: false",
+                "- candidate_relations_generated: false",
+                f"- rollback_manifest: {paths['backups'] / 'rollback_manifest.json'}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    s0149_audit_event(
+        paths["apply_log"],
+        "apply",
+        result="applied",
+        details={"records_modified": len(modified_ids), "canon_modified": canon_modified},
+    )
+    return report
+
+
+def rollback_s0149_metadata(*, out_dir: Path = DEFAULT_S0149_OUT_DIR) -> dict[str, Any]:
+    paths = s0149_paths(out_dir)
+    manifest_path = paths["backups"] / "rollback_manifest.json"
+    if not manifest_path.exists():
+        report = {
+            "schema": "repo-metadata-s0149-rollback-report/v1",
+            "session": "S0149",
+            "rollback_executed": False,
+            "rollback_blocked": True,
+            "block_reasons": ["missing_rollback_manifest"],
+            "canon_modified": False,
+        }
+        write_json(paths["rollback_report"], report)
+        s0149_audit_event(paths["rollback_log"], "rollback", result="blocked", details={"reason": "missing_rollback_manifest"})
+        return report
+    manifest = read_json(manifest_path)
+    restored: list[str] = []
+    for item in manifest.get("shards") or []:
+        source = Path(str(item.get("source") or ""))
+        backup = Path(str(item.get("backup") or ""))
+        if not backup.exists() or not source.parent.exists():
+            continue
+        shutil.copy2(backup, source)
+        restored.append(str(source))
+    report = {
+        "schema": "repo-metadata-s0149-rollback-report/v1",
+        "session": "S0149",
+        "rollback_executed": bool(restored),
+        "rollback_blocked": not bool(restored),
+        "block_reasons": [] if restored else ["no_shards_restored"],
+        "restored_shards": restored,
+        "canon_modified": bool(restored),
+    }
+    write_json(paths["rollback_report"], report)
+    s0149_audit_event(paths["rollback_log"], "rollback", result="restored" if restored else "blocked", details={"restored_shards": restored})
+    return report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run governed repo metadata admission gates")
+    parser.add_argument("--patch-preview", default=str(DEFAULT_PATCH_PREVIEW))
+    parser.add_argument("--review-batches", default=str(DEFAULT_REVIEW_BATCHES))
+    parser.add_argument("--patch-hashes", default=str(DEFAULT_PATCH_HASHES))
+    parser.add_argument("--dry-run-report", default=str(DEFAULT_DRY_RUN_REPORT))
+    parser.add_argument("--human-decisions", default=str(DEFAULT_HUMAN_DECISIONS))
+    parser.add_argument("--selected-batches", default=str(DEFAULT_S0149_SELECTED_BATCHES))
+    parser.add_argument("--canon-glob", default=DEFAULT_CANON_GLOB)
+    parser.add_argument("--s0146-classification", default=str(DEFAULT_CLASSIFICATION))
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
+    parser.add_argument("--session", default="S0148")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--apply-token", default=None)
+    parser.add_argument("--rollback", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    session = str(args.session).upper()
+    if session == "S0149":
+        modes = [args.dry_run, args.apply, args.rollback]
+        if sum(bool(item) for item in modes) != 1:
+            raise SystemExit("S0149 requires exactly one mode: --dry-run, --apply, or --rollback")
+        if args.rollback:
+            report = rollback_s0149_metadata(out_dir=Path(args.out_dir))
+        elif args.apply:
+            report = apply_s0149_metadata(
+                patch_preview=Path(args.patch_preview),
+                review_batches=Path(args.review_batches),
+                patch_hashes=Path(args.patch_hashes),
+                s0147_dry_run_report=Path(args.dry_run_report),
+                dry_run_report_path=Path(args.out_dir) / "s0149_metadata_admission_dry_run_report.json",
+                selected_batches=Path(args.selected_batches),
+                canon_glob=args.canon_glob,
+                s0146_classification=Path(args.s0146_classification),
+                out_dir=Path(args.out_dir),
+                apply_token=args.apply_token,
+            )
+        else:
+            report = run_s0149_dry_run(
+                patch_preview=Path(args.patch_preview),
+                review_batches=Path(args.review_batches),
+                patch_hashes=Path(args.patch_hashes),
+                dry_run_report=Path(args.dry_run_report),
+                selected_batches=Path(args.selected_batches),
+                canon_glob=args.canon_glob,
+                s0146_classification=Path(args.s0146_classification),
+                out_dir=Path(args.out_dir),
+            )
+        print(stable_json(report))
+        return 0
+
+    if not args.dry_run:
+        raise SystemExit("S0148 only supports --dry-run")
+    report = run_gate(
+        patch_preview=Path(args.patch_preview),
+        review_batches=Path(args.review_batches),
+        patch_hashes=Path(args.patch_hashes),
+        dry_run_report=Path(args.dry_run_report),
+        human_decisions=Path(args.human_decisions),
+        canon_glob=args.canon_glob,
+        s0146_classification=Path(args.s0146_classification),
+        out_dir=Path(args.out_dir),
+        session=args.session,
+        dry_run=args.dry_run,
+    )
+    print(stable_json(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python_scripts/repo_metadata_refresh_patch.py
+++ b/python_scripts/repo_metadata_refresh_patch.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Refresh S0147 repo metadata patch preview against the current canon.
+
+S0150 uses this script to resolve stale canon hashes without applying metadata.
+It reads the S0147 patch preview, verifies each target against the live canon,
+recomputes preview/batch hashes, and writes refreshed dry-run artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import hashlib
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+DEFAULT_S0147_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "repo_metadata_review" / "s0147"
+DEFAULT_OUT_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "repo_metadata_admission" / "s0150"
+DEFAULT_CANON_GLOB = str(REPO_ROOT / "data" / "out" / "local" / "tiddlers_*.jsonl")
+SESSION_TITLE_RE = re.compile(
+    r"^#### .*?(sesión|sesion|diagnóstico|diagnostico|hipótesis|hipotesis|procedencia|balance|propuesta|contrato)",
+    re.IGNORECASE,
+)
+
+
+def stable_json(value: Any, *, indent: int | None = None) -> str:
+    if indent is None:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=indent)
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def file_sha256(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def tree_sha256(glob_pattern: str) -> str:
+    digest = hashlib.sha256()
+    for path_str in sorted(glob.glob(glob_pattern)):
+        path = Path(path_str)
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for raw in handle:
+            if raw.strip():
+                value = json.loads(raw)
+                if isinstance(value, dict):
+                    rows.append(value)
+    return rows
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(stable_json(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(stable_json(row) + "\n" for row in rows), encoding="utf-8")
+
+
+def subset_sha(rows: list[dict[str, Any]]) -> str:
+    ordered = sorted(rows, key=lambda row: stable_json(row))
+    return hashlib.sha256("".join(stable_json(row) + "\n" for row in ordered).encode("utf-8")).hexdigest()
+
+
+def refreshed_paths(out_dir: Path = DEFAULT_OUT_DIR) -> dict[str, Path]:
+    return {
+        "report": out_dir / "s0150_metadata_refresh_report.json",
+        "summary": out_dir / "s0150_metadata_refresh_summary.md",
+        "patch_preview": out_dir / "s0150_metadata_patch_preview_refreshed.jsonl",
+        "review_batches": out_dir / "s0150_metadata_review_batches_refreshed.json",
+        "patch_hashes": out_dir / "s0150_metadata_patch_hashes_refreshed.json",
+        "blocked": out_dir / "s0150_metadata_refresh_blocked.jsonl",
+        "review": out_dir / "s0150_metadata_refresh_review.csv",
+    }
+
+
+def load_canon_index(canon_glob: str) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for path_str in sorted(glob.glob(canon_glob)):
+        for row in read_jsonl(Path(path_str)):
+            row_id = str(row.get("id") or "")
+            if row_id:
+                index[row_id] = row
+    return index
+
+
+def source_fields(record: dict[str, Any]) -> dict[str, Any]:
+    value = record.get("source_fields")
+    return value if isinstance(value, dict) else {}
+
+
+def current_family(record: dict[str, Any]) -> str:
+    fields = source_fields(record)
+    value = fields.get("artifact_family") or record.get("artifact_family") or record.get("family") or ""
+    return str(value or "unknown")
+
+
+def block_reasons_for_row(row: dict[str, Any], canon_index: dict[str, dict[str, Any]]) -> list[str]:
+    reasons: list[str] = []
+    target_id = str(row.get("target_id") or "")
+    current = canon_index.get(target_id)
+    fields_preview = row.get("fields_preview") if isinstance(row.get("fields_preview"), dict) else {}
+    if not current:
+        return ["target_missing"]
+    current_title = str(current.get("title") or "")
+    expected_title = str(row.get("target_title") or "")
+    if expected_title and current_title and expected_title != current_title:
+        reasons.append("target_title_changed")
+    current_key = str(current.get("key") or "")
+    expected_key = str(row.get("target_key") or "")
+    if expected_key and current_key and expected_key != current_key:
+        reasons.append("target_key_changed")
+    if str(row.get("source_risk_level") or row.get("risk_level") or "") == "critical":
+        reasons.append("critical_risk")
+    proposed_family = fields_preview.get("artifact_family")
+    if proposed_family:
+        family = current_family(current)
+        if SESSION_TITLE_RE.search(current_title):
+            reasons.append("artifact_family_session_preserved")
+        elif family not in {"", "unknown", str(proposed_family)}:
+            reasons.append("artifact_family_conflict")
+        if row.get("batch_id") != "batch_current_verified":
+            reasons.append("artifact_family_only_allowed_for_current_verified")
+    if "relations" in row or "candidate_relations" in row:
+        reasons.append("relation_field_present")
+    if "relations" in fields_preview or "candidate_relations" in fields_preview:
+        reasons.append("relation_field_present_in_fields_preview")
+    return sorted(set(reasons))
+
+
+def refreshed_row(row: dict[str, Any], *, session: str, canon_before_sha256: str) -> dict[str, Any]:
+    payload = dict(row)
+    payload["session"] = session
+    payload["source_session"] = "S0147"
+    payload["refresh_session"] = session
+    payload["canon_before_sha256_refreshed"] = canon_before_sha256
+    payload["dry_run"] = True
+    payload["applied_to_canon"] = False
+    payload["canon_modified"] = False
+    payload["relations_generated"] = False
+    payload["candidate_relations_generated"] = False
+    return payload
+
+
+def blocked_row(row: dict[str, Any], reasons: list[str], *, session: str) -> dict[str, Any]:
+    return {
+        "session": session,
+        "source_session": "S0147",
+        "op_id": row.get("op_id", ""),
+        "target_id": row.get("target_id", ""),
+        "target_title": row.get("target_title", ""),
+        "batch_id": row.get("batch_id", ""),
+        "patch_lane": row.get("patch_lane", ""),
+        "risk_level": row.get("source_risk_level", row.get("risk_level", "")),
+        "block_reasons": reasons,
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+    }
+
+
+def build_refreshed_batches(original_batches: dict[str, Any], ready_rows: list[dict[str, Any]], *, canon_before_sha256: str, session: str) -> dict[str, Any]:
+    rows_by_batch: dict[str, list[dict[str, Any]]] = {}
+    for row in ready_rows:
+        rows_by_batch.setdefault(str(row.get("batch_id") or ""), []).append(row)
+    refreshed: dict[str, Any] = {}
+    all_batch_ids = sorted(set(original_batches) | set(rows_by_batch))
+    for batch_id in all_batch_ids:
+        original = original_batches.get(batch_id, {})
+        rows = rows_by_batch.get(batch_id, [])
+        risks = Counter(str(row.get("source_risk_level") or row.get("risk_level") or "") for row in rows)
+        batch = dict(original)
+        batch.update(
+            {
+                "session": session,
+                "source_session": "S0147",
+                "batch_id": batch_id,
+                "record_count": len(rows),
+                "patch_sha256": subset_sha(rows),
+                "canon_before_sha256": canon_before_sha256,
+                "risk_profile": dict(sorted((risk, count) for risk, count in risks.items() if risk)),
+                "dry_run": True,
+                "applied_to_canon": False,
+                "human_approved": False,
+            }
+        )
+        refreshed[batch_id] = batch
+    return {
+        "schema": "repo-metadata-review-batches/v1",
+        "session": session,
+        "source_session": "S0147",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "human_approved": False,
+        "batches": refreshed,
+    }
+
+
+def write_review_csv(path: Path, ready_rows: list[dict[str, Any]], blocked_rows: list[dict[str, Any]]) -> None:
+    fieldnames = ["status", "op_id", "target_id", "target_title", "batch_id", "patch_lane", "risk_level", "block_reasons"]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in ready_rows:
+            writer.writerow(
+                {
+                    "status": "preserved",
+                    "op_id": row.get("op_id", ""),
+                    "target_id": row.get("target_id", ""),
+                    "target_title": row.get("target_title", ""),
+                    "batch_id": row.get("batch_id", ""),
+                    "patch_lane": row.get("patch_lane", ""),
+                    "risk_level": row.get("source_risk_level", row.get("risk_level", "")),
+                    "block_reasons": "",
+                }
+            )
+        for row in blocked_rows:
+            writer.writerow(
+                {
+                    "status": "blocked",
+                    "op_id": row.get("op_id", ""),
+                    "target_id": row.get("target_id", ""),
+                    "target_title": row.get("target_title", ""),
+                    "batch_id": row.get("batch_id", ""),
+                    "patch_lane": row.get("patch_lane", ""),
+                    "risk_level": row.get("risk_level", ""),
+                    "block_reasons": "|".join(row.get("block_reasons") or []),
+                }
+            )
+
+
+def summary_md(report: dict[str, Any]) -> str:
+    lines = [
+        "# S0150 metadata refresh summary",
+        "",
+        f"- source_patch_operations: {report['source_patch_operations']}",
+        f"- operations_preserved: {report['operations_preserved']}",
+        f"- operations_blocked: {report['operations_blocked']}",
+        f"- canon_before_sha256_old: `{report['canon_before_sha256_old']}`",
+        f"- canon_before_sha256_refreshed: `{report['canon_before_sha256_refreshed']}`",
+        f"- block_reason_counts: {report['block_reason_counts']}",
+        "- dry_run: true",
+        "- applied_to_canon: false",
+        "- canon_modified: false",
+        "- relations_generated: false",
+        "- candidate_relations_generated: false",
+        "",
+        "## Batches",
+    ]
+    for batch_id, count in report["preserved_by_batch"].items():
+        lines.append(f"- {batch_id}: {count}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def refresh_metadata_patch(
+    *,
+    patch_preview: Path,
+    review_batches: Path,
+    patch_hashes: Path,
+    canon_glob: str,
+    out_dir: Path,
+    session: str = "S0150",
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    if not dry_run:
+        raise ValueError("S0150 metadata refresh is dry-run only")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths = refreshed_paths(out_dir)
+    source_rows = read_jsonl(patch_preview)
+    source_batches_doc = read_json(review_batches)
+    source_hashes = read_json(patch_hashes)
+    canon_index = load_canon_index(canon_glob)
+    current_canon_sha = tree_sha256(canon_glob)
+    ready_rows: list[dict[str, Any]] = []
+    blocked_rows: list[dict[str, Any]] = []
+    reason_counter: Counter[str] = Counter()
+
+    for row in source_rows:
+        reasons = block_reasons_for_row(row, canon_index)
+        if reasons:
+            blocked = blocked_row(row, reasons, session=session)
+            blocked_rows.append(blocked)
+            reason_counter.update(reasons)
+        else:
+            ready_rows.append(refreshed_row(row, session=session, canon_before_sha256=current_canon_sha))
+
+    refreshed_batches = build_refreshed_batches(
+        source_batches_doc.get("batches") or {},
+        ready_rows,
+        canon_before_sha256=current_canon_sha,
+        session=session,
+    )
+    write_jsonl(paths["patch_preview"], ready_rows)
+    write_jsonl(paths["blocked"], blocked_rows)
+    write_json(paths["review_batches"], refreshed_batches)
+    write_review_csv(paths["review"], ready_rows, blocked_rows)
+
+    refreshed_hashes = {
+        "schema": "repo-metadata-patch-hashes/v1",
+        "session": session,
+        "source_session": "S0147",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "canon_before_sha256_old": source_hashes.get("canon_before_sha256", ""),
+        "canon_before_sha256": current_canon_sha,
+        "patch_preview_sha256": file_sha256(paths["patch_preview"]),
+        "review_batches_sha256": file_sha256(paths["review_batches"]),
+        "source_patch_preview_sha256": source_hashes.get("patch_preview_sha256", ""),
+        "source_review_batches_sha256": source_hashes.get("review_batches_sha256", ""),
+        "relations_generated": False,
+        "candidate_relations_generated": False,
+    }
+    write_json(paths["patch_hashes"], refreshed_hashes)
+
+    report = {
+        "schema": "repo-metadata-s0150-refresh-report/v1",
+        "session": session,
+        "source_session": "S0147",
+        "dry_run": True,
+        "applied_to_canon": False,
+        "canon_modified": False,
+        "source_patch_operations": len(source_rows),
+        "operations_preserved": len(ready_rows),
+        "operations_blocked": len(blocked_rows),
+        "canon_before_sha256_old": source_hashes.get("canon_before_sha256", ""),
+        "canon_before_sha256_refreshed": current_canon_sha,
+        "patch_preview_sha256_refreshed": refreshed_hashes["patch_preview_sha256"],
+        "review_batches_sha256_refreshed": refreshed_hashes["review_batches_sha256"],
+        "preserved_by_batch": dict(sorted(Counter(str(row.get("batch_id") or "") for row in ready_rows).items())),
+        "blocked_by_batch": dict(sorted(Counter(str(row.get("batch_id") or "") for row in blocked_rows).items())),
+        "block_reason_counts": dict(sorted(reason_counter.items())),
+        "relations_generated": False,
+        "formal_relation_candidates_generated": False,
+        "candidate_relations_generated": False,
+        "metadata_applied": False,
+    }
+    write_json(paths["report"], report)
+    paths["summary"].write_text(summary_md(report), encoding="utf-8")
+    return report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Refresh S0147 repo metadata patch against current canon")
+    parser.add_argument("--patch-preview", default=str(DEFAULT_S0147_DIR / "s0147_repo_metadata_patch_preview.jsonl"))
+    parser.add_argument("--review-batches", default=str(DEFAULT_S0147_DIR / "s0147_repo_metadata_review_batches.json"))
+    parser.add_argument("--patch-hashes", default=str(DEFAULT_S0147_DIR / "s0147_repo_metadata_patch_hashes.json"))
+    parser.add_argument("--canon-glob", default=DEFAULT_CANON_GLOB)
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
+    parser.add_argument("--session", default="S0150")
+    parser.add_argument("--dry-run", action="store_true", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report = refresh_metadata_patch(
+        patch_preview=Path(args.patch_preview),
+        review_batches=Path(args.review_batches),
+        patch_hashes=Path(args.patch_hashes),
+        canon_glob=args.canon_glob,
+        out_dir=Path(args.out_dir),
+        session=str(args.session).upper(),
+        dry_run=args.dry_run,
+    )
+    print(stable_json(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python_scripts/repo_metadata_review_menu.py
+++ b/python_scripts/repo_metadata_review_menu.py
@@ -1,0 +1,836 @@
+#!/usr/bin/env python3
+"""Local menu for S0147/S0148 repo metadata review and dry-run gate.
+
+The script inspects S0147 artifacts and, in S0148, records terminal decisions
+only when an explicit token is provided by the operator. It never applies
+metadata to canon.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import repo_metadata_admission_gate as gate
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+DEFAULT_OUT_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "repo_metadata_review" / "s0147"
+DEFAULT_S0148_OUT_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "repo_metadata_review" / "s0148"
+DEFAULT_S0149_OUT_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "repo_metadata_admission" / "s0149"
+DEFAULT_SEMANTIC_AUTHORITY_OUT_DIR = REPO_ROOT / "data" / "out" / "local" / "pipeline" / "semantic_text_authority" / "s0149"
+
+APPROVAL_REQUIRES_TERMINAL_TOKEN = "approval_requires_terminal_token"
+
+
+def _paths(out_dir: Path) -> dict[str, Path]:
+    return {
+        "patch_preview": out_dir / "s0147_repo_metadata_patch_preview.jsonl",
+        "summary": out_dir / "s0147_repo_metadata_patch_summary.json",
+        "summary_md": out_dir / "s0147_repo_metadata_patch_summary.md",
+        "review_queue": out_dir / "s0147_repo_metadata_review_queue.jsonl",
+        "batches": out_dir / "s0147_repo_metadata_review_batches.json",
+        "csv": out_dir / "s0147_repo_metadata_review.csv",
+        "excluded": out_dir / "s0147_repo_metadata_excluded_records.jsonl",
+        "risk": out_dir / "s0147_repo_metadata_risk_report.json",
+        "dry_run": out_dir / "s0147_repo_metadata_dry_run_report.json",
+        "contract": out_dir / "s0147_repo_metadata_menu_contract.md",
+        "hashes": out_dir / "s0147_repo_metadata_patch_hashes.json",
+        "validation": out_dir / "s0147_repo_metadata_validation_report.json",
+        "instructions": out_dir / "s0147_repo_metadata_operator_instructions.md",
+    }
+
+
+def _display(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for raw in handle:
+            if raw.strip():
+                value = json.loads(raw)
+                if not isinstance(value, dict):
+                    raise ValueError(f"expected JSON object line in {path}")
+                rows.append(value)
+    return rows
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2)
+
+
+def _file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _print_limited_rows(rows: list[dict[str, Any]], *, limit: int = 30) -> None:
+    for row in rows[:limit]:
+        title = row.get("target_title", "")
+        target = row.get("target_id", "")
+        lane = row.get("patch_lane", "")
+        risk = row.get("source_risk_level", row.get("risk_level", ""))
+        reason = row.get("reason", row.get("summary", row.get("excluded_reason", "")))
+        print(f"- {target} | {lane} | risk={risk} | {title}")
+        if reason:
+            print(f"  {reason}")
+    if len(rows) > limit:
+        print(f"... {len(rows) - limit} registros adicionales no mostrados")
+
+
+def show_summary(out_dir: Path = DEFAULT_OUT_DIR) -> None:
+    p = _paths(out_dir)
+    summary = _load_json(p["summary"])
+    hashes = _load_json(p["hashes"]) if p["hashes"].exists() else {}
+    print("S0147 repo metadata patch preview")
+    print(f"- classification_records_read: {summary.get('classification_records_read')}")
+    print(f"- patch_operations_generated: {summary.get('patch_operations_generated')}")
+    print(f"- excluded_records: {summary.get('excluded_records')}")
+    print(f"- preserve_artifact_family_count: {summary.get('preserve_artifact_family_count')}")
+    print(f"- future_artefacto_repositorio_count: {summary.get('future_artefacto_repositorio_count')}")
+    print(f"- canon_modified: {summary.get('canon_modified')}")
+    print(f"- human_approved: {summary.get('human_approved')}")
+    print(f"- applied_to_canon: {summary.get('applied_to_canon')}")
+    print(f"- patch_preview_sha256: {hashes.get('patch_preview_sha256', '')}")
+    print("Carriles:")
+    for lane, count in sorted((summary.get("patch_lane_counts") or {}).items()):
+        print(f"- {lane}: {count}")
+
+
+def list_batches(out_dir: Path = DEFAULT_OUT_DIR) -> None:
+    batches = _load_json(_paths(out_dir)["batches"]).get("batches", {})
+    print("S0147 batches")
+    for batch_id, batch in sorted(batches.items()):
+        print(
+            f"- {batch_id}: {batch.get('record_count')} registros, "
+            f"approved={batch.get('human_approved')}, "
+            f"approval_disabled={batch.get('approval_disabled_in_s0147')}"
+        )
+
+
+def show_batch(batch_id: str, out_dir: Path = DEFAULT_OUT_DIR) -> None:
+    p = _paths(out_dir)
+    batches = _load_json(p["batches"]).get("batches", {})
+    if batch_id not in batches:
+        raise KeyError(f"batch not found: {batch_id}")
+    batch = batches[batch_id]
+    print(_stable_json(batch))
+    print("Registros:")
+    if batch_id == "batch_excluded_review_required":
+        rows = _load_jsonl(p["excluded"])
+    else:
+        rows = [row for row in _load_jsonl(p["patch_preview"]) if row.get("batch_id") == batch_id]
+    _print_limited_rows(rows, limit=50)
+
+
+def show_excluded(out_dir: Path = DEFAULT_OUT_DIR) -> None:
+    rows = _load_jsonl(_paths(out_dir)["excluded"])
+    print(f"S0147 excluded records: {len(rows)}")
+    _print_limited_rows(rows, limit=80)
+
+
+def show_risks(out_dir: Path = DEFAULT_OUT_DIR) -> None:
+    report = _load_json(_paths(out_dir)["risk"])
+    print("S0147 risk report")
+    print(f"- high_or_critical_operations: {report.get('high_or_critical_operations')}")
+    print(f"- excluded_records: {report.get('excluded_records')}")
+    print("Risk counts:")
+    for risk, count in sorted((report.get("risk_counts") or {}).items()):
+        print(f"- {risk}: {count}")
+    print("Excluded reasons:")
+    for reason, count in sorted((report.get("excluded_reason_counts") or {}).items()):
+        print(f"- {reason}: {count}")
+    items = report.get("items") or []
+    if items:
+        print("Items:")
+        _print_limited_rows(items, limit=50)
+
+
+def show_hashes(out_dir: Path = DEFAULT_OUT_DIR) -> None:
+    print(_stable_json(_load_json(_paths(out_dir)["hashes"])))
+
+
+def export_csv(out_dir: Path = DEFAULT_OUT_DIR) -> None:
+    path = _paths(out_dir)["csv"]
+    if not path.exists():
+        raise FileNotFoundError(path)
+    row_count = 0
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for _ in reader:
+            row_count += 1
+    print(f"CSV disponible: {_display(path)}")
+    print(f"Registros: {row_count}")
+
+
+def show_contract(out_dir: Path = DEFAULT_OUT_DIR) -> None:
+    path = _paths(out_dir)["contract"]
+    if not path.exists():
+        raise FileNotFoundError(path)
+    print(path.read_text(encoding="utf-8"))
+
+
+def validate_dry_run_contract(out_dir: Path = DEFAULT_OUT_DIR) -> dict[str, Any]:
+    p = _paths(out_dir)
+    operations = _load_jsonl(p["patch_preview"])
+    queue = _load_jsonl(p["review_queue"])
+    excluded = _load_jsonl(p["excluded"])
+    batches_doc = _load_json(p["batches"])
+    summary = _load_json(p["summary"])
+    dry = _load_json(p["dry_run"])
+    validation = _load_json(p["validation"])
+    hashes = _load_json(p["hashes"])
+
+    violations: list[str] = []
+
+    for op in operations:
+        if op.get("dry_run") is not True:
+            violations.append(f"operation_not_dry_run:{op.get('op_id')}")
+        if op.get("applied_to_canon") is not False:
+            violations.append(f"operation_applied:{op.get('op_id')}")
+        if op.get("human_approved") is not False:
+            violations.append(f"operation_human_approved:{op.get('op_id')}")
+        if "relations" in op or "candidate_relations" in op:
+            violations.append(f"operation_relation_field:{op.get('op_id')}")
+        fields = op.get("fields_preview") or {}
+        if isinstance(fields, dict) and ("relations" in fields or "candidate_relations" in fields):
+            violations.append(f"operation_field_relation:{op.get('op_id')}")
+
+    for item in queue:
+        if item.get("human_approved") is not False:
+            violations.append(f"queue_human_approved:{item.get('review_id')}")
+        if item.get("human_decision") in {"approved", "accepted"}:
+            violations.append(f"queue_positive_decision:{item.get('review_id')}")
+
+    for item in excluded:
+        if item.get("dry_run") is not True:
+            violations.append(f"excluded_not_dry_run:{item.get('target_id')}")
+        if item.get("applied_to_canon") is not False:
+            violations.append(f"excluded_applied:{item.get('target_id')}")
+        if item.get("human_approved") is not False:
+            violations.append(f"excluded_human_approved:{item.get('target_id')}")
+
+    for batch_id, batch in (batches_doc.get("batches") or {}).items():
+        if batch.get("human_approved") is not False:
+            violations.append(f"batch_human_approved:{batch_id}")
+        if batch.get("approval_disabled_in_s0147") is not True:
+            violations.append(f"batch_approval_not_disabled:{batch_id}")
+        if batch.get("applied_to_canon") is not False:
+            violations.append(f"batch_applied:{batch_id}")
+
+    if summary.get("relations_generated") is not False:
+        violations.append("summary_relations_generated")
+    if summary.get("candidate_relations_generated") is not False:
+        violations.append("summary_candidate_relations_generated")
+    if summary.get("formal_relation_candidates_generated") is not False:
+        violations.append("summary_formal_relation_candidates_generated")
+    if dry.get("relations_generated") is not False:
+        violations.append("dry_run_relations_generated")
+    if dry.get("candidate_relations_generated") is not False:
+        violations.append("dry_run_candidate_relations_generated")
+    if dry.get("formal_relation_candidates_generated") is not False:
+        violations.append("dry_run_formal_relation_candidates_generated")
+    if validation.get("valid") is not True:
+        violations.append("validation_report_invalid")
+
+    expected_hashes = {
+        "patch_preview_sha256": p["patch_preview"],
+        "review_queue_sha256": p["review_queue"],
+        "review_batches_sha256": p["batches"],
+        "dry_run_report_sha256": p["dry_run"],
+    }
+    for field, file_path in expected_hashes.items():
+        expected = hashes.get(field)
+        actual = _file_sha256(file_path)
+        if expected != actual:
+            violations.append(f"hash_mismatch:{field}")
+
+    return {
+        "schema": "repo-metadata-menu-validation/v1",
+        "session": "S0147",
+        "valid": not violations,
+        "violations": violations,
+        "patch_records": len(operations),
+        "queue_records": len(queue),
+        "excluded_records": len(excluded),
+        "batch_count": len(batches_doc.get("batches") or {}),
+        "hashes_valid": not any(item.startswith("hash_mismatch:") for item in violations),
+        "approval_disabled_in_s0147": True,
+        "human_approved": False,
+        "applied_to_canon": False,
+        "dry_run": True,
+    }
+
+
+def run_validate_dry_run(out_dir: Path = DEFAULT_OUT_DIR) -> int:
+    result = validate_dry_run_contract(out_dir)
+    print(_stable_json(result))
+    return 0 if result["valid"] else 1
+
+
+def _prompt_token(batch_id: str, decision: str) -> str:
+    expected = gate.expected_token(batch_id, decision)
+    print(f"Token requerido: {expected}")
+    try:
+        return input("Token: ").strip()
+    except EOFError:
+        return ""
+
+
+def record_batch_decision(
+    *,
+    batch_id: str,
+    decision: str,
+    token: str | None,
+    out_dir: Path = DEFAULT_OUT_DIR,
+    decision_dir: Path = DEFAULT_S0148_OUT_DIR,
+) -> int:
+    if token is None:
+        token = _prompt_token(batch_id, decision)
+    if not token:
+        print(f"{APPROVAL_REQUIRES_TERMINAL_TOKEN}: no token provided for {batch_id}")
+        return 2
+    result = gate.record_terminal_decision(
+        batch_id=batch_id,
+        decision=decision,
+        token=token,
+        patch_preview=_paths(out_dir)["patch_preview"],
+        review_batches=_paths(out_dir)["batches"],
+        patch_hashes=_paths(out_dir)["hashes"],
+        human_decisions=gate.s0148_paths(decision_dir)["human_decisions"],
+        out_dir=decision_dir,
+    )
+    print(_stable_json(result))
+    return 0 if result.get("status") == "ok" else 2
+
+
+def run_gate_dry_run(
+    out_dir: Path = DEFAULT_OUT_DIR,
+    decision_dir: Path = DEFAULT_S0148_OUT_DIR,
+    *,
+    canon_glob: str | None = None,
+    s0146_classification: Path | None = None,
+) -> int:
+    report = gate.run_gate(
+        patch_preview=_paths(out_dir)["patch_preview"],
+        review_batches=_paths(out_dir)["batches"],
+        patch_hashes=_paths(out_dir)["hashes"],
+        dry_run_report=_paths(out_dir)["dry_run"],
+        human_decisions=gate.s0148_paths(decision_dir)["human_decisions"],
+        canon_glob=canon_glob or str(REPO_ROOT / "data" / "out" / "local" / "tiddlers_*.jsonl"),
+        s0146_classification=s0146_classification
+        or (
+            REPO_ROOT
+            / "data"
+            / "out"
+            / "local"
+            / "pipeline"
+            / "repo_artifacts"
+            / "s0146"
+            / "s0146_repo_artifact_classification.jsonl"
+        ),
+        out_dir=decision_dir,
+        session="S0148",
+        dry_run=True,
+    )
+    print(_stable_json(report))
+    return 0
+
+
+def show_last_gate_report(decision_dir: Path = DEFAULT_S0148_OUT_DIR) -> int:
+    path = gate.s0148_paths(decision_dir)["gate_report"]
+    if not path.exists():
+        print("No existe reporte de compuerta S0148 todavia.")
+        return 1
+    print(_stable_json(_load_json(path)))
+    return 0
+
+
+def show_s0149_summary(out_dir: Path = DEFAULT_OUT_DIR) -> None:
+    show_summary(out_dir)
+    catalog = gate.s0149_batch_catalog(_paths(out_dir)["batches"])
+    print("\nS0149 batches seleccionables")
+    for batch_id, item in sorted(catalog.items(), key=lambda pair: pair[1].get("choice", "")):
+        marker = "recomendado" if item["recommended"] else "no recomendado"
+        if item["blocked"]:
+            marker = "bloqueado"
+        print(
+            f"- {item.get('choice')}) {batch_id}: {item.get('record_count')} operaciones, "
+            f"{marker}, risk={item.get('risk_profile')}"
+        )
+
+
+def select_s0149_batches(selection: str, out_dir: Path = DEFAULT_OUT_DIR, admission_dir: Path = DEFAULT_S0149_OUT_DIR) -> int:
+    doc = gate.select_s0149_batches(
+        selection,
+        review_batches=_paths(out_dir)["batches"],
+        out_dir=admission_dir,
+    )
+    print(_stable_json(doc))
+    return 0 if doc.get("valid") is True else 2
+
+
+def run_s0149_gate_dry_run(
+    out_dir: Path = DEFAULT_OUT_DIR,
+    admission_dir: Path = DEFAULT_S0149_OUT_DIR,
+    *,
+    canon_glob: str | None = None,
+    s0146_classification: Path | None = None,
+) -> int:
+    selected = gate.s0149_paths(admission_dir)["selected_batches"]
+    if not selected.exists():
+        print(f"No existe seleccion S0149: {_display(selected)}")
+        return 2
+    report = gate.run_s0149_dry_run(
+        patch_preview=_paths(out_dir)["patch_preview"],
+        review_batches=_paths(out_dir)["batches"],
+        patch_hashes=_paths(out_dir)["hashes"],
+        dry_run_report=_paths(out_dir)["dry_run"],
+        selected_batches=selected,
+        canon_glob=canon_glob or str(REPO_ROOT / "data" / "out" / "local" / "tiddlers_*.jsonl"),
+        s0146_classification=s0146_classification
+        or (
+            REPO_ROOT
+            / "data"
+            / "out"
+            / "local"
+            / "pipeline"
+            / "repo_artifacts"
+            / "s0146"
+            / "s0146_repo_artifact_classification.jsonl"
+        ),
+        out_dir=admission_dir,
+    )
+    print(_stable_json(report))
+    return 0
+
+
+def show_s0149_gate_report(admission_dir: Path = DEFAULT_S0149_OUT_DIR) -> int:
+    path = gate.s0149_paths(admission_dir)["dry_run_report"]
+    if not path.exists():
+        print("No existe reporte dry-run S0149 todavia.")
+        return 1
+    print(_stable_json(_load_json(path)))
+    return 0
+
+
+def show_s0149_apply_status(admission_dir: Path = DEFAULT_S0149_OUT_DIR) -> int:
+    path = gate.s0149_paths(admission_dir)["apply_report"]
+    if not path.exists():
+        report = gate.s0149_apply_not_executed_report("apply_not_requested")
+        gate.write_json(path, report)
+    print(_stable_json(_load_json(path)))
+    return 0
+
+
+def apply_s0149_metadata_from_menu(
+    out_dir: Path = DEFAULT_OUT_DIR,
+    admission_dir: Path = DEFAULT_S0149_OUT_DIR,
+    *,
+    canon_glob: str | None = None,
+    s0146_classification: Path | None = None,
+    apply_token: str | None = None,
+) -> int:
+    if apply_token is None:
+        print("Vas a aplicar metadata al canon local.")
+        print("Canon sera modificado: SI")
+        print("Relaciones seran generadas: NO")
+        print("semantic_text sera regenerado: NO en este paso")
+        print(f"Para confirmar, escribe exactamente: {gate.S0149_APPLY_TOKEN}")
+        try:
+            apply_token = input("Token: ").strip()
+        except EOFError:
+            apply_token = ""
+    report = gate.apply_s0149_metadata(
+        patch_preview=_paths(out_dir)["patch_preview"],
+        review_batches=_paths(out_dir)["batches"],
+        patch_hashes=_paths(out_dir)["hashes"],
+        s0147_dry_run_report=_paths(out_dir)["dry_run"],
+        dry_run_report_path=gate.s0149_paths(admission_dir)["dry_run_report"],
+        selected_batches=gate.s0149_paths(admission_dir)["selected_batches"],
+        canon_glob=canon_glob or str(REPO_ROOT / "data" / "out" / "local" / "tiddlers_*.jsonl"),
+        s0146_classification=s0146_classification
+        or (
+            REPO_ROOT
+            / "data"
+            / "out"
+            / "local"
+            / "pipeline"
+            / "repo_artifacts"
+            / "s0146"
+            / "s0146_repo_artifact_classification.jsonl"
+        ),
+        out_dir=admission_dir,
+        apply_token=apply_token,
+    )
+    print(_stable_json(report))
+    return 0 if report.get("apply_executed") is True else 2
+
+
+def rollback_s0149_metadata(admission_dir: Path = DEFAULT_S0149_OUT_DIR) -> int:
+    report = gate.rollback_s0149_metadata(out_dir=admission_dir)
+    print(_stable_json(report))
+    return 0 if report.get("rollback_executed") is True else 2
+
+
+def run_semantic_authority(mode: str, *, canon_glob: str | None = None, out_dir: Path = DEFAULT_SEMANTIC_AUTHORITY_OUT_DIR) -> int:
+    if mode not in {"preview", "generate"}:
+        raise ValueError(f"invalid semantic authority mode: {mode}")
+    script = SCRIPT_DIR / "build_semantic_text_authority_aware.py"
+    args = [
+        sys.executable,
+        str(script),
+        "--canon-glob",
+        canon_glob or str(REPO_ROOT / "data" / "out" / "local" / "tiddlers_*.jsonl"),
+        "--out-dir",
+        str(out_dir),
+        "--session",
+        "S0149",
+        f"--{mode}",
+    ]
+    result = subprocess.run(args, cwd=REPO_ROOT, check=False, capture_output=True, text=True)
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.stderr:
+        print(result.stderr.rstrip())
+    return result.returncode
+
+
+def should_use_s0149_gate(out_dir: Path, admission_dir: Path) -> bool:
+    selected = gate.s0149_paths(admission_dir)["selected_batches"]
+    try:
+        return out_dir.resolve() == DEFAULT_OUT_DIR.resolve() and selected.exists()
+    except OSError:
+        return out_dir == DEFAULT_OUT_DIR and selected.exists()
+
+
+S0149_MENU_HEADER = """━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Metadata técnica / admisión gobernada [EXPERIMENTAL]
+  Modo: DRY-RUN por defecto
+  Canon: PROTEGIDO
+  Apply: requiere confirmación humana explícita
+  Relaciones: BLOQUEADAS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1) Ver resumen de metadata técnica
+2) Seleccionar batches para revisión/dry-run
+3) Ver detalle de batch
+4) Ejecutar compuerta dry-run con selección actual
+5) Ver último resultado dry-run
+6) Aplicar metadata aprobada al canon [requiere confirmación]
+7) Rollback último apply de metadata
+8) Semantic_text authority-aware
+9) Avanzado / mantenimiento
+0) Volver
+"""
+
+
+def interactive_s0149_menu(
+    out_dir: Path = DEFAULT_OUT_DIR,
+    admission_dir: Path = DEFAULT_S0149_OUT_DIR,
+    *,
+    canon_glob: str | None = None,
+    s0146_classification: Path | None = None,
+) -> int:
+    while True:
+        print(S0149_MENU_HEADER)
+        try:
+            choice = input("Seleccion: ").strip()
+        except EOFError:
+            return 0
+        if choice == "0":
+            return 0
+        if choice == "1":
+            show_s0149_summary(out_dir)
+        elif choice == "2":
+            show_s0149_summary(out_dir)
+            raw = input("Selecciona batches separados por coma: ").strip()
+            select_s0149_batches(raw, out_dir, admission_dir)
+        elif choice == "3":
+            batch_id = input("Batch ID o numero: ").strip()
+            show_batch(gate.normalize_s0149_batch_token(batch_id), out_dir)
+        elif choice == "4":
+            print(f"Para ejecutar dry-run, escribe exactamente: {gate.S0149_DRY_RUN_TOKEN}")
+            token = input("Token: ").strip()
+            if token != gate.S0149_DRY_RUN_TOKEN:
+                print("Dry-run bloqueado: token invalido.")
+            else:
+                run_s0149_gate_dry_run(
+                    out_dir,
+                    admission_dir,
+                    canon_glob=canon_glob,
+                    s0146_classification=s0146_classification,
+                )
+        elif choice == "5":
+            show_s0149_gate_report(admission_dir)
+        elif choice == "6":
+            apply_s0149_metadata_from_menu(
+                out_dir,
+                admission_dir,
+                canon_glob=canon_glob,
+                s0146_classification=s0146_classification,
+            )
+        elif choice == "7":
+            rollback_s0149_metadata(admission_dir)
+        elif choice == "8":
+            print("1) Preview authority-aware")
+            print("2) Generate authority-aware")
+            semantic_choice = input("Seleccion: ").strip()
+            if semantic_choice == "1":
+                run_semantic_authority("preview", canon_glob=canon_glob)
+            elif semantic_choice == "2":
+                print("Generate solo se recomienda despues de metadata apply exitoso y canon validado.")
+                run_semantic_authority("generate", canon_glob=canon_glob)
+            else:
+                print("Opcion no reconocida")
+        elif choice == "9":
+            print("Reportes:")
+            for key, path in gate.s0149_paths(admission_dir).items():
+                if key != "backups":
+                    print(f"- {key}: {_display(path)}")
+        else:
+            print("Opcion no reconocida")
+        print()
+
+
+def option_repo_metadata_admission_menu() -> int:
+    return interactive_s0149_menu()
+
+
+MENU_HEADER = """S0148 repo metadata review menu
+1) Ver resumen de patch preview
+2) Ver lotes disponibles
+3) Ver detalle de lote
+4) Ver riesgos / excluidos
+5) Aprobar batch por terminal
+6) Rechazar batch
+7) Diferir batch
+8) Ejecutar compuerta dry-run con decisiones actuales
+9) Ver ultimo reporte de compuerta
+10) Ver hashes del patch
+11) Ayuda / instrucciones de operador
+0) Volver / salir
+"""
+
+
+def interactive_menu(
+    out_dir: Path = DEFAULT_OUT_DIR,
+    decision_dir: Path = DEFAULT_S0148_OUT_DIR,
+    *,
+    canon_glob: str | None = None,
+    s0146_classification: Path | None = None,
+) -> int:
+    while True:
+        print(MENU_HEADER)
+        try:
+            choice = input("Seleccion: ").strip()
+        except EOFError:
+            return 0
+        if choice == "0":
+            return 0
+        if choice == "1":
+            show_summary(out_dir)
+        elif choice == "2":
+            list_batches(out_dir)
+        elif choice == "3":
+            batch_id = input("Batch ID: ").strip()
+            show_batch(batch_id, out_dir)
+        elif choice == "4":
+            show_risks(out_dir)
+            show_excluded(out_dir)
+        elif choice == "5":
+            batch_id = input("Batch ID: ").strip()
+            record_batch_decision(batch_id=batch_id, decision="approved", token=None, out_dir=out_dir, decision_dir=decision_dir)
+        elif choice == "6":
+            batch_id = input("Batch ID: ").strip()
+            record_batch_decision(batch_id=batch_id, decision="rejected", token=None, out_dir=out_dir, decision_dir=decision_dir)
+        elif choice == "7":
+            batch_id = input("Batch ID: ").strip()
+            record_batch_decision(batch_id=batch_id, decision="deferred", token=None, out_dir=out_dir, decision_dir=decision_dir)
+        elif choice == "8":
+            run_gate_dry_run(
+                out_dir,
+                decision_dir,
+                canon_glob=canon_glob,
+                s0146_classification=s0146_classification,
+            )
+        elif choice == "9":
+            show_last_gate_report(decision_dir)
+        elif choice == "10":
+            show_hashes(out_dir)
+        elif choice == "11":
+            show_contract(out_dir)
+        else:
+            print("Opcion no reconocida")
+        print()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Review S0147 repo metadata patch preview")
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR))
+    parser.add_argument("--decision-dir", default=str(DEFAULT_S0148_OUT_DIR))
+    parser.add_argument("--admission-dir", default=str(DEFAULT_S0149_OUT_DIR))
+    parser.add_argument("--summary", action="store_true", help="Show patch summary")
+    parser.add_argument("--list-batches", action="store_true", help="List review batches")
+    parser.add_argument("--show-batch", help="Show one batch by id")
+    parser.add_argument("--show-excluded", action="store_true", help="Show excluded records")
+    parser.add_argument("--show-risks", action="store_true", help="Show risk report")
+    parser.add_argument("--show-hashes", action="store_true", help="Show patch hashes")
+    parser.add_argument("--export-csv", action="store_true", help="Print CSV path and row count")
+    parser.add_argument("--validate-dry-run", action="store_true", help="Validate dry-run invariants")
+    parser.add_argument("--contract", action="store_true", help="Show menu contract")
+    parser.add_argument("--approve-batch", help="Approve one batch with explicit terminal token")
+    parser.add_argument("--reject-batch", help="Reject one batch with explicit terminal token")
+    parser.add_argument("--defer-batch", help="Defer one batch with explicit terminal token")
+    parser.add_argument("--decision-token", help="Explicit decision token; if omitted, prompt on terminal")
+    parser.add_argument("--select-batches", help="Select S0149 metadata batches by id or comma-separated menu numbers")
+    parser.add_argument("--run-gate-dry-run", action="store_true", help="Run S0148 or S0149 dry-run admission gate")
+    parser.add_argument("--show-last-gate-report", action="store_true", help="Show latest S0148/S0149 gate report")
+    parser.add_argument("--show-apply-status", action="store_true", help="Show S0149 metadata apply status")
+    parser.add_argument("--apply-metadata", action="store_true", help="Apply S0149 metadata with explicit token")
+    parser.add_argument("--apply-token", help="Exact S0149 apply token")
+    parser.add_argument("--rollback-last-apply", action="store_true", help="Rollback latest S0149 metadata apply")
+    parser.add_argument("--semantic-authority-preview", action="store_true", help="Run S0149 semantic_text authority-aware preview")
+    parser.add_argument("--semantic-authority-generate", action="store_true", help="Run S0149 semantic_text authority-aware generate")
+    parser.add_argument("--canon-glob", default=None, help="Canon glob for S0148 gate")
+    parser.add_argument("--s0146-classification", default=None, help="S0146 classification path for S0148 gate")
+    parser.add_argument("--interactive", action="store_true", help="Open interactive review menu")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    out_dir = Path(args.out_dir)
+    decision_dir = Path(args.decision_dir)
+    admission_dir = Path(args.admission_dir)
+
+    if args.summary:
+        show_summary(out_dir)
+        return 0
+    if args.list_batches:
+        list_batches(out_dir)
+        return 0
+    if args.show_batch:
+        show_batch(args.show_batch, out_dir)
+        return 0
+    if args.show_excluded:
+        show_excluded(out_dir)
+        return 0
+    if args.show_risks:
+        show_risks(out_dir)
+        return 0
+    if args.show_hashes:
+        show_hashes(out_dir)
+        return 0
+    if args.export_csv:
+        export_csv(out_dir)
+        return 0
+    if args.validate_dry_run:
+        return run_validate_dry_run(out_dir)
+    if args.contract:
+        show_contract(out_dir)
+        return 0
+    if args.approve_batch:
+        return record_batch_decision(
+            batch_id=args.approve_batch,
+            decision="approved",
+            token=args.decision_token,
+            out_dir=out_dir,
+            decision_dir=decision_dir,
+        )
+    if args.reject_batch:
+        return record_batch_decision(
+            batch_id=args.reject_batch,
+            decision="rejected",
+            token=args.decision_token,
+            out_dir=out_dir,
+            decision_dir=decision_dir,
+        )
+    if args.defer_batch:
+        return record_batch_decision(
+            batch_id=args.defer_batch,
+            decision="deferred",
+            token=args.decision_token,
+            out_dir=out_dir,
+            decision_dir=decision_dir,
+        )
+    if args.select_batches:
+        return select_s0149_batches(args.select_batches, out_dir, admission_dir)
+    if args.run_gate_dry_run:
+        if should_use_s0149_gate(out_dir, admission_dir):
+            return run_s0149_gate_dry_run(
+                out_dir,
+                admission_dir,
+                canon_glob=args.canon_glob,
+                s0146_classification=Path(args.s0146_classification) if args.s0146_classification else None,
+            )
+        return run_gate_dry_run(
+            out_dir,
+            decision_dir,
+            canon_glob=args.canon_glob,
+            s0146_classification=Path(args.s0146_classification) if args.s0146_classification else None,
+        )
+    if args.show_last_gate_report:
+        if should_use_s0149_gate(out_dir, admission_dir):
+            return show_s0149_gate_report(admission_dir)
+        return show_last_gate_report(decision_dir)
+    if args.show_apply_status:
+        return show_s0149_apply_status(admission_dir)
+    if args.apply_metadata:
+        return apply_s0149_metadata_from_menu(
+            out_dir,
+            admission_dir,
+            canon_glob=args.canon_glob,
+            s0146_classification=Path(args.s0146_classification) if args.s0146_classification else None,
+            apply_token=args.apply_token,
+        )
+    if args.rollback_last_apply:
+        return rollback_s0149_metadata(admission_dir)
+    if args.semantic_authority_preview:
+        return run_semantic_authority("preview", canon_glob=args.canon_glob)
+    if args.semantic_authority_generate:
+        return run_semantic_authority("generate", canon_glob=args.canon_glob)
+    if args.interactive:
+        if should_use_s0149_gate(out_dir, admission_dir):
+            return interactive_s0149_menu(
+                out_dir,
+                admission_dir,
+                canon_glob=args.canon_glob,
+                s0146_classification=Path(args.s0146_classification) if args.s0146_classification else None,
+            )
+        return interactive_menu(
+            out_dir,
+            decision_dir,
+            canon_glob=args.canon_glob,
+            s0146_classification=Path(args.s0146_classification) if args.s0146_classification else None,
+        )
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python_scripts/tdc_menu_registry.py
+++ b/python_scripts/tdc_menu_registry.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Declarative local operator menu registry for S0150."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+MAIN_MENU_ITEMS: list[dict[str, str]] = [
+    {"id": "1", "label": "Preparación / preflight", "action": "preparation"},
+    {"id": "2", "label": "Construir o importar canon", "action": "build_or_import_canon"},
+    {"id": "3", "label": "Exportar / consultar canon", "action": "export_or_consult_canon"},
+    {"id": "4", "label": "Sincronizar sesiones al canon", "action": "session_sync"},
+    {"id": "5", "label": "Generar derivados", "action": "derivatives"},
+    {"id": "6", "label": "Revisión / admisión gobernada", "action": "governed_admission"},
+    {"id": "7", "label": "Reportes / métricas / auditoría", "action": "reports_audit"},
+    {"id": "8", "label": "Rollback", "action": "rollback"},
+    {"id": "9", "label": "Exportador de repositorio", "action": "repository_exporter"},
+    {"id": "10", "label": "Configurar MCP / mirror remoto", "action": "mcp_remote_config"},
+    {"id": "11", "label": "Avanzado / mantenimiento", "action": "advanced_maintenance"},
+]
+
+COMPATIBILITY_ALIASES: dict[str, dict[str, str]] = {
+    "14": {
+        "target": "10",
+        "action": "mcp_remote_config",
+        "message": "Esta opción fue reorganizada. Abriendo Configurar MCP / mirror remoto...",
+    },
+    "16": {
+        "target": "6.2",
+        "action": "relation_review",
+        "message": "Revisión relacional ahora vive dentro de Revisión / admisión gobernada → Relaciones candidatas.",
+    },
+    "17": {
+        "target": "9",
+        "action": "repository_exporter",
+        "message": "Esta opción fue reorganizada. Abriendo Exportador de repositorio...",
+    },
+    "18": {
+        "target": "6.1",
+        "action": "metadata_admission",
+        "message": "Metadata técnica ahora vive dentro de Revisión / admisión gobernada → Metadata técnica.",
+    },
+}
+
+
+def menu_text() -> str:
+    lines = [
+        "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+        "  Tiddly Data Converter - Operador local",
+        "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+        "",
+    ]
+    lines.extend(f"{item['id']}) {item['label']}" for item in MAIN_MENU_ITEMS)
+    lines.append("0) Salir")
+    return "\n".join(lines)
+
+
+def resolve_choice(choice: str) -> dict[str, str] | None:
+    for item in MAIN_MENU_ITEMS:
+        if item["id"] == choice:
+            return dict(item)
+    alias = COMPATIBILITY_ALIASES.get(choice)
+    if alias:
+        return {"id": choice, "label": f"Alias {choice}", **alias}
+    return None
+
+
+def menu_mapping() -> dict[str, Any]:
+    return {
+        "schema": "tdc-menu-mapping/v1",
+        "session": "S0150",
+        "main_menu_items": MAIN_MENU_ITEMS,
+        "compatibility_aliases": COMPATIBILITY_ALIASES,
+        "critical_functions_preserved": {
+            "repository_exporter": "9",
+            "mcp_remote_config": "10",
+            "relation_review": "6.2 and alias 16",
+            "metadata_admission": "6.1 and alias 18",
+            "rollback": "8",
+            "derivatives": "5",
+            "session_sync": "4",
+        },
+    }

--- a/tests/test_legacy_test_classifier.py
+++ b/tests/test_legacy_test_classifier.py
@@ -1,0 +1,67 @@
+"""S0150 tests for legacy pytest failure classification."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import legacy_test_classifier as classifier  # noqa: E402
+
+
+def test_classifier_identifies_obsolete_baseline_freezes(tmp_path: Path) -> None:
+    log = tmp_path / "pytest.log"
+    log.write_text(
+        "\n".join(
+            [
+                "FAILED tests/test_classification_characterization.py::TestRoleDistributionFreeze::test_total_ai_record_count - AssertionError: assert 1597 == 1424",
+                "FAILED tests/test_derive_layers_characterization.py::TestDeriveCountInvariants::test_canon_record_count - AssertionError: Canon count mismatch",
+                "2 failed, 1514 passed, 1 skipped in 1.00s",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = classifier.classify_pytest_log(pytest_log=log, out_dir=tmp_path / "out", session="S0150")
+
+    assert payload["summary"]["failed"] == 2
+    assert len(payload["failures"]) == 2
+    assert all("baseline_freeze_obsolete" in failure["classification"] for failure in payload["failures"])
+    assert (tmp_path / "out" / "s0150_legacy_test_classification.json").exists()
+    assert (tmp_path / "out" / "s0150_legacy_test_classification.md").exists()
+
+
+def test_classifier_does_not_allow_removing_protected_tests_without_review(tmp_path: Path) -> None:
+    log = tmp_path / "pytest.log"
+    log.write_text(
+        "\n".join(
+            [
+                "FAILED tests/test_derive_layers_characterization.py::TestCanonImmutability::test_canon_sha256_stable - AssertionError: Canon hash mismatch",
+                "FAILED tests/test_relation_human_review_gate.py::test_human_review - AssertionError: human review failed",
+                "2 failed, 10 passed in 1.00s",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = classifier.classify_pytest_log(pytest_log=log, out_dir=tmp_path / "out", session="S0150")
+
+    assert payload["critical_test_removal_permitted"] is False
+    assert all(failure["removal_allowed"] is False for failure in payload["failures"])
+    assert all("requires_human_review" in failure["classification"] for failure in payload["failures"])
+
+
+def test_classifier_outputs_valid_json(tmp_path: Path) -> None:
+    log = tmp_path / "pytest.log"
+    log.write_text("1 passed in 0.01s\n", encoding="utf-8")
+
+    classifier.classify_pytest_log(pytest_log=log, out_dir=tmp_path / "out", session="S0150")
+    payload = json.loads((tmp_path / "out" / "s0150_legacy_test_classification.json").read_text(encoding="utf-8"))
+
+    assert payload["session"] == "S0150"
+    assert payload["failures"] == []
+    assert payload["tests_removed"] == 0

--- a/tests/test_operator_menu_smoke.py
+++ b/tests/test_operator_menu_smoke.py
@@ -82,22 +82,23 @@ class TestMenuExitsCleanly:
         result = _run_menu("0\n")
         stdout = result.stdout
         expected_fragments = [
-            "Preparacion",
-            "Validar canon",
-            "Sincronizar entregables",
+            "Preparación / preflight",
+            "Construir o importar canon",
+            "Exportar / consultar canon",
+            "Sincronizar sesiones",
             "Generar derivados",
-            "Ejecutar reverse",
+            "Revisión / admisión gobernada",
         ]
         missing = [f for f in expected_fragments if f not in stdout]
         assert not missing, (
             f"Menu missing options: {missing}\nGot:\n{stdout[:600]}"
         )
 
-    def test_menu_shows_saneamiento_del_canon(self):
-        """S0121: menu must show 'Saneamiento del canon' option."""
+    def test_menu_shows_advanced_maintenance(self):
+        """S0150: saneamiento lives under Avanzado / mantenimiento."""
         result = _run_menu("0\n")
-        assert "Saneamiento del canon" in result.stdout, (
-            f"'Saneamiento del canon' not found in menu output:\n{result.stdout[:600]}"
+        assert "Avanzado / mantenimiento" in result.stdout, (
+            f"'Avanzado / mantenimiento' not found in menu output:\n{result.stdout[:600]}"
         )
 
     def test_menu_shows_repository_exporter(self):
@@ -194,8 +195,8 @@ class TestMenuCanonSanitation:
     """S0121: verify the Saneamiento del canon submenu is reachable and safe."""
 
     def test_sanitation_submenu_shows_options(self):
-        # Open submenu (15) then exit (0) then exit main (0)
-        result = _run_menu("15\n0\n0\n", timeout=30)
+        # Open Avanzado (11), Saneamiento (2), exit sanitation, exit advanced, exit main.
+        result = _run_menu("11\n2\n0\n0\n0\n", timeout=30)
         assert result.returncode == 0, (
             f"Menu exited with code {result.returncode}\nstdout: {result.stdout[:400]}\nstderr: {result.stderr[:300]}"
         )
@@ -204,14 +205,14 @@ class TestMenuCanonSanitation:
         )
 
     def test_sanitation_submenu_shows_scan_option(self):
-        result = _run_menu("15\n0\n0\n", timeout=30)
+        result = _run_menu("11\n2\n0\n0\n0\n", timeout=30)
         assert "Escanear" in result.stdout, (
             f"'Escanear' option not found:\n{result.stdout[:400]}"
         )
 
     def test_sanitation_submenu_does_not_modify_canon(self):
         hashes_before = _canon_shard_hashes()
-        _run_menu("15\n0\n0\n", timeout=30)
+        _run_menu("11\n2\n0\n0\n0\n", timeout=30)
         hashes_after = _canon_shard_hashes()
         assert hashes_before == hashes_after, (
             "Canon shards were modified by opening the Saneamiento submenu"

--- a/tests/test_relation_review_menu.py
+++ b/tests/test_relation_review_menu.py
@@ -3,8 +3,8 @@ tests/test_relation_review_menu.py — S0127
 
 Tests del módulo auxiliar de revisión relacional experimental.
 
-Cobertura requerida por S0127:
-  1. La sección experimental aparece en el menú principal (opción 16).
+Cobertura requerida por S0127/S0150:
+  1. La revisión relacional aparece en admisión gobernada y alias 16 sigue funcionando.
   2. El texto del submenú incluye EXPERIMENTAL, dry-run,
      generación bloqueada y admisión bloqueada.
   3. La opción invoca el validador con --dry-run.
@@ -12,7 +12,7 @@ Cobertura requerida por S0127:
   5. La opción NO modifica data/out/local/tiddlers_*.jsonl.
   6. Si no hay candidatos, la salida es legible y no genera nuevos.
   7. El reporte humano puede mostrarse o referenciarse sin alterar archivos.
-  8. El submenú es accesible desde el menú principal como opción 16.
+  8. El submenú es accesible desde el alias histórico 16.
   9. El submenú cierra limpiamente con opción 0.
 """
 
@@ -417,21 +417,20 @@ class TestViewHumanReport:
 
 
 class TestMainMenuIntegration:
-    """Verifica que la opción 16 está integrada en el menú principal."""
+    """Verifica que la revisión relacional sigue integrada tras S0150."""
 
     def test_main_menu_shows_revision_relacional_experimental(self):
-        """El menú principal muestra la opción de revisión relacional experimental."""
+        """El menú principal muestra el punto central de admisión gobernada."""
         result = _run_menu("0\n")
         assert result.returncode == 0
-        assert (
-            "Revision relacional" in result.stdout
-            or "EXPERIMENTAL" in result.stdout
-        ), f"Opción experimental no encontrada:\n{result.stdout[:600]}"
+        assert "Revisión / admisión gobernada" in result.stdout, (
+            f"Admisión gobernada no encontrada:\n{result.stdout[:600]}"
+        )
 
-    def test_main_menu_shows_option_16(self):
-        result = _run_menu("0\n")
-        assert "16)" in result.stdout, (
-            f"Opción 16 no encontrada en el menú:\n{result.stdout[:600]}"
+    def test_alias_16_redirects_to_relation_review(self):
+        result = _run_menu("16\n0\n0\n", timeout=30)
+        assert "Revisión relacional ahora vive" in result.stdout, (
+            f"Alias 16 no redirigió correctamente:\n{result.stdout[:800]}"
         )
 
     def test_experimental_submenu_reachable_from_main(self):

--- a/tests/test_repo_artifact_characterization.py
+++ b/tests/test_repo_artifact_characterization.py
@@ -1,0 +1,264 @@
+"""S0146 tests for governed repo artifact characterization."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import characterize_repo_artifacts as cra  # noqa: E402
+
+
+def _record(
+    tid: str,
+    title: str,
+    *,
+    text: str = "",
+    role: str = "log",
+    tags: list[str] | None = None,
+    code: str | None = None,
+) -> dict:
+    content = {"plain": text}
+    if code is not None:
+        content["code_blocks"] = [{"language": "text", "text": code}]
+    return {
+        "id": tid,
+        "key": title,
+        "title": title,
+        "role_primary": role,
+        "tags": tags or [],
+        "source_tags": tags or [],
+        "source_fields": {"canonical_status": "local_admitted"},
+        "content": content,
+        "text": text,
+    }
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_lines(path: Path, lines: list[str]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return path
+
+
+def _repo_file(root: Path, rel: str, content: str = "print('ok')\n") -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _run(
+    tmp_path: Path,
+    monkeypatch,
+    records: list[dict],
+    *,
+    git_files: list[str] | None = None,
+    worktree_files: list[str] | None = None,
+    s0145_rows: list[dict] | None = None,
+    out_name: str = "out",
+) -> dict:
+    monkeypatch.setattr(cra, "REPO_ROOT", tmp_path)
+    canon = _write_jsonl(tmp_path / "canon" / "tiddlers_1.jsonl", records)
+    git_path = _write_lines(tmp_path / "git.txt", git_files or [])
+    worktree_path = _write_lines(tmp_path / "worktree.txt", worktree_files if worktree_files is not None else (git_files or []))
+    s0145_path = tmp_path / "s0145.jsonl"
+    if s0145_rows is not None:
+        _write_jsonl(s0145_path, s0145_rows)
+    return cra.build_repo_artifact_outputs(
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        s0145_candidates=s0145_path if s0145_rows is not None else None,
+        git_files=git_path,
+        worktree_files=worktree_path,
+        out_dir=tmp_path / out_name,
+        session="S0146",
+        dry_run=True,
+    )
+
+
+def _classifications(result: dict) -> list[dict]:
+    path = Path(result["paths"]["classification"])
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_detects_tiddler_tecnico_from_s0145(tmp_path: Path, monkeypatch) -> None:
+    result = _run(
+        tmp_path,
+        monkeypatch,
+        [_record("tech", "Entrada tecnica neutra")],
+        s0145_rows=[{"id": "tech", "candidate_artifact_family": "tiddler_tecnico", "signals": ["s0145"]}],
+    )
+
+    rows = _classifications(result)
+    assert len(rows) == 1
+    assert rows[0]["s0145_candidate_artifact_family"] == "tiddler_tecnico"
+
+
+def test_operates_without_s0145_using_only_canon(tmp_path: Path, monkeypatch) -> None:
+    result = _run(tmp_path, monkeypatch, [_record("code", "Bloque", code="print('x')")])
+
+    assert _classifications(result)[0]["diagnostic_category"] == "embedded_code_block"
+
+
+def test_detects_exact_git_path(tmp_path: Path, monkeypatch) -> None:
+    _repo_file(tmp_path, "python_scripts/demo.py", "print('ok')\n")
+    result = _run(
+        tmp_path,
+        monkeypatch,
+        [_record("demo", "python_scripts/demo.py", role="code", code="print('ok')\n")],
+        git_files=["python_scripts/demo.py"],
+    )
+
+    row = _classifications(result)[0]
+    assert row["repo_path_exists_in_git"] is True
+    assert row["diagnostic_category"] == "repo_snapshot_current"
+
+
+def test_detects_missing_path_as_missing_from_repo(tmp_path: Path, monkeypatch) -> None:
+    result = _run(tmp_path, monkeypatch, [_record("missing", "docs/missing.md", role="code", code="old")], git_files=[])
+
+    row = _classifications(result)[0]
+    assert row["candidate_repo_lifecycle_state"] == "missing_from_repo"
+
+
+def test_detects_moved_candidate_by_alternative_path(tmp_path: Path, monkeypatch) -> None:
+    _repo_file(tmp_path, "esquemas/old.md", "old\n")
+    result = _run(
+        tmp_path,
+        monkeypatch,
+        [_record("old", "docs/old.md", role="code", code="old\n")],
+        git_files=["esquemas/old.md"],
+    )
+
+    row = _classifications(result)[0]
+    assert row["diagnostic_category"] == "moved_candidate"
+    assert row["moved_to_candidate"] == "esquemas/old.md"
+
+
+def test_classifies_py_as_source_code(tmp_path: Path, monkeypatch) -> None:
+    _repo_file(tmp_path, "python_scripts/demo.py")
+    row = _classifications(_run(tmp_path, monkeypatch, [_record("py", "python_scripts/demo.py", role="code", code="print('ok')\n")], git_files=["python_scripts/demo.py"]))[0]
+    assert row["candidate_repo_artifact_kind"] == "source_code"
+
+
+def test_classifies_test_py_as_test_code(tmp_path: Path, monkeypatch) -> None:
+    _repo_file(tmp_path, "tests/test_demo.py")
+    row = _classifications(_run(tmp_path, monkeypatch, [_record("test", "tests/test_demo.py", role="code", code="print('ok')\n")], git_files=["tests/test_demo.py"]))[0]
+    assert row["candidate_repo_artifact_kind"] == "test_code"
+
+
+def test_classifies_sh_as_shell_script(tmp_path: Path, monkeypatch) -> None:
+    _repo_file(tmp_path, "shell_scripts/run.sh", "#!/usr/bin/env bash\n")
+    row = _classifications(_run(tmp_path, monkeypatch, [_record("sh", "shell_scripts/run.sh", role="code", code="#!/usr/bin/env bash\n")], git_files=["shell_scripts/run.sh"]))[0]
+    assert row["candidate_repo_artifact_kind"] == "shell_script"
+
+
+def test_classifies_github_workflow_as_ci_workflow(tmp_path: Path, monkeypatch) -> None:
+    _repo_file(tmp_path, ".github/workflows/ci.yml", "name: ci\n")
+    row = _classifications(_run(tmp_path, monkeypatch, [_record("ci", ".github/workflows/ci.yml", role="code", code="name: ci\n")], git_files=[".github/workflows/ci.yml"]))[0]
+    assert row["candidate_repo_artifact_kind"] == "ci_workflow"
+
+
+def test_classifies_esquemas_as_schema(tmp_path: Path, monkeypatch) -> None:
+    _repo_file(tmp_path, "esquemas/canon/rules.md", "rules\n")
+    row = _classifications(_run(tmp_path, monkeypatch, [_record("schema", "esquemas/canon/rules.md", role="code", code="rules\n")], git_files=["esquemas/canon/rules.md"]))[0]
+    assert row["candidate_repo_artifact_kind"] == "schema"
+
+
+def test_classifies_data_out_as_generated_output(tmp_path: Path, monkeypatch) -> None:
+    _repo_file(tmp_path, "data/out/local/report.json", "{}\n")
+    row = _classifications(_run(tmp_path, monkeypatch, [_record("out", "data/out/local/report.json", role="code", code="{}\n")], git_files=["data/out/local/report.json"]))[0]
+    assert row["diagnostic_category"] == "generated_output"
+    assert row["candidate_repo_artifact_kind"] == "generated_output"
+
+
+def test_distinguishes_narrative_code_reference_from_snapshot(tmp_path: Path, monkeypatch) -> None:
+    text = "La sesion menciona python_scripts/demo.py como ruta revisada."
+    result = _run(tmp_path, monkeypatch, [_record("session", "#### 🌀 Sesión 0146 = demo", text=text)])
+
+    row = _classifications(result)[0]
+    assert row["diagnostic_category"] == "session_or_diagnostic_narrative"
+    assert row["candidate_repo_path"] == ""
+
+
+def test_distinguishes_embedded_code_block_from_repo_file(tmp_path: Path, monkeypatch) -> None:
+    row = _classifications(_run(tmp_path, monkeypatch, [_record("block", "Ejemplo tecnico", code="x = 1")]))[0]
+    assert row["diagnostic_category"] == "embedded_code_block"
+
+
+def test_does_not_declare_current_verified_for_title_only(tmp_path: Path, monkeypatch) -> None:
+    _repo_file(tmp_path, "python_scripts/demo.py", "print('ok')\n")
+    row = _classifications(_run(tmp_path, monkeypatch, [_record("title", "python_scripts/demo.py", role="code")], git_files=["python_scripts/demo.py"]))[0]
+    assert row["candidate_authority_level"] != "current_verified"
+    assert row["content_comparison"] == "no_comparable_code_block"
+
+
+def test_requires_positive_comparison_for_current_verified(tmp_path: Path, monkeypatch) -> None:
+    _repo_file(tmp_path, "python_scripts/demo.py", "print('ok')\n")
+    row = _classifications(_run(tmp_path, monkeypatch, [_record("hash", "python_scripts/demo.py", role="code", code="print('ok')\n")], git_files=["python_scripts/demo.py"]))[0]
+    assert row["candidate_authority_level"] == "current_verified"
+    assert row["content_comparison"] == "exact_match"
+
+
+def test_declares_applied_to_canon_false(tmp_path: Path, monkeypatch) -> None:
+    row = _classifications(_run(tmp_path, monkeypatch, [_record("block", "Ejemplo tecnico", code="x = 1")]))[0]
+    assert row["applied_to_canon"] is False
+
+
+def test_relation_opportunities_are_not_formal_candidates(tmp_path: Path, monkeypatch) -> None:
+    _repo_file(tmp_path, "python_scripts/demo.py", "print('ok')\n")
+    result = _run(tmp_path, monkeypatch, [_record("demo", "python_scripts/demo.py", role="code", code="print('ok')\n")], git_files=["python_scripts/demo.py"])
+    path = Path(result["paths"]["relation_opportunities"])
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert rows
+    assert {row["formal_relation_candidate"] for row in rows} == {False}
+
+
+def test_classification_jsonl_is_valid(tmp_path: Path, monkeypatch) -> None:
+    result = _run(tmp_path, monkeypatch, [_record("block", "Ejemplo tecnico", code="x = 1")])
+    rows = _classifications(result)
+    assert rows[0]["dry_run"] is True
+
+
+def test_review_csv_contains_minimum_columns(tmp_path: Path, monkeypatch) -> None:
+    result = _run(tmp_path, monkeypatch, [_record("block", "Ejemplo tecnico", code="x = 1")])
+    with Path(result["paths"]["review"]).open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        assert reader.fieldnames == cra.REVIEW_COLUMNS
+
+
+def test_output_is_deterministic(tmp_path: Path, monkeypatch) -> None:
+    records = [_record("block", "Ejemplo tecnico", code="x = 1")]
+    first = _run(tmp_path, monkeypatch, records, out_name="out1")
+    second = _run(tmp_path, monkeypatch, records, out_name="out2")
+    first_hash = hashlib.sha256(Path(first["paths"]["classification"]).read_bytes()).hexdigest()
+    second_hash = hashlib.sha256(Path(second["paths"]["classification"]).read_bytes()).hexdigest()
+    assert first_hash == second_hash
+
+
+def test_does_not_modify_input_canon_jsonl(tmp_path: Path, monkeypatch) -> None:
+    canon = _write_jsonl(tmp_path / "canon" / "tiddlers_1.jsonl", [_record("block", "Ejemplo tecnico", code="x = 1")])
+    before = hashlib.sha256(canon.read_bytes()).hexdigest()
+    monkeypatch.setattr(cra, "REPO_ROOT", tmp_path)
+    cra.build_repo_artifact_outputs(
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        s0145_candidates=None,
+        git_files=_write_lines(tmp_path / "git.txt", []),
+        worktree_files=_write_lines(tmp_path / "worktree.txt", []),
+        out_dir=tmp_path / "out",
+        session="S0146",
+        dry_run=True,
+    )
+    assert hashlib.sha256(canon.read_bytes()).hexdigest() == before

--- a/tests/test_repo_metadata_admission_gate.py
+++ b/tests/test_repo_metadata_admission_gate.py
@@ -1,0 +1,341 @@
+"""S0148 tests for repo metadata dry-run admission gate."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import build_repo_metadata_patch_preview as preview  # noqa: E402
+import repo_metadata_admission_gate as gate  # noqa: E402
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+    return path
+
+
+def _classification(tid: str, title: str, category: str, **overrides) -> dict:
+    payload = {
+        "id": tid,
+        "title": title,
+        "diagnostic_category": category,
+        "candidate_authority_level": "unknown",
+        "candidate_is_current_repo_artifact": "false",
+        "risk_level": "low",
+        "confidence": "high",
+        "candidate_repo_path": "",
+        "candidate_repo_directory": "",
+        "candidate_repo_extension": "",
+        "candidate_repo_artifact_kind": "unknown_repo_artifact",
+        "candidate_repo_lifecycle_state": "",
+        "candidate_artifact_family": "artefacto_repositorio",
+        "candidate_content_sha256": f"sha-{tid}",
+        "content_comparison": "not_current",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _fixture(tmp_path: Path) -> dict[str, Path | str]:
+    classification = _write_jsonl(
+        tmp_path / "s0146" / "classification.jsonl",
+        [
+            _classification(
+                "cur",
+                "python_scripts/current.py",
+                "repo_snapshot_current",
+                candidate_authority_level="current_verified",
+                candidate_is_current_repo_artifact="true",
+                candidate_repo_path="python_scripts/current.py",
+                candidate_repo_directory="python_scripts",
+                candidate_repo_extension=".py",
+                candidate_repo_artifact_kind="source_code",
+                candidate_repo_lifecycle_state="current_repo_artifact",
+                content_comparison="exact_match",
+            ),
+            _classification("review", "needs review", "review_required", confidence="requires_human_review"),
+        ],
+    )
+    metadata_contract = tmp_path / "s0146" / "contract.md"
+    metadata_contract.write_text("# contract\n", encoding="utf-8")
+    canon = _write_jsonl(
+        tmp_path / "canon" / "tiddlers_1.jsonl",
+        [
+            {"id": "cur", "title": "python_scripts/current.py", "source_fields": {"artifact_family": "unknown"}},
+            {"id": "review", "title": "needs review", "source_fields": {"artifact_family": "unknown"}},
+        ],
+    )
+    out_dir = tmp_path / "s0147"
+    preview.build_repo_metadata_patch_preview(
+        classification=classification,
+        metadata_contract=metadata_contract,
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        out_dir=out_dir,
+        session="S0147",
+        dry_run=True,
+    )
+    return {
+        "classification": classification,
+        "canon_file": canon,
+        "canon_glob": str(canon.parent / "tiddlers_*.jsonl"),
+        "s0147": out_dir,
+        "s0148": tmp_path / "s0148",
+    }
+
+
+def _paths(fx: dict[str, Path | str]) -> dict[str, Path]:
+    s0147 = fx["s0147"]
+    assert isinstance(s0147, Path)
+    s0148 = fx["s0148"]
+    assert isinstance(s0148, Path)
+    return {
+        "patch": s0147 / "s0147_repo_metadata_patch_preview.jsonl",
+        "batches": s0147 / "s0147_repo_metadata_review_batches.json",
+        "hashes": s0147 / "s0147_repo_metadata_patch_hashes.json",
+        "dry": s0147 / "s0147_repo_metadata_dry_run_report.json",
+        "decisions": gate.s0148_paths(s0148)["human_decisions"],
+        "out": s0148,
+    }
+
+
+def _approve(fx: dict[str, Path | str]) -> None:
+    p = _paths(fx)
+    result = gate.record_terminal_decision(
+        batch_id="batch_current_verified",
+        decision="approved",
+        token="APROBAR_METADATA_BATCH_CURRENT_VERIFIED",
+        patch_preview=p["patch"],
+        review_batches=p["batches"],
+        patch_hashes=p["hashes"],
+        human_decisions=p["decisions"],
+        out_dir=p["out"],
+        timestamp="2026-06-12T00:00:00Z",
+    )
+    assert result["status"] == "ok"
+
+
+def _run_gate(fx: dict[str, Path | str]) -> dict:
+    p = _paths(fx)
+    classification = fx["classification"]
+    assert isinstance(classification, Path)
+    return gate.run_gate(
+        patch_preview=p["patch"],
+        review_batches=p["batches"],
+        patch_hashes=p["hashes"],
+        dry_run_report=p["dry"],
+        human_decisions=p["decisions"],
+        canon_glob=str(fx["canon_glob"]),
+        s0146_classification=classification,
+        out_dir=p["out"],
+        session="S0148",
+        dry_run=True,
+    )
+
+
+def _refresh_hashes(fx: dict[str, Path | str]) -> None:
+    p = _paths(fx)
+    patch_rows = gate.read_jsonl(p["patch"])
+    batches = gate.read_json(p["batches"])
+    for batch_id, batch in batches["batches"].items():
+        rows = [row for row in patch_rows if row.get("batch_id") == batch_id]
+        if batch_id != "batch_excluded_review_required":
+            batch["patch_sha256"] = gate.subset_sha(rows)
+    gate.write_json(p["batches"], batches)
+    hashes = gate.read_json(p["hashes"])
+    hashes["patch_preview_sha256"] = gate.file_sha256(p["patch"])
+    hashes["review_batches_sha256"] = gate.file_sha256(p["batches"])
+    hashes["dry_run_report_sha256"] = gate.file_sha256(p["dry"])
+    classification = fx["classification"]
+    assert isinstance(classification, Path)
+    hashes["s0146_classification_sha256"] = gate.file_sha256(classification)
+    hashes["canon_before_sha256"] = gate.tree_sha256(str(fx["canon_glob"]))
+    gate.write_json(p["hashes"], hashes)
+
+
+def test_gate_blocks_without_human_approval_and_writes_reports(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+
+    report = _run_gate(fx)
+
+    assert report["blocked"] is True
+    assert report["admission_ready_dry_run"] == 0
+    assert "no_human_approval" in report["block_reasons"]
+    paths = gate.s0148_paths(fx["s0148"])
+    for key in [
+        "human_decisions",
+        "batch_approvals",
+        "gate_report",
+        "admission_ready",
+        "blocked_records",
+        "rejected_or_deferred",
+        "terminal_audit",
+        "hash_verification",
+        "risk_verification",
+        "operator_summary",
+        "next_apply_plan",
+    ]:
+        assert paths[key].exists()
+
+
+def test_approved_current_verified_batch_produces_admission_ready_dry_run(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    _approve(fx)
+
+    report = _run_gate(fx)
+    ready_rows = gate.read_jsonl(gate.s0148_paths(fx["s0148"])["admission_ready"])
+
+    assert report["blocked"] is False
+    assert report["approved_batches"] == ["batch_current_verified"]
+    assert report["admission_ready_dry_run"] == 1
+    assert ready_rows[0]["human_approved"] is True
+    assert ready_rows[0]["dry_run"] is True
+    assert ready_rows[0]["applied_to_canon"] is False
+    assert "relations" not in ready_rows[0]
+    assert "candidate_relations" not in ready_rows[0]
+    assert report["relations_generated"] is False
+    assert report["candidate_relations_generated"] is False
+    assert report["semantic_text_modified"] is False
+
+
+def test_rejected_and_deferred_decisions_block_admission(tmp_path: Path) -> None:
+    for decision, token, expected_key in [
+        ("rejected", "RECHAZAR_METADATA_BATCH_CURRENT_VERIFIED", "rejected_batches"),
+        ("deferred", "DIFERIR_METADATA_BATCH_CURRENT_VERIFIED", "deferred_batches"),
+    ]:
+        fx = _fixture(tmp_path / decision)
+        p = _paths(fx)
+        gate.record_terminal_decision(
+            batch_id="batch_current_verified",
+            decision=decision,
+            token=token,
+            patch_preview=p["patch"],
+            review_batches=p["batches"],
+            patch_hashes=p["hashes"],
+            human_decisions=p["decisions"],
+            out_dir=p["out"],
+            timestamp="2026-06-12T00:00:00Z",
+        )
+        report = _run_gate(fx)
+        assert report["blocked"] is True
+        assert report["admission_ready_dry_run"] == 0
+        assert report[expected_key] == ["batch_current_verified"]
+
+
+def test_patch_hash_mismatch_blocks_admission(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    _approve(fx)
+    p = _paths(fx)
+    rows = gate.read_jsonl(p["patch"])
+    rows[0]["target_title"] = "changed.py"
+    gate.write_jsonl(p["patch"], rows)
+
+    report = _run_gate(fx)
+
+    assert report["blocked"] is True
+    assert "hash_mismatch:patch_preview_sha256" in report["block_reasons"]
+
+
+def test_canon_hash_mismatch_blocks_admission_and_canon_is_not_modified_by_gate(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    _approve(fx)
+    canon_file = fx["canon_file"]
+    assert isinstance(canon_file, Path)
+    before_gate = canon_file.read_text(encoding="utf-8")
+    canon_file.write_text(before_gate + "\n", encoding="utf-8")
+    changed_before_gate = canon_file.read_text(encoding="utf-8")
+
+    report = _run_gate(fx)
+
+    assert report["blocked"] is True
+    assert "hash_mismatch:canon_before_sha256" in report["block_reasons"]
+    assert canon_file.read_text(encoding="utf-8") == changed_before_gate
+
+
+def test_s0146_classification_hash_mismatch_blocks_admission(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    _approve(fx)
+    classification = fx["classification"]
+    assert isinstance(classification, Path)
+    classification.write_text(classification.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+    report = _run_gate(fx)
+
+    assert report["blocked"] is True
+    assert "hash_mismatch:s0146_classification_sha256" in report["block_reasons"]
+
+
+def test_critical_risk_in_approved_batch_blocks_admission(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    p = _paths(fx)
+    rows = gate.read_jsonl(p["patch"])
+    rows[0]["source_risk_level"] = "critical"
+    gate.write_jsonl(p["patch"], rows)
+    _refresh_hashes(fx)
+    _approve(fx)
+
+    report = _run_gate(fx)
+
+    assert report["blocked"] is True
+    assert "critical_risk_in_approved_batch" in report["block_reasons"]
+
+
+def test_lane_f_batch_blocks_admission(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    p = _paths(fx)
+    batches = gate.read_json(p["batches"])["batches"]
+    hashes = gate.read_json(p["hashes"])
+    decisions = gate.empty_decisions_doc()
+    decisions["human_approval_found"] = True
+    decisions["decisions"] = [
+        {
+            "batch_id": "batch_excluded_review_required",
+            "decision": "approved",
+            "human_approved": True,
+            "token_verified": True,
+            "token_name": "APROBAR_METADATA_EXCLUDED_REVIEW_REQUIRED",
+            "decision_timestamp": "2026-06-12T00:00:00Z",
+            "patch_sha256": hashes["patch_preview_sha256"],
+            "batch_sha256": batches["batch_excluded_review_required"]["patch_sha256"],
+            "canon_before_sha256": hashes["canon_before_sha256"],
+            "s0146_classification_sha256": hashes["s0146_classification_sha256"],
+            "source_session": "S0147",
+            "decision_source": "terminal",
+        }
+    ]
+    gate.write_json(p["decisions"], decisions)
+
+    report = _run_gate(fx)
+
+    assert report["blocked"] is True
+    assert "excluded_batch_not_approvable" in report["block_reasons"]
+
+
+def test_hash_and_risk_verification_files_are_generated(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    _approve(fx)
+
+    report = _run_gate(fx)
+    paths = gate.s0148_paths(fx["s0148"])
+
+    assert report["hash_verification"]["all_hashes_match"] is True
+    assert paths["hash_verification"].exists()
+    assert paths["risk_verification"].exists()
+
+
+def test_gate_report_is_deterministic_for_equivalent_runs(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    _approve(fx)
+
+    first = _run_gate(fx)
+    first_text = gate.s0148_paths(fx["s0148"])["gate_report"].read_text(encoding="utf-8")
+    second = _run_gate(fx)
+    second_text = gate.s0148_paths(fx["s0148"])["gate_report"].read_text(encoding="utf-8")
+
+    assert first == second
+    assert first_text == second_text

--- a/tests/test_repo_metadata_apply_gate.py
+++ b/tests/test_repo_metadata_apply_gate.py
@@ -1,0 +1,243 @@
+"""S0149 tests for governed metadata apply and rollback."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import build_repo_metadata_patch_preview as preview  # noqa: E402
+import repo_metadata_admission_gate as gate  # noqa: E402
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+    return path
+
+
+def _classification(tid: str, title: str, category: str, **overrides) -> dict:
+    payload = {
+        "id": tid,
+        "title": title,
+        "diagnostic_category": category,
+        "candidate_authority_level": "unknown",
+        "candidate_is_current_repo_artifact": "false",
+        "risk_level": "low",
+        "confidence": "high",
+        "candidate_repo_path": "",
+        "candidate_repo_directory": "",
+        "candidate_repo_extension": "",
+        "candidate_repo_artifact_kind": "unknown_repo_artifact",
+        "candidate_repo_lifecycle_state": "",
+        "candidate_artifact_family": "artefacto_repositorio",
+        "candidate_content_sha256": f"sha-{tid}",
+        "content_comparison": "not_current",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _fixture(tmp_path: Path) -> dict[str, Path | str]:
+    classification = _write_jsonl(
+        tmp_path / "s0146" / "classification.jsonl",
+        [
+            _classification(
+                "cur",
+                "python_scripts/current.py",
+                "repo_snapshot_current",
+                candidate_authority_level="current_verified",
+                candidate_is_current_repo_artifact="true",
+                candidate_repo_path="python_scripts/current.py",
+                candidate_repo_directory="python_scripts",
+                candidate_repo_extension=".py",
+                candidate_repo_artifact_kind="source_code",
+                candidate_repo_lifecycle_state="current_repo_artifact",
+                candidate_content_sha256="abc123",
+                content_comparison="exact_match",
+            ),
+            _classification("nar", "#### 🌀 Sesión 0102 = narrative", "session_or_diagnostic_narrative", risk_level="high"),
+        ],
+    )
+    metadata_contract = tmp_path / "s0146" / "contract.md"
+    metadata_contract.write_text("# contract\n", encoding="utf-8")
+    canon = _write_jsonl(
+        tmp_path / "canon" / "tiddlers_1.jsonl",
+        [
+            {"id": "cur", "title": "python_scripts/current.py", "source_fields": {"artifact_family": "unknown"}, "text": "current"},
+            {
+                "id": "nar",
+                "title": "#### 🌀 Sesión 0102 = narrative",
+                "source_fields": {"artifact_family": "detalles_de_sesion"},
+                "text": "mentions python_scripts/current.py",
+            },
+        ],
+    )
+    out_dir = tmp_path / "s0147"
+    preview.build_repo_metadata_patch_preview(
+        classification=classification,
+        metadata_contract=metadata_contract,
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        out_dir=out_dir,
+        session="S0147",
+        dry_run=True,
+    )
+    return {
+        "classification": classification,
+        "canon": canon,
+        "canon_glob": str(canon.parent / "tiddlers_*.jsonl"),
+        "s0147": out_dir,
+        "s0149": tmp_path / "s0149",
+    }
+
+
+def _refresh_hashes(fx: dict[str, Path | str]) -> None:
+    s0147 = fx["s0147"]
+    assert isinstance(s0147, Path)
+    rows = gate.read_jsonl(s0147 / "s0147_repo_metadata_patch_preview.jsonl")
+    batches_path = s0147 / "s0147_repo_metadata_review_batches.json"
+    batches = gate.read_json(batches_path)
+    for batch_id, batch in batches["batches"].items():
+        batch["patch_sha256"] = gate.subset_sha([row for row in rows if row.get("batch_id") == batch_id])
+    gate.write_json(batches_path, batches)
+    hashes_path = s0147 / "s0147_repo_metadata_patch_hashes.json"
+    hashes = gate.read_json(hashes_path)
+    hashes["patch_preview_sha256"] = gate.file_sha256(s0147 / "s0147_repo_metadata_patch_preview.jsonl")
+    hashes["review_batches_sha256"] = gate.file_sha256(batches_path)
+    hashes["dry_run_report_sha256"] = gate.file_sha256(s0147 / "s0147_repo_metadata_dry_run_report.json")
+    classification = fx["classification"]
+    assert isinstance(classification, Path)
+    hashes["s0146_classification_sha256"] = gate.file_sha256(classification)
+    hashes["canon_before_sha256"] = gate.tree_sha256(str(fx["canon_glob"]))
+    gate.write_json(hashes_path, hashes)
+
+
+def _prepare_successful_dry_run(fx: dict[str, Path | str]) -> dict:
+    s0147 = fx["s0147"]
+    s0149 = fx["s0149"]
+    classification = fx["classification"]
+    assert isinstance(s0147, Path)
+    assert isinstance(s0149, Path)
+    assert isinstance(classification, Path)
+    gate.select_s0149_batches("1,3", review_batches=s0147 / "s0147_repo_metadata_review_batches.json", out_dir=s0149)
+    return gate.run_s0149_dry_run(
+        patch_preview=s0147 / "s0147_repo_metadata_patch_preview.jsonl",
+        review_batches=s0147 / "s0147_repo_metadata_review_batches.json",
+        patch_hashes=s0147 / "s0147_repo_metadata_patch_hashes.json",
+        dry_run_report=s0147 / "s0147_repo_metadata_dry_run_report.json",
+        selected_batches=gate.s0149_paths(s0149)["selected_batches"],
+        canon_glob=str(fx["canon_glob"]),
+        s0146_classification=classification,
+        out_dir=s0149,
+    )
+
+
+def _apply(fx: dict[str, Path | str], token: str | None) -> dict:
+    s0147 = fx["s0147"]
+    s0149 = fx["s0149"]
+    classification = fx["classification"]
+    assert isinstance(s0147, Path)
+    assert isinstance(s0149, Path)
+    assert isinstance(classification, Path)
+    return gate.apply_s0149_metadata(
+        patch_preview=s0147 / "s0147_repo_metadata_patch_preview.jsonl",
+        review_batches=s0147 / "s0147_repo_metadata_review_batches.json",
+        patch_hashes=s0147 / "s0147_repo_metadata_patch_hashes.json",
+        s0147_dry_run_report=s0147 / "s0147_repo_metadata_dry_run_report.json",
+        dry_run_report_path=gate.s0149_paths(s0149)["dry_run_report"],
+        selected_batches=gate.s0149_paths(s0149)["selected_batches"],
+        canon_glob=str(fx["canon_glob"]),
+        s0146_classification=classification,
+        out_dir=s0149,
+        apply_token=token,
+    )
+
+
+def _canon_records(canon: Path) -> dict[str, dict]:
+    return {row["id"]: row for row in gate.read_jsonl(canon)}
+
+
+def test_apply_blocks_without_successful_dry_run_or_valid_token(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+
+    missing_dry_run = _apply(fx, gate.S0149_APPLY_TOKEN)
+    _prepare_successful_dry_run(fx)
+    bad_token = _apply(fx, "BAD TOKEN")
+
+    assert missing_dry_run["apply_executed"] is False
+    assert "missing_successful_dry_run" in missing_dry_run["block_reasons"]
+    assert bad_token["apply_executed"] is False
+    assert "invalid_or_missing_apply_token" in bad_token["block_reasons"]
+
+
+def test_apply_blocks_if_hashes_changed_after_dry_run(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    canon = fx["canon"]
+    assert isinstance(canon, Path)
+    _prepare_successful_dry_run(fx)
+    canon.write_text(canon.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+    report = _apply(fx, gate.S0149_APPLY_TOKEN)
+
+    assert report["apply_executed"] is False
+    assert "hash_mismatch_before_apply" in report["block_reasons"]
+
+
+def test_apply_blocks_if_selected_patch_has_critical_risk(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    s0147 = fx["s0147"]
+    assert isinstance(s0147, Path)
+    patch = s0147 / "s0147_repo_metadata_patch_preview.jsonl"
+    rows = gate.read_jsonl(patch)
+    rows[0]["source_risk_level"] = "critical"
+    gate.write_jsonl(patch, rows)
+    _refresh_hashes(fx)
+    dry = _prepare_successful_dry_run(fx)
+
+    report = _apply(fx, gate.S0149_APPLY_TOKEN)
+
+    assert dry["blocked"] is True
+    assert "critical_risk_in_selected_batches" in dry["block_reasons"]
+    assert report["apply_executed"] is False
+    assert "dry_run_not_successful" in report["block_reasons"]
+
+
+def test_apply_uses_only_patch_fields_preserves_session_family_and_generates_no_relations(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    canon = fx["canon"]
+    assert isinstance(canon, Path)
+    _prepare_successful_dry_run(fx)
+
+    report = _apply(fx, gate.S0149_APPLY_TOKEN)
+    records = _canon_records(canon)
+
+    assert report["apply_executed"] is True
+    assert report["relations_generated"] is False
+    assert report["candidate_relations_generated"] is False
+    assert records["cur"]["source_fields"]["artifact_family"] == "artefacto_repositorio"
+    assert records["cur"]["source_fields"]["repo_path"] == "python_scripts/current.py"
+    assert records["nar"]["source_fields"]["artifact_family"] == "detalles_de_sesion"
+    assert records["nar"]["source_fields"]["technical_content_role"] == "session_or_diagnostic_narrative"
+    assert "relations" not in records["cur"]["source_fields"]
+    assert "candidate_relations" not in records["nar"]["source_fields"]
+
+
+def test_rollback_restores_canon_before_apply(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    canon = fx["canon"]
+    s0149 = fx["s0149"]
+    assert isinstance(canon, Path)
+    assert isinstance(s0149, Path)
+    before = canon.read_text(encoding="utf-8")
+    _prepare_successful_dry_run(fx)
+    report = _apply(fx, gate.S0149_APPLY_TOKEN)
+
+    rollback = gate.rollback_s0149_metadata(out_dir=s0149)
+
+    assert report["apply_executed"] is True
+    assert rollback["rollback_executed"] is True
+    assert canon.read_text(encoding="utf-8") == before

--- a/tests/test_repo_metadata_menu_integration.py
+++ b/tests/test_repo_metadata_menu_integration.py
@@ -1,0 +1,38 @@
+"""S0149/S0150 tests for metadata menu integration."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import repo_metadata_review_menu as metadata_menu  # noqa: E402
+
+
+def test_tdc_menu_exposes_governed_admission_and_keeps_critical_access() -> None:
+    result = subprocess.run(
+        [str(REPO_ROOT / "shell_scripts" / "tdc.sh")],
+        cwd=REPO_ROOT,
+        input="0\n",
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "6) Revisión / admisión gobernada" in result.stdout
+    assert "9) Exportador de repositorio" in result.stdout
+    assert "10) Configurar MCP / mirror remoto" in result.stdout
+
+
+def test_metadata_submenu_header_declares_s0149_safety_policy() -> None:
+    assert callable(metadata_menu.option_repo_metadata_admission_menu)
+    header = metadata_menu.S0149_MENU_HEADER
+    assert "Metadata técnica / admisión gobernada [EXPERIMENTAL]" in header
+    assert "Modo: DRY-RUN por defecto" in header
+    assert "Apply: requiere confirmación humana explícita" in header
+    assert "Relaciones: BLOQUEADAS" in header

--- a/tests/test_repo_metadata_multi_batch_selection.py
+++ b/tests/test_repo_metadata_multi_batch_selection.py
@@ -1,0 +1,185 @@
+"""S0149 tests for governed multi-batch metadata selection."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import build_repo_metadata_patch_preview as preview  # noqa: E402
+import repo_metadata_admission_gate as gate  # noqa: E402
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+    return path
+
+
+def _classification(tid: str, title: str, category: str, **overrides) -> dict:
+    payload = {
+        "id": tid,
+        "title": title,
+        "diagnostic_category": category,
+        "candidate_authority_level": "unknown",
+        "candidate_is_current_repo_artifact": "false",
+        "risk_level": "low",
+        "confidence": "high",
+        "candidate_repo_path": "",
+        "candidate_repo_directory": "",
+        "candidate_repo_extension": "",
+        "candidate_repo_artifact_kind": "unknown_repo_artifact",
+        "candidate_repo_lifecycle_state": "",
+        "candidate_artifact_family": "artefacto_repositorio",
+        "candidate_content_sha256": f"sha-{tid}",
+        "content_comparison": "not_current",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _fixture(tmp_path: Path) -> dict[str, Path | str]:
+    classification = _write_jsonl(
+        tmp_path / "s0146" / "classification.jsonl",
+        [
+            _classification(
+                "cur",
+                "python_scripts/current.py",
+                "repo_snapshot_current",
+                candidate_authority_level="current_verified",
+                candidate_is_current_repo_artifact="true",
+                candidate_repo_path="python_scripts/current.py",
+                candidate_repo_directory="python_scripts",
+                candidate_repo_extension=".py",
+                candidate_repo_artifact_kind="source_code",
+                candidate_repo_lifecycle_state="current_repo_artifact",
+                content_comparison="exact_match",
+            ),
+            _classification("emb", "#### 🌀 Sesión 0101 = embedded", "embedded_code_block", risk_level="high"),
+            _classification("nar", "#### 🌀 Sesión 0102 = narrative", "session_or_diagnostic_narrative", risk_level="high"),
+            _classification(
+                "hist",
+                "README-old",
+                "repo_snapshot_drifted",
+                candidate_authority_level="historical_snapshot",
+                candidate_repo_path="README-old",
+                candidate_repo_extension="",
+                risk_level="high",
+            ),
+            _classification("gen", "data/out/local/generated.json", "generated_output"),
+            _classification("blocked", "needs review", "review_required", confidence="requires_human_review"),
+        ],
+    )
+    metadata_contract = tmp_path / "s0146" / "contract.md"
+    metadata_contract.write_text("# contract\n", encoding="utf-8")
+    canon = _write_jsonl(
+        tmp_path / "canon" / "tiddlers_1.jsonl",
+        [
+            {"id": "cur", "title": "python_scripts/current.py", "source_fields": {"artifact_family": "unknown"}},
+            {"id": "emb", "title": "#### 🌀 Sesión 0101 = embedded", "source_fields": {"artifact_family": "hipotesis_de_sesion"}},
+            {"id": "nar", "title": "#### 🌀 Sesión 0102 = narrative", "source_fields": {"artifact_family": "detalles_de_sesion"}},
+            {"id": "hist", "title": "README-old", "source_fields": {"artifact_family": "artefacto_repositorio"}},
+            {"id": "gen", "title": "data/out/local/generated.json", "source_fields": {"artifact_family": "artefacto_repositorio"}},
+            {"id": "blocked", "title": "needs review", "source_fields": {"artifact_family": "unknown"}},
+        ],
+    )
+    out_dir = tmp_path / "s0147"
+    preview.build_repo_metadata_patch_preview(
+        classification=classification,
+        metadata_contract=metadata_contract,
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        out_dir=out_dir,
+        session="S0147",
+        dry_run=True,
+    )
+    return {
+        "classification": classification,
+        "canon": canon,
+        "canon_glob": str(canon.parent / "tiddlers_*.jsonl"),
+        "s0147": out_dir,
+        "s0149": tmp_path / "s0149",
+    }
+
+
+def _run_s0149_dry_run(fx: dict[str, Path | str]) -> dict:
+    s0147 = fx["s0147"]
+    assert isinstance(s0147, Path)
+    s0149 = fx["s0149"]
+    assert isinstance(s0149, Path)
+    classification = fx["classification"]
+    assert isinstance(classification, Path)
+    return gate.run_s0149_dry_run(
+        patch_preview=s0147 / "s0147_repo_metadata_patch_preview.jsonl",
+        review_batches=s0147 / "s0147_repo_metadata_review_batches.json",
+        patch_hashes=s0147 / "s0147_repo_metadata_patch_hashes.json",
+        dry_run_report=s0147 / "s0147_repo_metadata_dry_run_report.json",
+        selected_batches=gate.s0149_paths(s0149)["selected_batches"],
+        canon_glob=str(fx["canon_glob"]),
+        s0146_classification=classification,
+        out_dir=s0149,
+    )
+
+
+def test_selects_multiple_recommended_batches_by_menu_number(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    s0147 = fx["s0147"]
+    s0149 = fx["s0149"]
+    assert isinstance(s0147, Path)
+    assert isinstance(s0149, Path)
+
+    doc = gate.select_s0149_batches("1,2,3", review_batches=s0147 / "s0147_repo_metadata_review_batches.json", out_dir=s0149)
+
+    assert doc["valid"] is True
+    assert doc["selected_batch_ids"] == [
+        "batch_current_verified",
+        "batch_embedded_code",
+        "batch_narrative_reference",
+    ]
+    assert doc["selected_operation_count"] == 3
+    assert gate.s0149_paths(s0149)["selected_batches"].exists()
+
+
+def test_rejects_empty_missing_and_excluded_batch_selection(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    s0147 = fx["s0147"]
+    s0149 = fx["s0149"]
+    assert isinstance(s0147, Path)
+    assert isinstance(s0149, Path)
+    batches = s0147 / "s0147_repo_metadata_review_batches.json"
+
+    empty = gate.select_s0149_batches("", review_batches=batches, out_dir=s0149 / "empty")
+    missing = gate.select_s0149_batches("batch_missing", review_batches=batches, out_dir=s0149 / "missing")
+    excluded = gate.select_s0149_batches("6", review_batches=batches, out_dir=s0149 / "excluded")
+
+    assert empty["valid"] is False
+    assert empty["empty_selection"] is True
+    assert missing["valid"] is False
+    assert missing["invalid_batch_ids"] == ["batch_missing"]
+    assert excluded["valid"] is False
+    assert excluded["blocked_batch_ids"] == ["batch_excluded_review_required"]
+
+
+def test_dry_run_with_multiple_batches_does_not_modify_canon(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    s0147 = fx["s0147"]
+    s0149 = fx["s0149"]
+    canon = fx["canon"]
+    assert isinstance(s0147, Path)
+    assert isinstance(s0149, Path)
+    assert isinstance(canon, Path)
+    before = canon.read_text(encoding="utf-8")
+    gate.select_s0149_batches("1,2,3", review_batches=s0147 / "s0147_repo_metadata_review_batches.json", out_dir=s0149)
+
+    report = _run_s0149_dry_run(fx)
+
+    assert report["blocked"] is False
+    assert report["admission_ready"] == 3
+    assert report["blocked_records"] == 0
+    assert report["canon_modified"] is False
+    assert report["relations_generated"] is False
+    assert report["candidate_relations_generated"] is False
+    assert canon.read_text(encoding="utf-8") == before

--- a/tests/test_repo_metadata_patch_preview.py
+++ b/tests/test_repo_metadata_patch_preview.py
@@ -1,0 +1,227 @@
+"""S0147 tests for dry-run repo metadata patch preview."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import build_repo_metadata_patch_preview as preview  # noqa: E402
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _row(
+    tid: str,
+    title: str,
+    category: str,
+    *,
+    authority: str = "unknown",
+    current: str = "false",
+    risk: str = "low",
+    confidence: str = "high",
+    path: str = "",
+    family: str = "artefacto_repositorio",
+    lifecycle: str = "",
+    kind: str = "source_code",
+) -> dict:
+    return {
+        "id": tid,
+        "title": title,
+        "diagnostic_category": category,
+        "candidate_authority_level": authority,
+        "candidate_is_current_repo_artifact": current,
+        "risk_level": risk,
+        "confidence": confidence,
+        "candidate_repo_path": path,
+        "candidate_repo_directory": str(Path(path).parent) if path else "",
+        "candidate_repo_extension": Path(path).suffix if path else "",
+        "candidate_repo_artifact_kind": kind,
+        "candidate_repo_lifecycle_state": lifecycle,
+        "candidate_artifact_family": family,
+        "candidate_content_sha256": f"sha-{tid}",
+        "canon_content_sha256": f"canon-sha-{tid}",
+        "content_comparison": "exact_match" if current == "true" else "not_current",
+    }
+
+
+def _canon_row(tid: str, title: str, family: str = "unknown") -> dict:
+    return {
+        "id": tid,
+        "title": title,
+        "source_fields": {"artifact_family": family},
+        "text": title,
+    }
+
+
+def _run(tmp_path: Path, rows: list[dict], canon_rows: list[dict], *, out_name: str = "out") -> dict:
+    classification = _write_jsonl(tmp_path / "s0146" / "classification.jsonl", rows)
+    metadata_contract = tmp_path / "s0146" / "metadata_contract.md"
+    metadata_contract.write_text("# contract\n", encoding="utf-8")
+    canon = _write_jsonl(tmp_path / "canon" / "tiddlers_1.jsonl", canon_rows)
+    return preview.build_repo_metadata_patch_preview(
+        classification=classification,
+        metadata_contract=metadata_contract,
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        out_dir=tmp_path / out_name,
+        session="S0147",
+        dry_run=True,
+    )
+
+
+def _jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _ops(result: dict) -> list[dict]:
+    return _jsonl(Path(result["paths"]["patch_preview"]))
+
+
+def _excluded(result: dict) -> list[dict]:
+    return _jsonl(Path(result["paths"]["excluded"]))
+
+
+def test_reads_s0146_classification_and_generates_dry_run_patch_without_canon_change(tmp_path: Path) -> None:
+    rows = [
+        _row(
+            "current",
+            "python_scripts/current.py",
+            "repo_snapshot_current",
+            authority="current_verified",
+            current="true",
+            path="python_scripts/current.py",
+        ),
+        _row(
+            "historical",
+            "python_scripts/old.py",
+            "repo_snapshot_drifted",
+            authority="historical_snapshot",
+            lifecycle="historical_snapshot",
+            path="python_scripts/old.py",
+        ),
+        _row("review", "needs review", "review_required", risk="high", confidence="requires_human_review"),
+    ]
+    canon_rows = [
+        _canon_row("current", "python_scripts/current.py", "unknown"),
+        _canon_row("historical", "python_scripts/old.py", "tiddler_tecnico"),
+        _canon_row("review", "needs review", "unknown"),
+    ]
+    canon_path = _write_jsonl(tmp_path / "canon_before" / "tiddlers_1.jsonl", canon_rows)
+    canon_before = canon_path.read_text(encoding="utf-8")
+    classification = _write_jsonl(tmp_path / "s0146" / "classification.jsonl", rows)
+    metadata_contract = tmp_path / "s0146" / "metadata_contract.md"
+    metadata_contract.write_text("# contract\n", encoding="utf-8")
+
+    result = preview.build_repo_metadata_patch_preview(
+        classification=classification,
+        metadata_contract=metadata_contract,
+        canon_glob=str(canon_path.parent / "tiddlers_*.jsonl"),
+        out_dir=tmp_path / "out",
+        session="S0147",
+        dry_run=True,
+    )
+
+    assert canon_path.read_text(encoding="utf-8") == canon_before
+    summary = result["summary"]
+    assert summary["classification_records_read"] == 3
+    assert summary["patch_operations_generated"] == 2
+    assert summary["excluded_records"] == 1
+    assert summary["patch_lane_counts"]["lane_a_current_verified"] == 1
+    assert summary["patch_lane_counts"]["lane_b_historical_review"] == 1
+    assert summary["patch_lane_counts"]["lane_f_excluded_review_required"] == 1
+    assert summary["candidate_relations_generated"] is False
+    assert summary["formal_relation_candidates_generated"] is False
+
+    operations = _ops(result)
+    current_op = next(op for op in operations if op["target_id"] == "current")
+    historical_op = next(op for op in operations if op["target_id"] == "historical")
+    assert current_op["batch_id"] == "batch_current_verified"
+    assert current_op["fields_preview"]["artifact_family"] == "artefacto_repositorio"
+    assert historical_op["batch_id"] == "batch_historical_review"
+    assert "artifact_family" not in historical_op["fields_preview"]
+    assert _excluded(result)[0]["target_id"] == "review"
+    assert all(op["human_approved"] is False for op in operations)
+    assert all(op["applied_to_canon"] is False for op in operations)
+    assert all(op["dry_run"] is True for op in operations)
+    assert all("relations" not in op and "candidate_relations" not in op for op in operations)
+
+
+def test_generates_required_batches_and_excludes_critical_risk(tmp_path: Path) -> None:
+    result = _run(
+        tmp_path,
+        [
+            _row("cur", "python_scripts/current.py", "repo_snapshot_current", authority="current_verified", current="true", path="python_scripts/current.py"),
+            _row("crit", "python_scripts/critical.py", "repo_snapshot_current", authority="current_verified", current="true", risk="critical", path="python_scripts/critical.py"),
+        ],
+        [_canon_row("cur", "python_scripts/current.py"), _canon_row("crit", "python_scripts/critical.py")],
+    )
+
+    batches = json.loads(Path(result["paths"]["review_batches"]).read_text(encoding="utf-8"))
+    assert set(batches["batches"]) == set(preview.LANE_BATCHES.values())
+    assert batches["batches"]["batch_current_verified"]["record_count"] == 1
+    assert batches["batches"]["batch_excluded_review_required"]["record_count"] == 1
+    assert all(batch["human_approved"] is False for batch in batches["batches"].values())
+    assert all(batch["approval_disabled_in_s0147"] is True for batch in batches["batches"].values())
+    assert _excluded(result)[0]["excluded_reason"] == "critical_risk"
+
+
+def test_preserves_session_family_and_uses_narrative_metadata(tmp_path: Path) -> None:
+    result = _run(
+        tmp_path,
+        [_row("session", "#### 🌀 Sesión 0146 = demo", "session_or_diagnostic_narrative", authority="narrative_reference")],
+        [_canon_row("session", "#### 🌀 Sesión 0146 = demo", "sesion")],
+    )
+
+    op = _ops(result)[0]
+    assert op["batch_id"] == "batch_narrative_reference"
+    assert op["current_artifact_family"] == "sesion"
+    assert "artifact_family" not in op["fields_preview"]
+    assert op["fields_preview"]["contains_repo_references"] == "true"
+    assert op["fields_preview"]["technical_content_role"] == "session_or_diagnostic_narrative"
+
+
+def test_embedded_and_generated_records_get_auxiliary_metadata_only(tmp_path: Path) -> None:
+    result = _run(
+        tmp_path,
+        [
+            _row("embedded", "Ejemplo tecnico", "embedded_code_block", authority="narrative_reference"),
+            _row("generated", "data/out/local/report.json", "generated_output", authority="generated_derivative", kind="generated_output"),
+        ],
+        [
+            _canon_row("embedded", "Ejemplo tecnico", "unknown"),
+            _canon_row("generated", "data/out/local/report.json", "unknown"),
+        ],
+    )
+
+    by_id = {op["target_id"]: op for op in _ops(result)}
+    assert by_id["embedded"]["fields_preview"]["contains_code"] == "true"
+    assert by_id["embedded"]["fields_preview"]["technical_content_role"] == "embedded_code_block"
+    assert "artifact_family" not in by_id["embedded"]["fields_preview"]
+    assert by_id["generated"]["fields_preview"]["technical_content_role"] == "generated_output"
+    assert "artifact_family" not in by_id["generated"]["fields_preview"]
+
+
+def test_patch_preview_and_patch_hash_are_deterministic(tmp_path: Path) -> None:
+    rows = [
+        _row("cur", "python_scripts/current.py", "repo_snapshot_current", authority="current_verified", current="true", path="python_scripts/current.py"),
+        _row("narr", "#### 🌀 Diagnóstico de sesión 0146 = demo", "session_or_diagnostic_narrative", authority="narrative_reference"),
+    ]
+    canon_rows = [_canon_row("cur", "python_scripts/current.py"), _canon_row("narr", "diag", "diagnostico_de_sesion")]
+    first = _run(tmp_path, rows, canon_rows, out_name="out1")
+    second = _run(tmp_path, rows, canon_rows, out_name="out2")
+
+    first_patch = Path(first["paths"]["patch_preview"]).read_text(encoding="utf-8")
+    second_patch = Path(second["paths"]["patch_preview"]).read_text(encoding="utf-8")
+    assert first_patch == second_patch
+    assert first["hashes"]["patch_preview_sha256"] == second["hashes"]["patch_preview_sha256"]

--- a/tests/test_repo_metadata_refresh_patch.py
+++ b/tests/test_repo_metadata_refresh_patch.py
@@ -1,0 +1,162 @@
+"""S0150 tests for non-destructive repo metadata patch refresh."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import repo_metadata_refresh_patch as refresh  # noqa: E402
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+    return path
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _patch_row(tid: str, *, title: str, batch_id: str = "batch_current_verified", risk: str = "low", fields: dict | None = None) -> dict:
+    return {
+        "op_id": f"op_{tid}",
+        "target_id": tid,
+        "target_title": title,
+        "batch_id": batch_id,
+        "patch_lane": "lane_a_current_verified",
+        "source_risk_level": risk,
+        "fields_preview": fields or {"authority_level": "current_verified"},
+        "dry_run": True,
+        "applied_to_canon": False,
+        "human_approved": False,
+    }
+
+
+def _fixture(tmp_path: Path) -> dict[str, Path | str]:
+    canon = _write_jsonl(
+        tmp_path / "canon" / "tiddlers_1.jsonl",
+        [
+            {"id": "cur", "title": "python_scripts/current.py", "source_fields": {"artifact_family": "unknown"}},
+            {"id": "crit", "title": "critical.py", "source_fields": {"artifact_family": "unknown"}},
+            {"id": "session", "title": "#### 🌀 Sesión 0101 = session", "source_fields": {"artifact_family": "detalles_de_sesion"}},
+        ],
+    )
+    patch = _write_jsonl(
+        tmp_path / "s0147" / "patch.jsonl",
+        [
+            _patch_row("cur", title="python_scripts/current.py", fields={"artifact_family": "artefacto_repositorio", "authority_level": "current_verified"}),
+            _patch_row("missing", title="missing.py"),
+            _patch_row("crit", title="critical.py", risk="critical"),
+            _patch_row("session", title="#### 🌀 Sesión 0101 = session", fields={"artifact_family": "artefacto_repositorio"}),
+        ],
+    )
+    batches = _write_json(
+        tmp_path / "s0147" / "batches.json",
+        {
+            "schema": "repo-metadata-review-batches/v1",
+            "session": "S0147",
+            "batches": {
+                "batch_current_verified": {
+                    "batch_id": "batch_current_verified",
+                    "record_count": 4,
+                    "patch_sha256": "old",
+                    "canon_before_sha256": "old-canon",
+                }
+            },
+        },
+    )
+    hashes = _write_json(
+        tmp_path / "s0147" / "hashes.json",
+        {
+            "schema": "repo-metadata-patch-hashes/v1",
+            "session": "S0147",
+            "canon_before_sha256": "old-canon",
+            "patch_preview_sha256": "old-patch",
+            "review_batches_sha256": "old-batches",
+        },
+    )
+    return {
+        "canon": canon,
+        "canon_glob": str(canon.parent / "tiddlers_*.jsonl"),
+        "patch": patch,
+        "batches": batches,
+        "hashes": hashes,
+        "out": tmp_path / "s0150",
+    }
+
+
+def test_refresh_recalculates_canon_hash_and_preserves_safe_operations(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+    canon = fx["canon"]
+    assert isinstance(canon, Path)
+    before = canon.read_text(encoding="utf-8")
+
+    report = refresh.refresh_metadata_patch(
+        patch_preview=fx["patch"],
+        review_batches=fx["batches"],
+        patch_hashes=fx["hashes"],
+        canon_glob=str(fx["canon_glob"]),
+        out_dir=fx["out"],
+        session="S0150",
+        dry_run=True,
+    )
+
+    assert report["canon_before_sha256_old"] == "old-canon"
+    assert report["canon_before_sha256_refreshed"] == refresh.tree_sha256(str(fx["canon_glob"]))
+    assert report["operations_preserved"] == 1
+    assert report["operations_blocked"] == 3
+    assert report["canon_modified"] is False
+    assert canon.read_text(encoding="utf-8") == before
+
+
+def test_refresh_blocks_missing_critical_and_family_conflict(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+
+    refresh.refresh_metadata_patch(
+        patch_preview=fx["patch"],
+        review_batches=fx["batches"],
+        patch_hashes=fx["hashes"],
+        canon_glob=str(fx["canon_glob"]),
+        out_dir=fx["out"],
+        session="S0150",
+        dry_run=True,
+    )
+    blocked = refresh.read_jsonl(refresh.refreshed_paths(fx["out"])["blocked"])
+    reasons = {row["target_id"]: set(row["block_reasons"]) for row in blocked}
+
+    assert "target_missing" in reasons["missing"]
+    assert "critical_risk" in reasons["crit"]
+    assert "artifact_family_session_preserved" in reasons["session"]
+
+
+def test_refresh_recalculates_batch_hashes_and_writes_valid_outputs(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+
+    refresh.refresh_metadata_patch(
+        patch_preview=fx["patch"],
+        review_batches=fx["batches"],
+        patch_hashes=fx["hashes"],
+        canon_glob=str(fx["canon_glob"]),
+        out_dir=fx["out"],
+        session="S0150",
+        dry_run=True,
+    )
+    paths = refresh.refreshed_paths(fx["out"])
+    ready = refresh.read_jsonl(paths["patch_preview"])
+    batches = refresh.read_json(paths["review_batches"])
+    hashes = refresh.read_json(paths["patch_hashes"])
+
+    assert batches["batches"]["batch_current_verified"]["record_count"] == 1
+    assert batches["batches"]["batch_current_verified"]["patch_sha256"] == refresh.subset_sha(ready)
+    assert hashes["patch_preview_sha256"] == refresh.file_sha256(paths["patch_preview"])
+    assert hashes["review_batches_sha256"] == refresh.file_sha256(paths["review_batches"])
+    assert hashes["relations_generated"] is False
+    assert hashes["candidate_relations_generated"] is False

--- a/tests/test_repo_metadata_review_menu.py
+++ b/tests/test_repo_metadata_review_menu.py
@@ -1,0 +1,185 @@
+"""S0147 tests for local repo metadata review menu."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import build_repo_metadata_patch_preview as preview  # noqa: E402
+import repo_metadata_review_menu as menu  # noqa: E402
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _classification(tid: str, title: str, category: str, **overrides) -> dict:
+    payload = {
+        "id": tid,
+        "title": title,
+        "diagnostic_category": category,
+        "candidate_authority_level": "unknown",
+        "candidate_is_current_repo_artifact": "false",
+        "risk_level": "low",
+        "confidence": "high",
+        "candidate_repo_path": "",
+        "candidate_repo_directory": "",
+        "candidate_repo_extension": "",
+        "candidate_repo_artifact_kind": "unknown_repo_artifact",
+        "candidate_repo_lifecycle_state": "",
+        "candidate_artifact_family": "artefacto_repositorio",
+        "candidate_content_sha256": f"sha-{tid}",
+        "content_comparison": "not_current",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _fixture(tmp_path: Path) -> Path:
+    classification = _write_jsonl(
+        tmp_path / "s0146" / "classification.jsonl",
+        [
+            _classification(
+                "cur",
+                "python_scripts/current.py",
+                "repo_snapshot_current",
+                candidate_authority_level="current_verified",
+                candidate_is_current_repo_artifact="true",
+                candidate_repo_path="python_scripts/current.py",
+                candidate_repo_directory="python_scripts",
+                candidate_repo_extension=".py",
+                candidate_repo_artifact_kind="source_code",
+                candidate_repo_lifecycle_state="current_repo_artifact",
+                content_comparison="exact_match",
+            ),
+            _classification(
+                "hist",
+                "python_scripts/old.py",
+                "repo_snapshot_drifted",
+                candidate_authority_level="historical_snapshot",
+                candidate_repo_path="python_scripts/old.py",
+                candidate_repo_directory="python_scripts",
+                candidate_repo_extension=".py",
+                candidate_repo_artifact_kind="source_code",
+                candidate_repo_lifecycle_state="historical_snapshot",
+                risk_level="high",
+            ),
+            _classification("review", "needs review", "review_required", confidence="requires_human_review"),
+        ],
+    )
+    metadata_contract = tmp_path / "s0146" / "metadata_contract.md"
+    metadata_contract.write_text("# contract\n", encoding="utf-8")
+    canon = _write_jsonl(
+        tmp_path / "canon" / "tiddlers_1.jsonl",
+        [
+            {"id": "cur", "title": "python_scripts/current.py", "source_fields": {"artifact_family": "unknown"}},
+            {"id": "hist", "title": "python_scripts/old.py", "source_fields": {"artifact_family": "tiddler_tecnico"}},
+            {"id": "review", "title": "needs review", "source_fields": {"artifact_family": "unknown"}},
+        ],
+    )
+    out_dir = tmp_path / "out"
+    preview.build_repo_metadata_patch_preview(
+        classification=classification,
+        metadata_contract=metadata_contract,
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        out_dir=out_dir,
+        session="S0147",
+        dry_run=True,
+    )
+    return out_dir
+
+
+def test_menu_summary_shows_patch_preview(tmp_path: Path, capsys) -> None:
+    out_dir = _fixture(tmp_path)
+
+    assert menu.main(["--out-dir", str(out_dir), "--summary"]) == 0
+
+    out = capsys.readouterr().out
+    assert "S0147 repo metadata patch preview" in out
+    assert "patch_operations_generated: 2" in out
+    assert "lane_a_current_verified" in out
+
+
+def test_menu_lists_batches(tmp_path: Path, capsys) -> None:
+    out_dir = _fixture(tmp_path)
+
+    assert menu.main(["--out-dir", str(out_dir), "--list-batches"]) == 0
+
+    out = capsys.readouterr().out
+    assert "batch_current_verified" in out
+    assert "approval_disabled=True" in out
+
+
+def test_menu_shows_specific_batch(tmp_path: Path, capsys) -> None:
+    out_dir = _fixture(tmp_path)
+
+    assert menu.main(["--out-dir", str(out_dir), "--show-batch", "batch_current_verified"]) == 0
+
+    out = capsys.readouterr().out
+    assert "batch_current_verified" in out
+    assert "python_scripts/current.py" in out
+
+
+def test_menu_shows_excluded_records(tmp_path: Path, capsys) -> None:
+    out_dir = _fixture(tmp_path)
+
+    assert menu.main(["--out-dir", str(out_dir), "--show-excluded"]) == 0
+
+    out = capsys.readouterr().out
+    assert "excluded records: 1" in out
+    assert "needs review" in out
+
+
+def test_menu_shows_risks(tmp_path: Path, capsys) -> None:
+    out_dir = _fixture(tmp_path)
+
+    assert menu.main(["--out-dir", str(out_dir), "--show-risks"]) == 0
+
+    out = capsys.readouterr().out
+    assert "S0147 risk report" in out
+    assert "high_or_critical_operations: 1" in out
+
+
+def test_menu_validates_dry_run_contract(tmp_path: Path, capsys) -> None:
+    out_dir = _fixture(tmp_path)
+
+    assert menu.main(["--out-dir", str(out_dir), "--validate-dry-run"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["valid"] is True
+    assert payload["approval_disabled_in_s0147"] is True
+    assert payload["human_approved"] is False
+    assert payload["applied_to_canon"] is False
+
+
+def test_menu_requires_valid_token_for_approval(tmp_path: Path, capsys) -> None:
+    out_dir = _fixture(tmp_path)
+    decision_dir = tmp_path / "s0148"
+
+    assert (
+        menu.main(
+            [
+                "--out-dir",
+                str(out_dir),
+                "--decision-dir",
+                str(decision_dir),
+                "--approve-batch",
+                "batch_current_verified",
+                "--decision-token",
+                "BAD_TOKEN",
+            ]
+        )
+        == 2
+    )
+
+    assert "invalid_token" in capsys.readouterr().out

--- a/tests/test_repo_metadata_terminal_approval.py
+++ b/tests/test_repo_metadata_terminal_approval.py
@@ -1,0 +1,251 @@
+"""S0148 tests for terminal metadata batch decisions."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import build_repo_metadata_patch_preview as preview  # noqa: E402
+import repo_metadata_admission_gate as gate  # noqa: E402
+import repo_metadata_review_menu as menu  # noqa: E402
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+    return path
+
+
+def _classification(tid: str, title: str, category: str, **overrides) -> dict:
+    payload = {
+        "id": tid,
+        "title": title,
+        "diagnostic_category": category,
+        "candidate_authority_level": "unknown",
+        "candidate_is_current_repo_artifact": "false",
+        "risk_level": "low",
+        "confidence": "high",
+        "candidate_repo_path": "",
+        "candidate_repo_directory": "",
+        "candidate_repo_extension": "",
+        "candidate_repo_artifact_kind": "unknown_repo_artifact",
+        "candidate_repo_lifecycle_state": "",
+        "candidate_artifact_family": "artefacto_repositorio",
+        "candidate_content_sha256": f"sha-{tid}",
+        "content_comparison": "not_current",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _fixture(tmp_path: Path) -> dict[str, Path | str]:
+    classification = _write_jsonl(
+        tmp_path / "s0146" / "classification.jsonl",
+        [
+            _classification(
+                "cur",
+                "python_scripts/current.py",
+                "repo_snapshot_current",
+                candidate_authority_level="current_verified",
+                candidate_is_current_repo_artifact="true",
+                candidate_repo_path="python_scripts/current.py",
+                candidate_repo_directory="python_scripts",
+                candidate_repo_extension=".py",
+                candidate_repo_artifact_kind="source_code",
+                candidate_repo_lifecycle_state="current_repo_artifact",
+                content_comparison="exact_match",
+            )
+        ],
+    )
+    metadata_contract = tmp_path / "s0146" / "contract.md"
+    metadata_contract.write_text("# contract\n", encoding="utf-8")
+    canon = _write_jsonl(
+        tmp_path / "canon" / "tiddlers_1.jsonl",
+        [{"id": "cur", "title": "python_scripts/current.py", "source_fields": {"artifact_family": "unknown"}}],
+    )
+    out_dir = tmp_path / "s0147"
+    preview.build_repo_metadata_patch_preview(
+        classification=classification,
+        metadata_contract=metadata_contract,
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        out_dir=out_dir,
+        session="S0147",
+        dry_run=True,
+    )
+    return {
+        "classification": classification,
+        "canon_glob": str(canon.parent / "tiddlers_*.jsonl"),
+        "out_dir": out_dir,
+        "decision_dir": tmp_path / "s0148",
+    }
+
+
+def _decision_doc(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_invalid_token_does_not_approve_batch(tmp_path: Path, capsys) -> None:
+    fx = _fixture(tmp_path)
+
+    assert (
+        menu.main(
+            [
+                "--out-dir",
+                str(fx["out_dir"]),
+                "--decision-dir",
+                str(fx["decision_dir"]),
+                "--approve-batch",
+                "batch_current_verified",
+                "--decision-token",
+                "WRONG",
+            ]
+        )
+        == 2
+    )
+
+    assert "invalid_token" in capsys.readouterr().out
+    decisions_path = gate.s0148_paths(fx["decision_dir"])["human_decisions"]
+    decisions = _decision_doc(decisions_path)
+    assert decisions["human_approval_found"] is False
+    assert decisions["decisions"] == []
+
+
+def test_correct_token_approves_current_verified_batch(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+
+    assert (
+        menu.main(
+            [
+                "--out-dir",
+                str(fx["out_dir"]),
+                "--decision-dir",
+                str(fx["decision_dir"]),
+                "--approve-batch",
+                "batch_current_verified",
+                "--decision-token",
+                "APROBAR_METADATA_BATCH_CURRENT_VERIFIED",
+            ]
+        )
+        == 0
+    )
+
+    decisions = _decision_doc(gate.s0148_paths(fx["decision_dir"])["human_decisions"])
+    assert decisions["created_by_agent"] is False
+    assert decisions["human_approval_found"] is True
+    assert decisions["decisions"][0]["decision"] == "approved"
+    assert decisions["decisions"][0]["human_approved"] is True
+    assert decisions["decisions"][0]["token_verified"] is True
+
+
+def test_rejected_decision_records_without_approval(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+
+    assert (
+        menu.main(
+            [
+                "--out-dir",
+                str(fx["out_dir"]),
+                "--decision-dir",
+                str(fx["decision_dir"]),
+                "--reject-batch",
+                "batch_current_verified",
+                "--decision-token",
+                "RECHAZAR_METADATA_BATCH_CURRENT_VERIFIED",
+            ]
+        )
+        == 0
+    )
+
+    decision = _decision_doc(gate.s0148_paths(fx["decision_dir"])["human_decisions"])["decisions"][0]
+    assert decision["decision"] == "rejected"
+    assert decision["human_approved"] is False
+
+
+def test_deferred_decision_records_without_approval(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+
+    assert (
+        menu.main(
+            [
+                "--out-dir",
+                str(fx["out_dir"]),
+                "--decision-dir",
+                str(fx["decision_dir"]),
+                "--defer-batch",
+                "batch_current_verified",
+                "--decision-token",
+                "DIFERIR_METADATA_BATCH_CURRENT_VERIFIED",
+            ]
+        )
+        == 0
+    )
+
+    decision = _decision_doc(gate.s0148_paths(fx["decision_dir"])["human_decisions"])["decisions"][0]
+    assert decision["decision"] == "deferred"
+    assert decision["human_approved"] is False
+
+
+def test_nonexistent_batch_decision_is_blocked(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+
+    result = gate.record_terminal_decision(
+        batch_id="batch_missing",
+        decision="approved",
+        token="APROBAR_METADATA_MISSING",
+        patch_preview=fx["out_dir"] / "s0147_repo_metadata_patch_preview.jsonl",
+        review_batches=fx["out_dir"] / "s0147_repo_metadata_review_batches.json",
+        patch_hashes=fx["out_dir"] / "s0147_repo_metadata_patch_hashes.json",
+        human_decisions=gate.s0148_paths(fx["decision_dir"])["human_decisions"],
+        out_dir=fx["decision_dir"],
+    )
+
+    assert result["status"] == "blocked"
+    assert result["reason"] == "batch_not_found"
+
+
+def test_terminal_audit_is_generated_for_decision(tmp_path: Path) -> None:
+    fx = _fixture(tmp_path)
+
+    menu.main(
+        [
+            "--out-dir",
+            str(fx["out_dir"]),
+            "--decision-dir",
+            str(fx["decision_dir"]),
+            "--approve-batch",
+            "batch_current_verified",
+            "--decision-token",
+            "APROBAR_METADATA_BATCH_CURRENT_VERIFIED",
+        ]
+    )
+
+    audit = gate.s0148_paths(fx["decision_dir"])["terminal_audit"].read_text(encoding="utf-8")
+    assert "approved_batch" in audit
+    assert "recorded" in audit
+
+
+def test_menu_lists_batches_and_shows_last_gate_report(tmp_path: Path, capsys) -> None:
+    fx = _fixture(tmp_path)
+    menu.main(["--out-dir", str(fx["out_dir"]), "--list-batches"])
+    assert "batch_current_verified" in capsys.readouterr().out
+
+    menu.main(
+        [
+            "--out-dir",
+            str(fx["out_dir"]),
+            "--decision-dir",
+            str(fx["decision_dir"]),
+            "--run-gate-dry-run",
+            "--canon-glob",
+            str(fx["canon_glob"]),
+            "--s0146-classification",
+            str(fx["classification"]),
+        ]
+    )
+    assert menu.main(["--decision-dir", str(fx["decision_dir"]), "--show-last-gate-report"]) == 0
+    assert "repo-metadata-admission-gate-report" in capsys.readouterr().out

--- a/tests/test_semantic_text_authority_aware.py
+++ b/tests/test_semantic_text_authority_aware.py
@@ -1,0 +1,157 @@
+"""S0149 tests for authority-aware semantic_text sidecar."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import build_semantic_text_authority_aware as authority_builder  # noqa: E402
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+    return path
+
+
+def _canon(tmp_path: Path) -> Path:
+    return _write_jsonl(
+        tmp_path / "canon" / "tiddlers_1.jsonl",
+        [
+            {
+                "id": "cur",
+                "title": "python_scripts/current.py",
+                "source_fields": {"artifact_family": "artefacto_repositorio", "authority_level": "current_verified"},
+                "text": "def current(): pass",
+            },
+            {
+                "id": "hist",
+                "title": "README-old",
+                "source_fields": {"artifact_family": "artefacto_repositorio", "authority_level": "historical_snapshot"},
+                "text": "historical readme",
+            },
+            {
+                "id": "nar",
+                "title": "#### 🌀 Sesión 0102 = narrative",
+                "source_fields": {"artifact_family": "detalles_de_sesion", "authority_level": "narrative_reference"},
+                "text": "mentions python_scripts/current.py",
+            },
+            {
+                "id": "gen",
+                "title": "data/out/local/generated.json",
+                "source_fields": {"artifact_family": "artefacto_repositorio", "authority_level": "generated_derivative"},
+                "text": "generated output",
+            },
+            {
+                "id": "unk",
+                "title": "unknown",
+                "source_fields": {"artifact_family": "unknown"},
+                "text": "unknown authority",
+            },
+        ],
+    )
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                rows.append(json.loads(line))
+    return rows
+
+
+def test_semantic_text_authority_preview_writes_required_outputs(tmp_path: Path) -> None:
+    canon = _canon(tmp_path)
+    out_dir = tmp_path / "semantic_text_authority" / "s0149"
+
+    result = authority_builder.build_authority_outputs(
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        out_dir=out_dir,
+        session="S0149",
+        mode="preview",
+    )
+
+    assert result["authority_aware"] is True
+    assert result["modified_canon"] is False
+    assert result["mode"] == "preview"
+    paths = {name: Path(path) for name, path in result["paths"].items()}
+    for key in ["records", "index", "coverage_report", "summary", "review", "hashes"]:
+        assert paths[key].exists()
+    coverage = json.loads(paths["coverage_report"].read_text(encoding="utf-8"))
+    assert coverage["authority_aware"] is True
+    assert coverage["source_session"] == "S0149"
+    assert coverage["modified_canon"] is False
+    assert sorted(coverage["authority_levels_detected"]) == [
+        "current_verified",
+        "generated_derivative",
+        "historical_snapshot",
+        "narrative_reference",
+        "unknown",
+    ]
+
+
+def test_semantic_text_generate_distinguishes_authority_levels_and_is_deterministic(tmp_path: Path) -> None:
+    canon = _canon(tmp_path)
+    out_dir = tmp_path / "semantic_text_authority" / "s0149"
+
+    first = authority_builder.build_authority_outputs(
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        out_dir=out_dir,
+        session="S0149",
+        mode="generate",
+    )
+    records_path = Path(first["paths"]["records"])
+    first_records_text = records_path.read_text(encoding="utf-8")
+    second = authority_builder.build_authority_outputs(
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        out_dir=out_dir,
+        session="S0149",
+        mode="generate",
+    )
+
+    records = _read_jsonl(records_path)
+    by_id = {record["id"]: record for record in records}
+    assert by_id["cur"]["authority_statement"].startswith("Este tiddler representa un artefacto actual")
+    assert by_id["hist"]["authority_statement"].startswith("Este tiddler representa o describe un artefacto histórico")
+    assert by_id["nar"]["authority_statement"].startswith("Este tiddler documenta o menciona contenido técnico")
+    assert by_id["gen"]["authority_statement"].startswith("Este tiddler corresponde a una salida derivada")
+    assert by_id["unk"]["authority_statement"].startswith("La autoridad técnica")
+    assert first_records_text == records_path.read_text(encoding="utf-8")
+    assert first["summary"]["records_sha256"] == second["summary"]["records_sha256"]
+
+
+def test_semantic_text_authority_builder_does_not_overwrite_s0144(tmp_path: Path) -> None:
+    canon = _canon(tmp_path)
+    forbidden = tmp_path / "semantic_text" / "s0144"
+
+    with pytest.raises(ValueError):
+        authority_builder.build_authority_outputs(
+            canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+            out_dir=forbidden,
+            session="S0149",
+            mode="preview",
+        )
+
+
+def test_semantic_text_authority_jsonl_outputs_are_valid(tmp_path: Path) -> None:
+    canon = _canon(tmp_path)
+    result = authority_builder.build_authority_outputs(
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        out_dir=tmp_path / "semantic_text_authority" / "s0149",
+        session="S0149",
+        mode="preview",
+    )
+    paths = {name: Path(path) for name, path in result["paths"].items()}
+
+    json.loads(paths["index"].read_text(encoding="utf-8"))
+    json.loads(paths["coverage_report"].read_text(encoding="utf-8"))
+    json.loads(paths["hashes"].read_text(encoding="utf-8"))
+    assert len(_read_jsonl(paths["records"])) == 5

--- a/tests/test_tdc_menu_compatibility_aliases.py
+++ b/tests/test_tdc_menu_compatibility_aliases.py
@@ -1,0 +1,50 @@
+"""S0150 tests for historical menu alias compatibility."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import operator_menu  # noqa: E402
+import tdc_menu_registry as registry  # noqa: E402
+
+
+def test_aliases_resolve_to_critical_new_locations() -> None:
+    assert registry.resolve_choice("14")["action"] == "mcp_remote_config"
+    assert registry.resolve_choice("16")["action"] == "relation_review"
+    assert registry.resolve_choice("17")["action"] == "repository_exporter"
+    assert registry.resolve_choice("18")["action"] == "metadata_admission"
+
+
+def test_dispatch_alias_16_opens_relation_review(monkeypatch, capsys) -> None:
+    called: list[str] = []
+    monkeypatch.setattr(operator_menu, "option_relation_review_menu", lambda: called.append("relation"))
+
+    assert operator_menu.dispatch_main_choice("16", operator_menu.MenuState()) is True
+
+    assert called == ["relation"]
+    assert "Revisión relacional ahora vive" in capsys.readouterr().out
+
+
+def test_dispatch_alias_17_opens_repository_exporter(monkeypatch, capsys) -> None:
+    called: list[str] = []
+    monkeypatch.setattr(operator_menu, "option_repository_exporter", lambda: called.append("exporter"))
+
+    assert operator_menu.dispatch_main_choice("17", operator_menu.MenuState()) is True
+
+    assert called == ["exporter"]
+    assert "Exportador de repositorio" in capsys.readouterr().out
+
+
+def test_dispatch_alias_14_opens_mcp(monkeypatch, capsys) -> None:
+    called: list[str] = []
+    monkeypatch.setattr(operator_menu, "option_mcp_manager", lambda: called.append("mcp"))
+
+    assert operator_menu.dispatch_main_choice("14", operator_menu.MenuState()) is True
+
+    assert called == ["mcp"]
+    assert "Configurar MCP / mirror remoto" in capsys.readouterr().out

--- a/tests/test_tdc_menu_governed_admission.py
+++ b/tests/test_tdc_menu_governed_admission.py
@@ -1,0 +1,47 @@
+"""S0150 tests for centralized TDC operator menu."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+import tdc_menu_registry as registry  # noqa: E402
+
+
+def test_main_menu_contains_governed_admission_and_critical_functions() -> None:
+    text = registry.menu_text()
+
+    assert "6) Revisión / admisión gobernada" in text
+    assert "9) Exportador de repositorio" in text
+    assert "10) Configurar MCP / mirror remoto" in text
+    assert "11) Avanzado / mantenimiento" in text
+
+
+def test_tdc_shows_simplified_menu() -> None:
+    result = subprocess.run(
+        [str(REPO_ROOT / "shell_scripts" / "tdc.sh")],
+        cwd=REPO_ROOT,
+        input="0\n",
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Revisión / admisión gobernada" in result.stdout
+    assert "Exportador de repositorio" in result.stdout
+    assert "Configurar MCP / mirror remoto" in result.stdout
+    assert "Avanzado / mantenimiento" in result.stdout
+
+
+def test_menu_mapping_declares_metadata_and_relation_access() -> None:
+    mapping = registry.menu_mapping()
+
+    assert mapping["critical_functions_preserved"]["relation_review"] == "6.2 and alias 16"
+    assert mapping["critical_functions_preserved"]["metadata_admission"] == "6.1 and alias 18"
+    assert mapping["critical_functions_preserved"]["repository_exporter"] == "9"

--- a/tests/test_unknown_artifact_family_characterization.py
+++ b/tests/test_unknown_artifact_family_characterization.py
@@ -1,0 +1,259 @@
+"""S0145 tests for unknown artifact_family characterization."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "python_scripts"))
+
+from characterize_unknown_artifact_family import (  # noqa: E402
+    REVIEW_COLUMNS,
+    build_unknown_artifact_family_outputs,
+)
+
+
+def _record(
+    tid: str,
+    *,
+    title: str | None = None,
+    family: str | None = None,
+    tags: list[str] | None = None,
+    text: str = "Contenido estable sin senales fuertes.",
+) -> dict:
+    source_fields = {
+        "canonical_status": "local_admitted",
+        "source_path": "tests/fixture.md",
+        "provenance_ref": "test",
+    }
+    if family is not None:
+        source_fields["artifact_family"] = family
+    return {
+        "id": tid,
+        "key": title or f"Title {tid}",
+        "title": title or f"Title {tid}",
+        "tags": tags or [],
+        "source_tags": tags or [],
+        "source_fields": source_fields,
+        "relations": [],
+        "text": text,
+    }
+
+
+def _semantic(records: list[dict], *, unknown_ids: set[str]) -> list[dict]:
+    return [
+        {
+            "id": record["id"],
+            "title": record["title"],
+            "artifact_family": "unknown" if record["id"] in unknown_ids else "contrato_de_sesion",
+            "semantic_text": f"semantic text for {record['id']}",
+        }
+        for record in records
+    ]
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _run(tmp_path: Path, records: list[dict], *, unknown_ids: set[str]) -> tuple[dict, Path, Path]:
+    canon = _write_jsonl(tmp_path / "canon" / "tiddlers_1.jsonl", records)
+    semantic = _write_jsonl(tmp_path / "semantic" / "records.jsonl", _semantic(records, unknown_ids=unknown_ids))
+    result = build_unknown_artifact_family_outputs(
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        semantic_text_records=semantic,
+        out_dir=tmp_path / "out",
+        session="s0145",
+    )
+    return result, canon, semantic
+
+
+def _candidates(result: dict) -> list[dict]:
+    path = Path(result["paths"]["classification_candidates"])
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _mapping(result: dict) -> dict:
+    return json.loads(Path(result["paths"]["mapping_preview"]).read_text(encoding="utf-8"))
+
+
+def _hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_detects_unknown_records(tmp_path: Path) -> None:
+    result, _, _ = _run(
+        tmp_path,
+        [_record("unknown"), _record("known", family="contrato_de_sesion")],
+        unknown_ids={"unknown"},
+    )
+
+    assert result["summary"]["total_unknown"] == 1
+    assert _candidates(result)[0]["id"] == "unknown"
+
+
+def test_does_not_classify_known_artifact_family_records(tmp_path: Path) -> None:
+    result, _, _ = _run(
+        tmp_path,
+        [_record("unknown"), _record("known", family="contrato_de_sesion")],
+        unknown_ids={"unknown"},
+    )
+
+    candidate_ids = {item["id"] for item in _candidates(result)}
+    assert candidate_ids == {"unknown"}
+
+
+def test_detects_referencia_documental_from_url_author_year_and_citation(tmp_path: Path) -> None:
+    text = "Autor: Ana Perez (2024). Articulo citado. Fuente: https://example.org/paper"
+    result, _, _ = _run(tmp_path, [_record("ref", title="Referencia de estudio", text=text)], unknown_ids={"ref"})
+
+    candidate = _candidates(result)[0]
+    assert candidate["candidate_artifact_family"] == "referencia_documental"
+    assert candidate["confidence"] == "high"
+    assert "url_detected" in candidate["signals"]
+
+
+def test_detects_tiddler_tecnico_from_paths_scripts_and_extensions(tmp_path: Path) -> None:
+    text = "Ejecutar python3 -m pytest para validar el script.\n```python\nprint('ok')\n```"
+    result, _, _ = _run(
+        tmp_path,
+        [_record("tech", title="python_scripts/demo.py", tags=["codigo"], text=text)],
+        unknown_ids={"tech"},
+    )
+
+    candidate = _candidates(result)[0]
+    assert candidate["candidate_artifact_family"] == "tiddler_tecnico"
+    assert candidate["confidence"] == "high"
+
+
+def test_detects_indice_o_navegacion_from_link_lists(tmp_path: Path) -> None:
+    text = "- [[A]]\n- [[B]]\n- [[C]]\n- [[D]]\n- [[E]]"
+    result, _, _ = _run(tmp_path, [_record("nav", title="Indice de temas", text=text)], unknown_ids={"nav"})
+
+    candidate = _candidates(result)[0]
+    assert candidate["candidate_artifact_family"] == "indice_o_navegacion"
+    assert candidate["confidence"] == "high"
+
+
+def test_detects_concepto_from_definition_pattern(tmp_path: Path) -> None:
+    text = "Memoria colectiva es una categoria conceptual usada para explicar el corpus."
+    result, _, _ = _run(tmp_path, [_record("concept", title="Memoria colectiva", text=text)], unknown_ids={"concept"})
+
+    candidate = _candidates(result)[0]
+    assert candidate["candidate_artifact_family"] == "concepto"
+    assert candidate["confidence"] == "high"
+
+
+def test_tags_are_signal_not_decision(tmp_path: Path) -> None:
+    result, _, _ = _run(
+        tmp_path,
+        [_record("tag-only", title="Entrada neutra", tags=["referencia"], text="Contenido sin evidencia externa.")],
+        unknown_ids={"tag-only"},
+    )
+
+    candidate = _candidates(result)[0]
+    assert candidate["candidate_artifact_family"] == "requires_human_review"
+    assert candidate["confidence"] == "requires_human_review"
+    assert "tags are evidence" in candidate["reason"]
+
+
+def test_every_record_has_confidence_and_recommended_action(tmp_path: Path) -> None:
+    result, _, _ = _run(
+        tmp_path,
+        [_record("a"), _record("b", title="Indice", text="- [[A]]\n- [[B]]")],
+        unknown_ids={"a", "b"},
+    )
+
+    for candidate in _candidates(result):
+        assert candidate["confidence"]
+        assert candidate["recommended_action"]
+
+
+def test_mapping_preview_is_non_applicable(tmp_path: Path) -> None:
+    result, _, _ = _run(tmp_path, [_record("unknown")], unknown_ids={"unknown"})
+
+    mapping = _mapping(result)
+    assert mapping["dry_run"] is True
+    assert mapping["applied_to_canon"] is False
+    assert mapping["canon_modified"] is False
+    assert mapping["mapping_allowed_in_s0145"] is False
+
+
+def test_does_not_modify_input_canon_jsonl(tmp_path: Path) -> None:
+    records = [_record("unknown", title="python_scripts/demo.py")]
+    canon = _write_jsonl(tmp_path / "canon" / "tiddlers_1.jsonl", records)
+    semantic = _write_jsonl(tmp_path / "semantic" / "records.jsonl", _semantic(records, unknown_ids={"unknown"}))
+    before = _hash(canon)
+
+    build_unknown_artifact_family_outputs(
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        semantic_text_records=semantic,
+        out_dir=tmp_path / "out",
+        session="s0145",
+    )
+
+    assert _hash(canon) == before
+
+
+def test_review_csv_contains_minimum_columns(tmp_path: Path) -> None:
+    result, _, _ = _run(tmp_path, [_record("unknown")], unknown_ids={"unknown"})
+    with Path(result["paths"]["review"]).open(encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        assert reader.fieldnames == REVIEW_COLUMNS
+
+
+def test_classification_jsonl_is_valid(tmp_path: Path) -> None:
+    result, _, _ = _run(tmp_path, [_record("unknown")], unknown_ids={"unknown"})
+
+    path = Path(result["paths"]["classification_candidates"])
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert rows
+    assert rows[0]["dry_run"] is True
+    assert rows[0]["applied_to_canon"] is False
+
+
+def test_classification_is_deterministic_across_two_runs(tmp_path: Path) -> None:
+    records = [
+        _record("ref", title="Referencia", text="Autor: A (2024). Fuente: https://example.org"),
+        _record("tech", title="data/out/local/report.json", text="{}"),
+    ]
+    canon = _write_jsonl(tmp_path / "canon" / "tiddlers_1.jsonl", records)
+    semantic = _write_jsonl(tmp_path / "semantic" / "records.jsonl", _semantic(records, unknown_ids={"ref", "tech"}))
+
+    first = build_unknown_artifact_family_outputs(
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        semantic_text_records=semantic,
+        out_dir=tmp_path / "out1",
+        session="s0145",
+    )
+    second = build_unknown_artifact_family_outputs(
+        canon_glob=str(canon.parent / "tiddlers_*.jsonl"),
+        semantic_text_records=semantic,
+        out_dir=tmp_path / "out2",
+        session="s0145",
+    )
+
+    assert Path(first["paths"]["classification_candidates"]).read_text(encoding="utf-8") == Path(
+        second["paths"]["classification_candidates"]
+    ).read_text(encoding="utf-8")
+    assert Path(first["paths"]["mapping_preview"]).read_text(encoding="utf-8") == Path(
+        second["paths"]["mapping_preview"]
+    ).read_text(encoding="utf-8")
+
+
+def test_ambiguous_records_require_human_review(tmp_path: Path) -> None:
+    text = "python3\nPendiente de revision."
+    result, _, _ = _run(tmp_path, [_record("ambiguous", title="Entrada ambigua", text=text)], unknown_ids={"ambiguous"})
+
+    candidate = _candidates(result)[0]
+    assert candidate["candidate_artifact_family"] == "requires_human_review"
+    assert candidate["recommended_action"] == "review_manually"

--- a/ux/cat terminal.txt
+++ b/ux/cat terminal.txt
@@ -1,0 +1,33 @@
+ /\_/\
+( ^_^ )
+ > ^ <
+
+Estado: success
+<mensaje>
+
+ /\_/\
+( x_x )
+ > ^ <
+
+Estado: error
+Revisar stderr / salida anterior.
+
+
+ /\_/\
+( -_- )
+ > ^ <
+Estado: blink (loading)
+
+
+
+ /\_/\
+( o_o )
+ > ^ <
+
+Estado: awake
+
+
+ /\_/\
+( O_O )
+ > ^ <
+Estado: Alerta


### PR DESCRIPTION
# PR: pipeline(repo): integra pipeline de caracterización, revisión y admisión de metadatos técnicos

```text
Commit: feat(pipeline): implementa flujo de admisión de metadatos de repositorio
Meta: Es:listo|V:1|R:3|Md:estable|B:pipeline|Ctx:runtime|Pr:P1|Sz:L|Est:8|Dr:+2|Dc:+3
Arch: Sb:Ejecución|Ea:Implementación|Cx:Extracción e Inspección|Lg:PYTHON|Mdls:repo_metadata_pipeline, operator_menu
```

---

## Metadatos

| Campo | Valor |
|-------|-------|
| Estado | listo |
| Vuelta | 1 |
| Radio | 3 |
| Madurez | estable |
| Bloque | pipeline |
| ContextoCambio | runtime |
| Priority | P1 |
| Size | L |
| Estimate | 8 |
| Delta-r | +2 |
| Delta-c | +3 |

---

## Tablero y Arquitectura

| Campo | Valor |
|-------|-------|
| StatusTablero | Ejecución |
| EstadoArquitectonico | Implementación |
| Caja | Extracción e Inspección |
| Lenguajes | PYTHON |
| Modulos | repo_metadata_pipeline, operator_menu |

---

## Objetivo

Implementar un pipeline completo y gobernado para la caracterización, revisión y admisión de metadatos técnicos asociados a los artefactos del repositorio. El objetivo es enriquecer el canon con información precisa sobre la procedencia y estado del código fuente referenciado en los tiddlers, estableciendo un flujo robusto desde la identificación hasta la aprobación controlada por el operador.

---

## Resultado integrado

El repositorio ahora cuenta con un pipeline de admisión de metadatos técnicos compuesto por varios scripts y menús interactivos. Este flujo permite:
1.  Caracterizar tiddlers con contenido técnico no identificado (`unknown`).
2.  Clasificar artefactos del repositorio (`repo_artifacts`) y verificar su estado contra el worktree de Git.
3.  Generar vistas previas (`patch_preview`) de los cambios de metadatos en lotes (`batches`) estratificados por riesgo.
4.  Utilizar una compuerta de admisión (`admission_gate`) para aprobar o rechazar estos lotes de forma segura y controlada.
5.  Refrescar las vistas previas cuando el canon base cambia.
6.  Acceder a todo el flujo a través de un menú de operador reorganizado y centralizado.

---

## Acciones realizadas

- **S145:** Se creó `characterize_unknown_artifact_family.py` para proponer una `artifact_family` a los tiddlers marcados como `unknown`.
- **S146:** Se implementó `characterize_repo_artifacts.py` para analizar tiddlers técnicos, cruzarlos con el repositorio Git y clasificar su estado (`current`, `drifted`, `missing`).
- **S147:** Se desarrollaron `build_repo_metadata_patch_preview.py` y `repo_metadata_review_menu.py` para generar una vista previa de los parches de metadatos y un menú de revisión por lotes.
- **S148:** Se introdujo `repo_metadata_admission_gate.py` como una compuerta de seguridad (dry-run) para la aprobación de lotes de metadatos.
- **S149:** Se extendieron los menús para selección multi-lote y se integró el submenú de admisión en el orquestador principal `tdc.sh`.
- **S150:** Se refactorizó y simplificó el `operator_menu.py` principal, y se creó `repo_metadata_refresh_patch.py` para actualizar las vistas previas de metadatos si el canon ha cambiado, evitando admisiones sobre un estado obsoleto.

---

## Archivos modificados / añadidos

- characterize_unknown_artifact_family.py
- characterize_repo_artifacts.py
- build_repo_metadata_patch_preview.py
- repo_metadata_review_menu.py
- repo_metadata_admission_gate.py
- build_semantic_text_authority_aware.py
- repo_metadata_refresh_patch.py
- operator_menu.py (refactorizado)
- tdc_menu_registry.py
- test_repo_artifact_characterization.py
- test_repo_metadata_terminal_approval.py
- test_repo_metadata_admission_gate.py
- README.md (actualizado)

---

## Comprobaciones sugeridas

- Verificar que el comando tdc.sh invoca el nuevo menú reorganizado.
- Comprobar que la opción "Revisión / admisión gobernada" (o similar) en el menú principal conduce al submenú de admisión de metadatos técnicos.
- Ejecutar los tests correspondientes a las sesiones S145-S150 para validar la lógica de cada componente del pipeline.
- Revisar que el cambio es de runtime y no se clasifica como `documental`.
- Confirmar que los nuevos scripts tienen cobertura de tests y siguen las convenciones del proyecto.
- Validar que los contratos de sesión `.md.json` para las sesiones 145 a 150 existen en 00_contratos.

---

## Notas para el revisor

Este PR integra un bloque funcional significativo que introduce un gobierno estricto sobre cómo se asignan los metadatos técnicos. Aunque las sesiones se ejecutaron en modo `dry-run` (sin escribir al canon), los scripts están diseñados para realizar escrituras protegidas una vez que un operador humano apruebe los lotes. La refactorización del menú en S150 es clave para la usabilidad futura del sistema.
